### PR TITLE
Feature/#144 fix following id list

### DIFF
--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -200,7 +200,12 @@ class _StateScrollBar extends StatelessWidget {
             padding: contentPadding,
             sliver: SliverToBoxAdapter(
               child: asyncListState.value!.list.isEmpty
-                  ? emptyWidget ?? const SizedBox.shrink()
+                  // 表示件数がある程度多い状態から、0件になるような refresh を
+                  // した際のエラーを回避するために、[SingleChildScrollView]で囲っている。
+                  ? SingleChildScrollView(
+                      controller: scrollController,
+                      child: emptyWidget ?? const SizedBox.shrink(),
+                    )
                   : ListView.builder(
                       controller: scrollController,
                       shrinkWrap: true,

--- a/lib/feature/definition/repository/fetch_definition_repository.dart
+++ b/lib/feature/definition/repository/fetch_definition_repository.dart
@@ -487,7 +487,7 @@ class FetchDefinitionRepository {
             Filter(DefinitionsCollection.isPublic, isEqualTo: true),
           ),
         )
-        .orderBy(DefinitionsCollection.wordReading, descending: true)
+        .orderBy(DefinitionsCollection.wordReading)
         .limit(fetchLimitForDefinitionList);
 
     if (lastDocument != null) {

--- a/lib/feature/user_profile/application/user_follow_service.dart
+++ b/lib/feature/user_profile/application/user_follow_service.dart
@@ -78,6 +78,7 @@ class UserFollowService extends _$UserFollowService {
     ref
       ..invalidate(followCountProvider(currentUserId))
       ..invalidate(followCountProvider(targetUserId))
-      ..invalidate(isFollowingProvider(targetUserId));
+      ..invalidate(isFollowingProvider(targetUserId))
+      ..invalidate(followingIdListProvider(currentUserId));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,14 @@ Future<void> main() async {
 
   await MobileAds.instance.initialize();
 
+  // iOS 端末にてステータスバーを表示させるための設定。
+  //
+  // 参考: https://halzoblog.com/error-bug-diary/20220922-2/
+  await SystemChrome.setEnabledSystemUIMode(
+    SystemUiMode.manual,
+    overlays: SystemUiOverlay.values,
+  );
+
   await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,


### PR DESCRIPTION
# 対象Issue

- #144 

# やった事

- フォローが、ホーム画面のフォロータブ に反映されない事象を解決
- iOS にて、ステータスバー（時間や残充電など）が表示されない事象を解決

# やらなかった事

# 動作確認

- iPhone 11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - iOSデバイスでステータスバーを表示する設定を追加しました。

- **バグ修正**
  - 空のリストがリフレッシュによって発生した際のエラーを防ぐため、無限スクロールウィジェットを改善しました。
  - 定義の取得順序を変更し、降順から昇順に修正しました。

- **機能改善**
  - ユーザーフォローサービスの無効化処理を更新し、現在のユーザーIDを使用してフォローIDリストのプロバイダーも更新するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->