### PR TITLE
アプリ内レビューを実装

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,6 +28,12 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
@@ -62,12 +68,22 @@ android {
         applicationIdSuffix appIdSuffix
         resValue "string", "app_name", appName
     }
+    
+    signingConfigs {
+       release {
+           keyAlias keystoreProperties['keyAlias']
+           keyPassword keystoreProperties['keyPassword']
+           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+           storePassword keystoreProperties['storePassword']
+       }
+   }  
 
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            // signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.toda.teigiii">
+    <uses-permission android:name="android.permission.INTERNET"/>
    <application
         android:label="Teigiii"
         android:name="${applicationName}"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -871,6 +871,8 @@ PODS:
     - TOCropViewController (~> 2.6.1)
   - image_picker_ios (0.0.1):
     - Flutter
+  - in_app_review (0.2.0):
+    - Flutter
   - leveldb-library (1.22.2)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
@@ -909,6 +911,7 @@ DEPENDENCIES:
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -970,6 +973,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  in_app_review:
+    :path: ".symlinks/plugins/in_app_review/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
@@ -1015,6 +1020,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
   image_cropper: a3291c624a953049bc6a02e1f8c8ceb162a24b25
   image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
+  in_app_review: 318597b3a06c22bb46dc454d56828c85f444f99d
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85

--- a/lib/core/common_provider/in_app_review_provider.dart
+++ b/lib/core/common_provider/in_app_review_provider.dart
@@ -1,0 +1,7 @@
+import 'package:in_app_review/in_app_review.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'in_app_review_provider.g.dart';
+
+@riverpod
+InAppReview inAppReview(InAppReviewRef ref) => InAppReview.instance;

--- a/lib/core/common_provider/in_app_review_provider.g.dart
+++ b/lib/core/common_provider/in_app_review_provider.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'in_app_review_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$inAppReviewHash() => r'e4a81de941378fc21b9690e55d12aad3923b492c';
+
+/// See also [inAppReview].
+@ProviderFor(inAppReview)
+final inAppReviewProvider = AutoDisposeProvider<InAppReview>.internal(
+  inAppReview,
+  name: r'inAppReviewProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$inAppReviewHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef InAppReviewRef = AutoDisposeProviderRef<InAppReview>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/force_event/presentation/overlay_force_update_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_force_update_dialog.dart
@@ -1,15 +1,19 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/common_provider/launch_url.dart';
 import '../../../core/common_widget/button/primary_filled_button.dart';
+import '../../../util/constant/url.dart';
 
 /// 端末のバックキーや画面操作を受け付けないWidget
 ///
 /// 透明のWidgetで囲い、ダイアログ表示を模している
-class OverlayForceUpdateDialog extends StatelessWidget {
+class OverlayForceUpdateDialog extends ConsumerWidget {
   const OverlayForceUpdateDialog({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return WillPopScope(
       onWillPop: () async => false,
       child: Container(
@@ -36,7 +40,22 @@ class OverlayForceUpdateDialog extends StatelessWidget {
                   const SizedBox(height: 16),
                   PrimaryFilledButton(
                     onPressed: () {
-                      // TODO(me): Storeに遷移させる
+                      switch (defaultTargetPlatform) {
+                        case TargetPlatform.iOS:
+                          ref.read(launchURLProvider(appStoreUrl));
+                          return;
+                        case TargetPlatform.android:
+                          ref.read(launchURLProvider(googlePlayStoreUrl));
+                          return;
+
+                        case TargetPlatform.fuchsia:
+                        case TargetPlatform.linux:
+                        case TargetPlatform.macOS:
+                        case TargetPlatform.windows:
+                          throw UnsupportedError(
+                            '想定外のプラットフォームです。 defaultTargetPlatform: $defaultTargetPlatform',
+                          );
+                      }
                     },
                     text: 'アップデートする',
                   ),

--- a/lib/feature/setting/presentation/license_page.dart
+++ b/lib/feature/setting/presentation/license_page.dart
@@ -18,7 +18,6 @@ class MyLicensePage extends ConsumerWidget {
       body: appVersion.when(
         data: (appVersion) {
           return LicensePage(
-            // TODO(me): アプリアイコンを指定する
             applicationName: 'Teigiii',
             applicationVersion: appVersion,
           );

--- a/lib/feature/setting/presentation/setting_page.dart
+++ b/lib/feature/setting/presentation/setting_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/common_provider/in_app_review_provider.dart';
 import '../../../core/common_provider/launch_url.dart';
 import '../../../core/common_widget/shimmer_widget.dart';
 import '../../../core/router/app_router.dart';
@@ -88,7 +89,12 @@ class SettingPage extends ConsumerWidget {
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.star),
               label: 'レビューで応援する',
-              onTap: () {}, // TODO(me): レビューダイアログを表示
+              onTap: () {
+                // TODO(me): Application層に移譲したほうがいいかも
+                ref.read(inAppReviewProvider).openStoreListing(
+                      appStoreId: appleId,
+                );
+              },
             ),
             const SizedBox(height: 32),
 

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -1,4 +1,6 @@
-const appStoreUrl = 'https://apps.apple.com/jp/app/id6472884411';
+const appleId = '6472884411';
+
+const appStoreUrl = 'https://apps.apple.com/jp/app/id$appleId';
 
 const googlePlayStoreUrl =
     'https://play.google.com/store/apps/details?id=com.toda.teigiii';

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -1,3 +1,8 @@
+const appStoreUrl = 'https://apps.apple.com/jp/app/id6472884411';
+
+const googlePlayStoreUrl =
+    'https://play.google.com/store/apps/details?id=com.toda.teigiii';
+
 const latestInformationPageUrl =
     'https://almondine-ixora-d9e.notion.site/8e8ca7ad482a473099743dddb3b930ab?pvs=4';
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import firebase_auth
 import firebase_core
 import firebase_crashlytics
 import firebase_storage
+import in_app_review
 import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
@@ -28,6 +29,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -773,6 +773,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  in_app_review:
+    dependency: "direct main"
+    description:
+      name: in_app_review
+      sha256: "41ec6f30427ab09eb6ae1c85c4a2a624a145fc5d726f023de4d97170ec9e5466"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
+  in_app_review_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_review_platform_interface
+      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   image_cropper: ^5.0.0
   image_picker: ^1.0.4
+  in_app_review: ^2.0.8
   intl: ^0.18.1
   keyboard_actions: ^4.2.0
   like_button: ^2.0.5


### PR DESCRIPTION
# 対象Issue

- #34 

# やった事

- Play Store の URL を取得するため、aabファイルを作成し、アップロード
- 強制アップデート時のストアへの遷移するを実装
- アプリ内レビューを実装

# やらなかった事

# 動作確認

- iPhone11 (実機) , Pixel 6a (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Androidのリリースビルドに署名するためのキーストア設定を追加しました。
  - アプリ内レビュー機能を提供する新しいプロバイダーを追加しました。
  - 強制アップデートダイアログにプラットフォーム別のURL起動機能を組み込みました。
  - 設定ページにアプリストアのレビューページへのリンク機能を追加しました。
  - アプリのApple IDとストアのURLを定義しました。

- **バグ修正**
  - ライセンスページのコメントアウトされたTODOを削除しました。

- **ドキュメント**
  - macOSのプロジェクトにアプリ内レビュープラグインを登録しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->