### PR TITLE
prod環境の対応

### DIFF
--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -61,13 +61,12 @@ class InfinityScrollWidget extends ConsumerWidget {
 
     Future<void> onRefresh() async {
       ref.invalidate(listStateNotifierProvider);
+      // indicatorを表示し続けるため、取得が完了するまで待つ
+      await ref.read(listStateNotifierProvider.future);
 
       if (additionalOnRefresh != null) {
         additionalOnRefresh!();
       }
-
-      // indicatorを表示し続けるため、取得が完了するまで待つ
-      await ref.read(listStateNotifierProvider.future);
     }
 
     return asyncListState.when(

--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -18,11 +18,13 @@ class InfinityScrollWidget extends ConsumerWidget {
     required this.shimmerTile,
     required this.shimmerTileNumber,
     required this.emptyWidget,
+    this.additionalOnRefresh,
     this.showBannerAd = false,
   });
 
   /// 扱う state ([ListState]型)を保持する Provider。
   final AsyncNotifierProvider<dynamic, ListState> listStateNotifierProvider;
+
   final VoidCallback fetchMore;
 
   /// [ListState] の中身（tile）を作成するための関数。
@@ -40,6 +42,10 @@ class InfinityScrollWidget extends ConsumerWidget {
   /// 扱う state ([ListState]型) の中身が空の場合に表示させる Widget。
   final Widget? emptyWidget;
 
+  /// スワイプリフレッシュ時、[listStateNotifierProvider] の invalidate
+  /// 以外に行う処理。
+  final VoidCallback? additionalOnRefresh;
+
   /// バナー広告を表示させるかどうか。
   ///
   /// true の場合、 [tileBuilder] で作成した tile 7件ごとにバナー広告を表示させる。
@@ -55,6 +61,11 @@ class InfinityScrollWidget extends ConsumerWidget {
 
     Future<void> onRefresh() async {
       ref.invalidate(listStateNotifierProvider);
+
+      if (additionalOnRefresh != null) {
+        additionalOnRefresh!();
+      }
+
       // indicatorを表示し続けるため、取得が完了するまで待つ
       await ref.read(listStateNotifierProvider.future);
     }
@@ -149,7 +160,7 @@ class InfinityScrollWidget extends ConsumerWidget {
 
 /// [ListState] を無限スクロールで表示するWidget。
 ///
-/// スワイプリフレッシュ, ListView , ListView の一番下に表示する Widget ([bottomWidget]) 
+/// スワイプリフレッシュ, ListView , ListView の一番下に表示する Widget ([bottomWidget])
 /// を内包している。
 class _StateScrollBar extends StatelessWidget {
   const _StateScrollBar({

--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -64,9 +64,7 @@ class InfinityScrollWidget extends ConsumerWidget {
       // indicatorを表示し続けるため、取得が完了するまで待つ
       await ref.read(listStateNotifierProvider.future);
 
-      if (additionalOnRefresh != null) {
-        additionalOnRefresh!();
-      }
+      additionalOnRefresh?.call();
     }
 
     return asyncListState.when(

--- a/lib/feature/auth/application/auth_service.dart
+++ b/lib/feature/auth/application/auth_service.dart
@@ -12,6 +12,7 @@ import '../../user_config/repository/device_info_repository.dart';
 import '../../user_config/repository/user_config_repository.dart';
 import '../../user_profile/application/user_id_list_state.dart';
 import '../../user_profile/domain/user_profile.dart';
+import '../../user_profile/repository/storage_repository.dart';
 import '../../user_profile/repository/user_follow_repository.dart';
 import '../../user_profile/repository/user_profile_repository.dart';
 import '../../user_profile/util/user_list_type.dart';
@@ -114,6 +115,7 @@ class AuthService extends _$AuthService {
     await ref
         .read(userProfileRepositoryProvider)
         .deleteUserProfile(currentUserId);
+    await ref.read(storageRepositoryProvider).deleteFile(currentUserId);
 
     // * userConfig
     await ref

--- a/lib/feature/auth/application/auth_service.dart
+++ b/lib/feature/auth/application/auth_service.dart
@@ -87,6 +87,7 @@ class AuthService extends _$AuthService {
       ref
           .read(toastControllerProvider.notifier)
           .showToast('エラーが発生しました。再度お試しください。');
+      rethrow;
     } finally {
       ref.read(isLoadingOverlayNotifierProvider.notifier).finishLoading();
     }

--- a/lib/feature/auth/application/auth_service.dart
+++ b/lib/feature/auth/application/auth_service.dart
@@ -105,7 +105,7 @@ class AuthService extends _$AuthService {
 
     // * follow関連
     await unfollowAllFollowing(currentUserId);
-    await unfollowedByAllFollower(currentUserId);
+    await unfollowByAllFollower(currentUserId);
     await ref
         .read(userFollowRepositoryProvider)
         .deleteUserFollowCount(currentUserId);
@@ -158,7 +158,7 @@ class AuthService extends _$AuthService {
   }
 
   /// 全てのフォロワーが、currentUser をフォロー解除する
-  Future<void> unfollowedByAllFollower(String currentUserId) async {
+  Future<void> unfollowByAllFollower(String currentUserId) async {
     final followerIdList = await ref.read(
       userIdListStateNotifierProvider(
         UserListType.follower,

--- a/lib/feature/definition/application/definition_id_list_state.dart
+++ b/lib/feature/definition/application/definition_id_list_state.dart
@@ -23,8 +23,11 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
     String? targetUserId,
     InitialSubGroup? initialSubGroup,
   }) async {
-    // ミュートユーザーが更新されるたびに、本Notifierも更新されるよう監視
-    ref.watch(mutedUserIdListProvider);
+    // ミュートユーザー, currentUser が更新されるたびに、
+    // 本Notifierも更新されるよう監視する。
+    ref
+      ..watch(mutedUserIdListProvider)
+      ..watch(userIdProvider);
 
     return await _fetchBasedOnType(isFirstFetch: true);
   }

--- a/lib/feature/definition/presentation/component/definition_list.dart
+++ b/lib/feature/definition/presentation/component/definition_list.dart
@@ -18,6 +18,7 @@ class DefinitionList extends ConsumerWidget {
     this.targetUserId,
     this.initialSubGroup,
     this.shimmerTileNumber = 8,
+    this.additionalOnRefresh,
   });
 
   final DefinitionFeedType definitionFeedType;
@@ -33,6 +34,10 @@ class DefinitionList extends ConsumerWidget {
   ///
   /// デフォルト値は恐らく画面を埋め尽くされるであろう数として8を設定
   final int shimmerTileNumber;
+
+  /// スワイプリフレッシュ時、[definitionIdListStateNotifierProvider] の invalidate
+  /// 以外に行う処理。
+  final VoidCallback? additionalOnRefresh;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -54,6 +59,7 @@ class DefinitionList extends ConsumerWidget {
       shimmerTileNumber: shimmerTileNumber,
       emptyWidget: emptyWidget,
       showBannerAd: true,
+      additionalOnRefresh: additionalOnRefresh,
     );
   }
 }

--- a/lib/feature/definition/presentation/component/definition_list.dart
+++ b/lib/feature/definition/presentation/component/definition_list.dart
@@ -23,20 +23,22 @@ class DefinitionList extends ConsumerWidget {
 
   final DefinitionFeedType definitionFeedType;
 
-  /// 扱うstateの中身が空の場合に表示させるWidget
+  /// 扱う state の中身が空の場合に表示させる Widget 。
   final Widget? emptyWidget;
 
   final String? wordId;
   final String? targetUserId;
   final InitialSubGroup? initialSubGroup;
 
-  /// ローディング時に何タイル分のshimmerを表示させるか
+  /// ローディング時に何タイル分の shimmer を表示させるか。
   ///
-  /// デフォルト値は恐らく画面を埋め尽くされるであろう数として8を設定
+  /// デフォルト値は恐らく画面を埋め尽くされるであろう数として8を設定。
   final int shimmerTileNumber;
 
   /// スワイプリフレッシュ時、[definitionIdListStateNotifierProvider] の invalidate
   /// 以外に行う処理。
+  ///
+  /// null の場合は、[definitionIdListStateNotifierProvider] の invalidate のみ行う。
   final VoidCallback? additionalOnRefresh;
 
   @override

--- a/lib/feature/definition/presentation/component/write_definition_base_page.dart
+++ b/lib/feature/definition/presentation/component/write_definition_base_page.dart
@@ -51,8 +51,7 @@ class WriteDefinitionBasePage extends ConsumerWidget {
             ref.read(dialogControllerProvider.notifier).show(
                   ConfirmDialog(
                     confirmMessage: '入力した内容は保存されません。\nよろしいですか？',
-                    onConfirm: () => Navigator.of(context)
-                        .popUntil((route) => route.isFirst),
+                    onConfirm: context.popRoute,
                     confirmButtonText: 'OK',
                   ),
                 );

--- a/lib/feature/introduction/application/introduction_service.dart
+++ b/lib/feature/introduction/application/introduction_service.dart
@@ -26,6 +26,6 @@ class IntroductionService extends _$IntroductionService {
     }
 
     // [BaseRoute] に遷移する。
-    await ref.read(appRouterProvider).push(const BaseRoute());
+    await ref.read(appRouterProvider).popAndPush(const BaseRoute());
   }
 }

--- a/lib/feature/setting/presentation/muted_user_list_page.dart
+++ b/lib/feature/setting/presentation/muted_user_list_page.dart
@@ -29,7 +29,7 @@ class MutedUserListPage extends ConsumerWidget {
           }
 
           return Padding(
-            padding: const EdgeInsets.only(top: 24),
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: ListView.builder(
               itemCount: mutedUserIdList.length,
               itemBuilder: (context, index) {
@@ -47,7 +47,7 @@ class MutedUserListPage extends ConsumerWidget {
           // エラーが発生し、再読み込み中の場合
           if (asyncMutedUserIdList.isRefreshing) {
             return const Padding(
-              padding: EdgeInsets.symmetric(vertical: 24),
+              padding: EdgeInsets.symmetric(horizontal: 16),
               child: Align(
                 alignment: Alignment.topCenter,
                 child: CupertinoActivityIndicator(),
@@ -58,7 +58,7 @@ class MutedUserListPage extends ConsumerWidget {
           logger.e('ミュートユーザーの取得に失敗しました。'
               'error: $error, stackTrace: $stackTrace');
           return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 24),
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Align(
               alignment: Alignment.topCenter,
               child: ErrorAndRetryWidget(

--- a/lib/feature/setting/presentation/setting_page.dart
+++ b/lib/feature/setting/presentation/setting_page.dart
@@ -162,6 +162,7 @@ class SettingPage extends ConsumerWidget {
               alignment: Alignment.topCenter,
               child: DeleteAccountButton(),
             ),
+            const SizedBox(height: 40),
           ],
         ),
       ),

--- a/lib/feature/user_config/application/user_config_state.dart
+++ b/lib/feature/user_config/application/user_config_state.dart
@@ -8,7 +8,7 @@ part 'user_config_state.g.dart';
 
 @Riverpod(keepAlive: true)
 Future<List<String>> mutedUserIdList(MutedUserIdListRef ref) async {
-  final userId = ref.watch(userIdProvider)!;
+  final userId = ref.read(userIdProvider)!;
   final userProfileDoc =
       await ref.read(userConfigRepositoryProvider).fetchUserConfig(userId);
 

--- a/lib/feature/user_profile/application/user_profile_for_write_notifier.dart
+++ b/lib/feature/user_profile/application/user_profile_for_write_notifier.dart
@@ -50,19 +50,29 @@ class UserProfileForWriteNotifier extends _$UserProfileForWriteNotifier {
     final imageRepository = ref.read(imageRepositoryProvider);
 
     // 画像を選択
-    final pickedFile = await imageRepository.pickImage(imageSource);
-    if (pickedFile == null) {
-      isLoadingOverlayNotifier.finishLoading();
-      return;
-    }
+    try {
+      final pickedFile = await imageRepository.pickImage(imageSource);
+      if (pickedFile == null) {
+        isLoadingOverlayNotifier.finishLoading();
+        return;
+      }
 
-    // 画像を切り抜き
-    final croppedFile = await imageRepository.cropImage(pickedFile.path);
-    if (croppedFile == null) {
+      // 画像を切り抜き
+      final croppedFile = await imageRepository.cropImage(pickedFile.path);
+      if (croppedFile == null) {
+        isLoadingOverlayNotifier.finishLoading();
+        return;
+      }
+      state = AsyncData(state.value!.copyWith(croppedFile: croppedFile));
+    } on Exception catch (e, stackTrace) {
+      logger.e('画像選択もしくは切り抜き時にエラーが発生 error: $e, stackTrace: $stackTrace');
+
+      ref
+          .read(toastControllerProvider.notifier)
+          .showToast('エラーが発生しました。もう一度お試しください');
       isLoadingOverlayNotifier.finishLoading();
       return;
     }
-    state = AsyncData(state.value!.copyWith(croppedFile: croppedFile));
 
     isLoadingOverlayNotifier.finishLoading();
   }

--- a/lib/feature/user_profile/presentation/component/profile_list.dart
+++ b/lib/feature/user_profile/presentation/component/profile_list.dart
@@ -17,12 +17,17 @@ class ProfileList extends ConsumerWidget {
     required this.targetUserId,
     required this.targetDefinitionId,
     required this.emptyWidget,
+    this.additionalOnRefresh,
   });
 
   final UserListType userListType;
   final String? targetUserId;
   final String? targetDefinitionId;
   final Widget? emptyWidget;
+
+  /// スワイプリフレッシュ時、[userIdListStateNotifierProvider] の invalidate
+  /// 以外に行う処理。
+  final VoidCallback? additionalOnRefresh;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -48,6 +53,7 @@ class ProfileList extends ConsumerWidget {
       shimmerTile: const ProfileTileShimmer(),
       shimmerTileNumber: 4,
       emptyWidget: emptyWidget,
+      additionalOnRefresh: additionalOnRefresh,
     );
   }
 }

--- a/lib/feature/user_profile/presentation/page/following_and_follower_list/following_and_follower_list_page.dart
+++ b/lib/feature/user_profile/presentation/page/following_and_follower_list/following_and_follower_list_page.dart
@@ -34,7 +34,7 @@ class FollowingAndFollowerListPage extends ConsumerWidget {
           child: NestedScrollView(
             headerSliverBuilder: (BuildContext context, bool _) {
               final isMyPage = currentUserId == targetUserId;
-        
+
               return <Widget>[
                 SliverAppBar(
                   forceElevated: true,
@@ -74,7 +74,7 @@ class FollowingAndFollowerListPage extends ConsumerWidget {
                           // * タブを切り替えた場合
                           return;
                         }
-        
+
                         // * 同じタブをタップした場合
                         PrimaryScrollController.of(context).scrollToTop();
                       },
@@ -92,6 +92,8 @@ class FollowingAndFollowerListPage extends ConsumerWidget {
                   emptyWidget: const SimpleWidgetForEmpty(
                     message: 'フォロー中のユーザーがいません🌱',
                   ),
+                  additionalOnRefresh: () =>
+                      ref.invalidate(followCountProvider(targetUserId)),
                 ),
                 ProfileList(
                   userListType: UserListType.follower,
@@ -100,6 +102,8 @@ class FollowingAndFollowerListPage extends ConsumerWidget {
                   emptyWidget: const SimpleWidgetForEmpty(
                     message: 'フォロワーがいません🌴',
                   ),
+                  additionalOnRefresh: () =>
+                      ref.invalidate(followCountProvider(targetUserId)),
                 ),
               ],
             ),

--- a/lib/feature/user_profile/presentation/page/profile/profile_widget.dart
+++ b/lib/feature/user_profile/presentation/page/profile/profile_widget.dart
@@ -41,7 +41,7 @@ class ProfileWidget extends ConsumerWidget {
                   const Spacer(),
                   currentUserId == targetUserId
                       ? PrimaryOutlinedButton(
-                          text: 'プロフィールを編集する',
+                          text: 'プロフィールを編集',
                           onPressed: () {
                             context.pushRoute(EditProfileRoute());
                           },

--- a/lib/feature/user_profile/repository/storage_repository.dart
+++ b/lib/feature/user_profile/repository/storage_repository.dart
@@ -31,4 +31,11 @@ class StorageRepository {
 
     return snapshot.ref.getDownloadURL();
   }
+
+  /// [userId] のプロフィール画像を削除する
+  Future<void> deleteFile(String userId) async {
+    final storageRef =
+        FirebaseStorage.instance.ref().child('users/$userId/$_fileName');
+    await storageRef.delete();
+  }
 }

--- a/lib/feature/word/application/word_state.dart
+++ b/lib/feature/word/application/word_state.dart
@@ -15,7 +15,6 @@ Future<Word?> word(WordRef ref, String wordId) async {
   final wordRepository = ref.read(wordRepositoryProvider);
 
   final wordDoc = await wordRepository.fetchWordById(wordId);
-
   if (wordDoc == null) {
     return null;
   }

--- a/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
+++ b/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
@@ -42,7 +42,7 @@ class IndividualDictionaryDefinitionListPage extends ConsumerWidget {
         '「$initialLabel」はまだ投稿されていません😭',
         '「$initialLabel」デビューしませんか🥺',
         'やあ✋私は「$initialLabel」である👴。\nここに来た記念に私を投稿してくれ',
-        'やっほー！私は「$initialLabel」だよ。投稿してくれるよね？🥺',
+        'やっほー！私は「$initialLabel」だよ。\n投稿してくれるよね？🥺',
         '「$initialLabel」を開くとはお目が高い！',
         '無理にとは言わんけぇ、\n「$initialLabel」を投稿してはくれまいか？👴',
         '🙃んせまりあは稿投だま',

--- a/lib/feature/word/presentation/page/word_list/word_list_page.dart
+++ b/lib/feature/word/presentation/page/word_list/word_list_page.dart
@@ -37,7 +37,7 @@ class WordListPage extends ConsumerWidget {
         '「$initialLabel」はまだ投稿されていません😭',
         '「$initialLabel」はまだ誰も投稿していません...!!',
         'やあ✋私は「$initialLabel」である👴。\nここに来た記念に私を投稿してくれ',
-        'やっほー！私は「$initialLabel」だよ。投稿してくれるよね？🥺',
+        'やっほー！私は「$initialLabel」だよ。\n投稿してくれるよね？🥺',
         '「$initialLabel」を開くとはお目が高い！',
         '無理にとは言わんけぇ、\n「$initialLabel」を投稿してはくれまいか？👴',
         '🙃んせまりあは稿投だま',

--- a/lib/feature/word/presentation/page/word_top/word_top_page.dart
+++ b/lib/feature/word/presentation/page/word_top/word_top_page.dart
@@ -96,7 +96,7 @@ class WordTopPage extends ConsumerWidget {
                               // * タブを切り替えた場合
                               return;
                             }
-            
+
                             // * 同じタブをタップした場合
                             PrimaryScrollController.of(context).scrollToTop();
                           },
@@ -114,6 +114,8 @@ class WordTopPage extends ConsumerWidget {
                       wordId: wordId,
                       shimmerTileNumber: 2,
                       emptyWidget: null,
+                      additionalOnRefresh: () =>
+                          ref.invalidate(wordProvider(wordId)),
                     ),
                     DefinitionList(
                       definitionFeedType:
@@ -121,6 +123,8 @@ class WordTopPage extends ConsumerWidget {
                       wordId: wordId,
                       shimmerTileNumber: 2,
                       emptyWidget: null,
+                      additionalOnRefresh: () =>
+                          ref.invalidate(wordProvider(wordId)),
                     ),
                   ],
                 ),

--- a/lib/feature/word/presentation/page/word_top/word_top_page.dart
+++ b/lib/feature/word/presentation/page/word_top/word_top_page.dart
@@ -114,6 +114,7 @@ class WordTopPage extends ConsumerWidget {
                       wordId: wordId,
                       shimmerTileNumber: 2,
                       emptyWidget: null,
+                      // TODO(me): スワイプリフレッシュ時、インジケータの表示がなめらかじゃないの直したい。
                       additionalOnRefresh: () =>
                           ref.invalidate(wordProvider(wordId)),
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,18 +57,6 @@ Future<void> main() async {
 
   await MobileAds.instance.initialize();
 
-  // TODO(me): リリース時に削除する
-  // デバッグ用にダミーデータを登録する
-  // await addUserConfigsToFirestore(flavorName);
-  // await addUserProfilesToFirestore(flavorName);
-  // await addUserFollowCountsToFirestore(flavorName);
-  // await addUserFollowsToFirestore2(flavorName);
-  // await addUserFollowsToFirestore3(flavorName);
-  // await addWordsDummy0to29(flavorName);
-  // await addWordsDummy30to59(flavorName);
-  // await addDefinitionDummy0to29(flavorName);
-  // await addLikesToFirestore(flavorName);
-
   await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -28,8 +28,11 @@ String inquireFormUrl(String currentUserPublicId) {
   return 'https://docs.google.com/forms/d/e/1FAIpQLScVQ21a8-CtMRwD7Syy3AZfK07SpZQQCjYSuqNNvoA4g7rSsw/viewform?usp=pp_url&entry.2104212620=${Uri.encodeComponent(currentUserPublicId)}';
 }
 
-// TODO(me): prod環境のURLを設定する
-const defaultIconImageUrlListForProd = <String>[];
+const defaultIconImageUrlListForProd = <String>[
+  'https://firebasestorage.googleapis.com/v0/b/everyone-teigi-prod.appspot.com/o/common%2Fdefault_icon_image%2Fghost_writer.png?alt=media&token=37ed60f0-9f7a-4307-981b-437cde7a5e6f',
+  'https://firebasestorage.googleapis.com/v0/b/everyone-teigi-prod.appspot.com/o/common%2Fdefault_icon_image%2Fanimal_chara_radio_penguin.png?alt=media&token=9fe745eb-51a3-4194-b4ab-c96823e486f4',
+  'https://firebasestorage.googleapis.com/v0/b/everyone-teigi-prod.appspot.com/o/common%2Fdefault_icon_image%2Fanimal_chara_mogura_hakase.png?alt=media&token=3606cf7f-a8ee-4ba3-8aee-42ab4ddde5bd',
+];
 
 const defaultIconImageUrlListForDev = [
   'https://firebasestorage.googleapis.com/v0/b/everyone-teigi-dev.appspot.com/o/common%2Fdefault_icon_image%2Fanimal_chara_mogura_hakase.png?alt=media&token=fe96fdd8-f17a-45ec-9c47-3921b60b2580',


### PR DESCRIPTION
# 対象Issue

- #128 

# やった事

- prod 環境で動作確認をし、発生した問題を修正
- Firestore の index を設定

# やらなかった事

# 動作確認

- iPhone11 (実機) , Pixel 6a (実機), iPhone SE 3ad (Simulator) それぞれ prod 環境で実施

# その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `InfinityScrollWidget`に追加のリフレッシュオプションを追加しました。
  - `DefinitionList`と`ProfileList`にスワイプリフレッシュ時の追加アクションを設定するための新しいオプションを追加しました。
  - `WordTopPage`において、スワイプリフレッシュのインジケータ表示を改善しました。

- **バグ修正**
  - `AuthService`のエラーハンドリングを強化し、特定のユーザー操作におけるナビゲーションの挙動を修正しました。
  - `UserProfileForWriteNotifier`で画像選択時のエラー処理を追加しました。

- **UIの改善**
  - `MutedUserListPage`のレイアウトを調整し、エラー時のログ出力を追加しました。
  - `SettingPage`にアカウント削除ボタンの下にスペースを追加しました。
  - `ProfileWidget`のボタンテキストを短縮しました。

- **その他の変更**
  - デバッグ用のダミーデータ関連のコードを削除しました。
  - デフォルトアイコン画像のURLリストに新しい画像を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->