### PR TITLE
chore: バージョン更新とtagの作成を行うワークフローを作成

### DIFF
--- a/.github/workflows/bump-pull-request.yml
+++ b/.github/workflows/bump-pull-request.yml
@@ -1,0 +1,75 @@
+name: bump pull request
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        type: choice
+        description: Please Choice Bump Target
+        options:
+          - build
+          - patch
+          - minor
+          - major
+
+env:
+    # 「 github-actions[bot] 」 というユーザーが commit するよう設定。
+  GIT_USER_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com'
+  GIT_USER_NAME: 'github-actions[bot]'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: install flutter
+        uses: subosito/flutter-action@v2
+        with:
+            # TODO:  ハードコーディング避けたい。
+          flutter-version: '3.13.6'
+          channel: 'stable'
+          cache: true
+
+      - name: run flutter version
+        run: flutter --version
+
+      - name: run flutter pub get
+        run: flutter pub get
+
+      - name: init git config
+        run: |
+          git config --local user.name $GIT_USER_NAME
+          git config --local user.email $GIT_USER_EMAIL
+
+      - name: bump up version
+        run: |
+          echo choice: ${{ github.event.inputs.bump }}
+          flutter pub run cider bump ${{ github.event.inputs.bump }} --bump-build
+          echo "BUMP_VERSION=$(flutter pub run cider version)" >> $GITHUB_ENV
+
+      - name: commit pubspec.yaml
+        run: |
+          git add -u pubspec.yaml
+          echo "Bumped version number to $BUMP_VERSION" | git commit --file=-
+
+      - name: create releaser branch
+        run: |
+          git checkout -b releases/$BUMP_VERSION
+          echo "RELEASE_BRANCH=releases/$BUMP_VERSION" >> $GITHUB_ENV
+
+      - name: push branch
+        run: |
+          git push -u origin $RELEASE_BRANCH
+
+      - name: create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create -B main -t "Release $BUMP_VERSION" -b "Release $BUMP_VERSION" --head $RELEASE_BRANCH

--- a/.github/workflows/tagging-when-merged.yml
+++ b/.github/workflows/tagging-when-merged.yml
@@ -1,0 +1,30 @@
+name: tagging when merged
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tagged:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: get version from pubspec.yaml
+        run: |
+          echo "BUMP_VERSION=$(sed -n 's/^version: *\([^ ]*\) *$/\1/p' pubspec.yaml)" >> $GITHUB_ENV
+
+      - name: create tag and release note
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh release create v$BUMP_VERSION --generate-notes

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  change:
+    dependency: transitive
+    description:
+      name: change
+      sha256: "75b6e28073433946a987e6082d00f08676a8260a6aa68cac8594c10611e7e9b9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   change_app_package_name:
     dependency: "direct main"
     description:
@@ -217,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.0"
+  cider:
+    dependency: "direct dev"
+    description:
+      name: cider
+      sha256: "918ded9f4473d8042247b9e66a90101eb5ff72935c31df5d511a55f14e085ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
   cli_util:
     dependency: transitive
     description:
@@ -941,6 +957,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  marker:
+    dependency: transitive
+    description:
+      name: marker
+      sha256: "3dadd01f3b0ffae148ffb3b1bc04290a98e54a465cddbab59727bd2a9fe57750"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   matcher:
     dependency: transitive
     description:
@@ -1173,6 +1205,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      sha256: df1bbfa3d023009598f19636d6114c6ac1e0b7bb7bf6a260f0e6e6ce91416820
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   riverpod:
     dependency: transitive
     description:
@@ -1522,6 +1562,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  version_manipulation:
+    dependency: transitive
+    description:
+      name: version_manipulation
+      sha256: "9ef166939794d5bd80309cc6dbfe33c9f81674ba1c73ac117a866fd2dc746846"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   visibility_detector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dev_dependencies:
     
   auto_route_generator: ^7.3.1
   build_runner: ^2.4.6
+  cider: ^0.2.4
   custom_lint: ^0.5.3
   flutter_launcher_icons: ^0.13.1
   flutter_lints: ^2.0.0


### PR DESCRIPTION
# 対象Issue

- #118 

# やった事

- バージョン更新を行うワークフローを作成
- tagの作成を行うワークフローを作成

# やらなかった事

- App Store, Play Store への配布を行うワークフローの作成

# 動作確認

- Merge してからでないとできないっぽいため未実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - マニュアルトリガーによるバージョンアップタイプの選択を可能にする「バージョンアッププルリクエスト」のGitHub Actionsワークフローを追加。
  - プルリクエストがメインブランチにマージされた際にタグ付けを行う「マージ時タグ付け」のGitHub Actionsワークフローを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->