### PR TITLE
#162 余白をつけることを目的としたSizedBoxをGapに変更

### DIFF
--- a/lib/core/common_provider/toast_controller.dart
+++ b/lib/core/common_provider/toast_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:gap/gap.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../util/constant/color_scheme.dart';
@@ -42,7 +43,7 @@ class ToastController extends _$ToastController {
                       CupertinoIcons.exclamationmark_circle_fill,
                       color: lightColorScheme.error,
                     ),
-                    const SizedBox(width: 8),
+                    const Gap(8),
                   ],
                 )
               : const SizedBox.shrink(),

--- a/lib/core/common_widget/error_and_retry_widget.dart
+++ b/lib/core/common_widget/error_and_retry_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/auth/application/auth_state.dart';
 import '../../feature/user_profile/application/user_profile_state.dart';
@@ -28,12 +29,12 @@ class ErrorAndRetryWidget extends ConsumerWidget {
           color: Theme.of(context).colorScheme.error,
           size: 24,
         ),
-        const SizedBox(height: 8),
+        const Gap(8),
         Text(
           'エラーが発生しました。',
           style: Theme.of(context).textTheme.titleLarge,
         ),
-        const SizedBox(height: 8),
+        const Gap(8),
         Text(
           '再読み込みをお試しください。',
           style: Theme.of(context).textTheme.bodyMedium,
@@ -42,12 +43,12 @@ class ErrorAndRetryWidget extends ConsumerWidget {
           '繰り返し発生する場合は、運営へお問い合わせください。',
           style: Theme.of(context).textTheme.bodyMedium,
         ),
-        const SizedBox(height: 24),
+        const Gap(24),
         PrimaryFilledButton(onPressed: onRetry, text: '再読み込み'),
         showInquireButton
             ? Column(
                 children: [
-                  const SizedBox(height: 24),
+                  const Gap(24),
                   TertiaryOutlinedButton(
                     onPressed: () {
                       final currentUserId = ref.read(userIdProvider);
@@ -96,7 +97,7 @@ class SimpleErrorAndRetryWidget extends StatelessWidget {
                 color: Theme.of(context).colorScheme.error,
                 size: 24,
               ),
-              const SizedBox(width: 8),
+              const Gap(8),
               Text(
                 'エラー',
                 style: Theme.of(context).textTheme.titleMedium!.copyWith(
@@ -105,7 +106,7 @@ class SimpleErrorAndRetryWidget extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 8),
+          const Gap(8),
           Text(
             'タップで再読み込み',
             style: Theme.of(context).textTheme.titleMedium,

--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../core/common_widget/cupertino_refresh_indicator.dart';
 import '../../../core/common_widget/error_and_retry_widget.dart';
@@ -105,10 +106,10 @@ class InfinityScrollWidget extends ConsumerWidget {
                 ? const Column(
                     children: [
                       CupertinoActivityIndicator(),
-                      SizedBox(height: 40),
+                      Gap(40),
                     ],
                   )
-                : const SizedBox(),
+                : const SizedBox.shrink(),
             emptyWidget: emptyWidget,
             showBannerAd: showBannerAd,
           ),
@@ -283,7 +284,7 @@ class _BottomWidgetWhenError extends StatelessWidget {
                           CupertinoIcons.exclamationmark_circle_fill,
                           color: Theme.of(context).colorScheme.error,
                         ),
-                  const SizedBox(height: 4),
+                  const Gap(4),
                   asyncListState.isRefreshing
                       ? Text(
                           '読み込み中...',
@@ -299,12 +300,12 @@ class _BottomWidgetWhenError extends StatelessWidget {
                                     fontWeight: FontWeight.bold,
                                   ),
                         ),
-                  const SizedBox(height: 40),
+                  const Gap(40),
                 ],
               ),
             ),
           )
-        : const SizedBox();
+        : const SizedBox.shrink();
   }
 }
 

--- a/lib/core/common_widget/simple_empty_widget.dart
+++ b/lib/core/common_widget/simple_empty_widget.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
-/// emptyステートとして使用する [message] を表示させるだけのシンプルなWidget
-class SimpleWidgetForEmpty extends StatelessWidget {
-  const SimpleWidgetForEmpty({
+/// emptyステートとして使用する [message] を表示させるだけのシンプルな Widget.
+class SimpleEmptyWidget extends StatelessWidget {
+  const SimpleEmptyWidget({
     super.key,
     required this.message,
   });

--- a/lib/core/common_widget/simple_widget_for_empty.dart
+++ b/lib/core/common_widget/simple_widget_for_empty.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 /// emptyステートとして使用する [message] を表示させるだけのシンプルなWidget
 class SimpleWidgetForEmpty extends StatelessWidget {
@@ -13,7 +14,7 @@ class SimpleWidgetForEmpty extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        const SizedBox(height: 40),
+        const Gap(40),
         Center(
           child: Text(
             message,

--- a/lib/core/page/definition_detail_page.dart
+++ b/lib/core/page/definition_detail_page.dart
@@ -7,14 +7,14 @@ import 'package:gap/gap.dart';
 
 import '../../feature/auth/application/auth_state.dart';
 import '../../feature/definition/application/definition_state.dart';
+import '../../feature/definition/presentation/post_definition_fab.dart';
 import '../../feature/definition/presentation/self_definition_action_icon_button.dart';
 import '../../feature/definition_like/presentation/like_widget.dart';
+import '../../feature/user_config/presentation/other_user_action_icon_button.dart';
 import '../../feature/user_follow/presentation/follow_or_unfollow_button.dart';
+import '../../feature/user_profile/presentation/avatar_network_image_widget.dart';
 import '../../util/extension/date_time_extension.dart';
 import '../../util/logger.dart';
-import '../common_widget/avatar_network_image_widget.dart';
-import '../common_widget/button/other_user_action_icon_button.dart';
-import '../common_widget/button/post_definition_fab.dart';
 import '../common_widget/error_and_retry_widget.dart';
 import '../common_widget/shimmer_widget.dart';
 import '../router/app_router.dart';

--- a/lib/core/page/definition_detail_page.dart
+++ b/lib/core/page/definition_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:easy_refresh/easy_refresh.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/auth/application/auth_state.dart';
 import '../../feature/definition/application/definition_state.dart';
@@ -77,7 +78,7 @@ class DefinitionDetailPage extends ConsumerWidget {
                                           .colorScheme
                                           .onSurfaceVariant,
                                     ),
-                                    const SizedBox(width: 2),
+                                    const Gap(2),
                                     Text(
                                       'この投稿はあなただけに見えています',
                                       style: Theme.of(context)
@@ -92,7 +93,7 @@ class DefinitionDetailPage extends ConsumerWidget {
                                     ),
                                   ],
                                 ),
-                                const SizedBox(height: 16),
+                                const Gap(16),
                               ],
                             ),
                           ),
@@ -108,7 +109,7 @@ class DefinitionDetailPage extends ConsumerWidget {
                           AvatarNetworkImageWidget(
                             imageUrl: definition.authorImageUrl,
                           ),
-                          const SizedBox(width: 16),
+                          const Gap(16),
                           Expanded(
                             child: Text(
                               definition.authorName,
@@ -129,8 +130,7 @@ class DefinitionDetailPage extends ConsumerWidget {
                         ],
                       ),
                     ),
-                    const SizedBox(height: 8),
-                    const SizedBox(height: 8),
+                    const Gap(16),
                     InkWell(
                       onTap: () async {
                         await context.pushRoute(
@@ -161,12 +161,12 @@ class DefinitionDetailPage extends ConsumerWidget {
                         ],
                       ),
                     ),
-                    const SizedBox(height: 16),
+                    const Gap(16),
                     Text(
                       definition.definition,
                       style: Theme.of(context).textTheme.bodyLarge,
                     ),
-                    const SizedBox(height: 16),
+                    const Gap(16),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: [
@@ -271,19 +271,19 @@ class _DefinitionDetailPageShimmer extends StatelessWidget {
           Row(
             children: [
               ShimmerWidget.circular(width: 48, height: 48),
-              SizedBox(width: 16),
+              Gap(16),
               ShimmerWidget.rectangular(height: 16, width: 120),
             ],
           ),
-          SizedBox(height: 16),
+          Gap(16),
           ShimmerWidget.rectangular(height: 32, width: 300),
-          SizedBox(height: 16),
+          Gap(16),
           ShimmerWidget.rectangular(height: 120),
-          SizedBox(height: 16),
+          Gap(16),
           ShimmerWidget.rectangular(height: 16, width: 120),
-          SizedBox(height: 4),
+          Gap(4),
           ShimmerWidget.rectangular(height: 16, width: 120),
-          SizedBox(height: 8),
+          Gap(8),
           ShimmerWidget.rectangular(height: 20, width: 48),
         ],
       ),

--- a/lib/core/page/definition_edit_page.dart
+++ b/lib/core/page/definition_edit_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/definition/application/definition_for_write_notifier.dart';
 import '../../feature/definition/domain/definition.dart';
@@ -140,7 +141,7 @@ class _AlertCannotEditDialog extends ConsumerWidget {
             '投稿から1時間が経過したため保存できませんでした。',
             overflow: TextOverflow.clip,
           ),
-          SizedBox(height: 8),
+          Gap(8),
           Text(
             '代わりに、入力した内容で新規投稿しませんか？',
             overflow: TextOverflow.clip,

--- a/lib/core/page/dictionary_everyone_page.dart
+++ b/lib/core/page/dictionary_everyone_page.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/word/presentation/initial_main_group_list.dart';
 import '../../feature/word/util/dictionary_page_type.dart';
@@ -31,7 +32,7 @@ class DictionaryEveryonePage extends StatelessWidget {
           ),
           child: ListView(
             children: const [
-              SizedBox(height: 24),
+              Gap(24),
               SizedBox(
                 height: 80,
                 child: Padding(

--- a/lib/core/page/dictionary_individual_page.dart
+++ b/lib/core/page/dictionary_individual_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/user_profile/application/user_profile_state.dart';
 import '../../feature/user_profile/presentation/dictionary_author_widget.dart';
@@ -44,7 +45,7 @@ class DictionaryIndividualPage extends ConsumerWidget {
                 height: 80,
                 child: DictionaryAuthorWidget(targetUserId: targetUserId),
               ),
-              const SizedBox(height: 24),
+              const Gap(24),
               Padding(
                 padding: const EdgeInsets.only(left: 16, right: 16),
                 child: InitialMainGroupList(

--- a/lib/core/page/dictionary_sub_index_page.dart
+++ b/lib/core/page/dictionary_sub_index_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/user_profile/presentation/dictionary_author_widget.dart';
 import '../../feature/word/presentation/index_tile.dart';
@@ -38,7 +39,7 @@ class DictionarySubIndexPage extends ConsumerWidget {
           dictionaryPageType == DictionaryPageType.individual
               ? Column(
                   children: [
-                    const SizedBox(height: 16),
+                    const Gap(16),
                     Padding(
                       padding: const EdgeInsets.only(bottom: 16),
                       child:
@@ -47,7 +48,7 @@ class DictionarySubIndexPage extends ConsumerWidget {
                   ],
                 )
               : const SizedBox.shrink(),
-          const SizedBox(height: 8),
+          const Gap(8),
           Padding(
             padding: const EdgeInsets.only(
               left: 16,

--- a/lib/core/page/home_page.dart
+++ b/lib/core/page/home_page.dart
@@ -8,7 +8,7 @@ import '../../feature/definition_list/util/definition_feed_type.dart';
 import '../../util/extension/scroll_controller_extension.dart';
 import '../common_provider/key_provider.dart';
 import '../common_widget/button/to_setting_button.dart';
-import '../common_widget/simple_widget_for_empty.dart';
+import '../common_widget/simple_empty_widget.dart';
 import '../common_widget/stickey_tab_bar_deligate.dart';
 
 @RoutePage()
@@ -63,13 +63,13 @@ class HomePage extends ConsumerWidget {
               children: <Widget>[
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.homeRecommend,
-                  emptyWidget: SimpleWidgetForEmpty(
+                  emptyWidget: SimpleEmptyWidget(
                     message: 'おすすめの投稿がありません...',
                   ),
                 ),
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.homeFollowing,
-                  emptyWidget: SimpleWidgetForEmpty(
+                  emptyWidget: SimpleEmptyWidget(
                     message: 'フォローしたユーザーの投稿が表示されます🏄‍♂',
                   ),
                 ),

--- a/lib/core/page/home_page.dart
+++ b/lib/core/page/home_page.dart
@@ -2,11 +2,11 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../feature/definition/presentation/post_definition_fab.dart';
 import '../../feature/definition_list/presentation/definition_list.dart';
 import '../../feature/definition_list/util/definition_feed_type.dart';
 import '../../util/extension/scroll_controller_extension.dart';
 import '../common_provider/key_provider.dart';
-import '../common_widget/button/post_definition_fab.dart';
 import '../common_widget/button/to_setting_button.dart';
 import '../common_widget/simple_widget_for_empty.dart';
 import '../common_widget/stickey_tab_bar_deligate.dart';

--- a/lib/core/page/introduction_page.dart
+++ b/lib/core/page/introduction_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/introduction/presentation/confirm_agreement_dialog.dart';
 import '../../util/constant/url.dart';
@@ -32,18 +33,18 @@ class IntroductionPage extends ConsumerWidget {
                   ),
                 ),
               ),
-              const SizedBox(height: 24),
+              const Gap(24),
               Text(
                 'ようこそ！',
                 style: Theme.of(context).textTheme.titleLarge,
               ),
-              const SizedBox(height: 24),
+              const Gap(24),
               Text(
                 '思うがままに\n言葉を定義しちゃってください😆',
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.titleMedium,
               ),
-              const SizedBox(height: 24),
+              const Gap(24),
               PrimaryFilledButton(
                 onPressed: () {
                   ref.read(dialogControllerProvider).show(
@@ -52,7 +53,7 @@ class IntroductionPage extends ConsumerWidget {
                 },
                 text: 'はじめる',
               ),
-              const SizedBox(height: 16),
+              const Gap(16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [

--- a/lib/core/page/profile_edit_page.dart
+++ b/lib/core/page/profile_edit_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/user_profile/application/user_profile_for_write_notifier.dart';
 import '../../feature/user_profile/presentation/changeable_profile_image.dart';
@@ -90,7 +91,7 @@ class ProfileEditPage extends ConsumerWidget with PresentationMixin {
                   ),
                 ),
               ),
-              const SizedBox(width: 24),
+              const Gap(24),
             ],
           ),
           body: GestureDetector(
@@ -99,12 +100,12 @@ class ProfileEditPage extends ConsumerWidget with PresentationMixin {
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: ListView(
                 children: [
-                  const SizedBox(height: 24),
+                  const Gap(24),
                   ChangeableProfileImage(
                     userProfileForWrite: userProfileForWrite,
                     globalKey: globalKey,
                   ),
-                  const SizedBox(height: 16),
+                  const Gap(16),
                   TextFormField(
                     initialValue: userProfileForWrite.name,
                     maxLength: userProfileForWrite.maxNameLength,
@@ -118,7 +119,7 @@ class ProfileEditPage extends ConsumerWidget with PresentationMixin {
                       border: InputBorder.none,
                     ),
                   ),
-                  const SizedBox(height: 8),
+                  const Gap(8),
                   TextFormField(
                     initialValue: userProfileForWrite.bio,
                     maxLength: userProfileForWrite.maxBioLength,

--- a/lib/core/page/profile_edit_page.dart
+++ b/lib/core/page/profile_edit_page.dart
@@ -5,11 +5,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
 import '../../feature/user_profile/application/user_profile_for_write_notifier.dart';
+import '../../feature/user_profile/presentation/avatar_network_image_widget.dart';
 import '../../feature/user_profile/presentation/changeable_profile_image.dart';
 import '../../util/logger.dart';
 import '../../util/mixin/presentation_mixin.dart';
 import '../common_provider/dialog_controller.dart';
-import '../common_widget/avatar_network_image_widget.dart';
 import '../common_widget/dialog/confirm_dialog.dart';
 import '../common_widget/error_and_retry_widget.dart';
 import '../router/app_router.dart';

--- a/lib/core/page/profile_top_page.dart
+++ b/lib/core/page/profile_top_page.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../feature/auth/application/auth_state.dart';
+import '../../feature/definition/presentation/post_definition_fab.dart';
 import '../../feature/definition_list/presentation/definition_list.dart';
 import '../../feature/definition_list/util/definition_feed_type.dart';
+import '../../feature/user_config/presentation/other_user_action_icon_button.dart';
 import '../../feature/user_profile/application/user_profile_state.dart';
 import '../../feature/user_profile/presentation/profile_widget.dart';
 import '../../util/extension/scroll_controller_extension.dart';
 import '../../util/logger.dart';
-import '../common_widget/button/other_user_action_icon_button.dart';
-import '../common_widget/button/post_definition_fab.dart';
 import '../common_widget/button/to_search_user_button.dart';
 import '../common_widget/simple_widget_for_empty.dart';
 import '../common_widget/stickey_tab_bar_deligate.dart';

--- a/lib/core/page/profile_top_page.dart
+++ b/lib/core/page/profile_top_page.dart
@@ -12,7 +12,7 @@ import '../../feature/user_profile/presentation/profile_widget.dart';
 import '../../util/extension/scroll_controller_extension.dart';
 import '../../util/logger.dart';
 import '../common_widget/button/to_search_user_button.dart';
-import '../common_widget/simple_widget_for_empty.dart';
+import '../common_widget/simple_empty_widget.dart';
 import '../common_widget/stickey_tab_bar_deligate.dart';
 
 @RoutePage()
@@ -95,14 +95,14 @@ class ProfileTopPage extends ConsumerWidget {
                   definitionFeedType:
                       DefinitionFeedType.profileOrderByCreatedAt,
                   targetUserId: targetUserId,
-                  emptyWidget: SimpleWidgetForEmpty(
+                  emptyWidget: SimpleEmptyWidget(
                     message: isMyProfile ? '🙃んせまりあは稿投だま' : '投稿がありません。',
                   ),
                 ),
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.profileLiked,
                   targetUserId: targetUserId,
-                  emptyWidget: SimpleWidgetForEmpty(
+                  emptyWidget: SimpleEmptyWidget(
                     message: isMyProfile ? 'いいねした投稿が表示されます💖' : 'いいねした投稿がありません',
                   ),
                 ),

--- a/lib/core/page/setting_page.dart
+++ b/lib/core/page/setting_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_provider/in_app_review_provider.dart';
 import '../../../../core/common_provider/launch_url.dart';
@@ -45,13 +46,13 @@ class SettingPage extends ConsumerWidget {
         ),
         child: ListView(
           children: [
-            const SizedBox(height: 24),
+            const Gap(24),
             // 一般
             Text(
               '一般',
               style: Theme.of(context).textTheme.titleSmall,
             ),
-            const SizedBox(height: 8),
+            const Gap(8),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.speaker_slash),
               label: 'ミュートの管理',
@@ -59,20 +60,20 @@ class SettingPage extends ConsumerWidget {
                 context.navigateTo(const UserListMutedRoute());
               },
             ),
-            const SizedBox(height: 32),
+            const Gap(32),
 
             // サポート
             Text(
               'サポート',
               style: Theme.of(context).textTheme.titleSmall,
             ),
-            const SizedBox(height: 8),
+            const Gap(8),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.question_square),
               label: '使い方',
               onTap: () => ref.read(launchURLProvider(howToPageUrl)),
             ),
-            const SizedBox(height: 24),
+            const Gap(24),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.mail),
               label: 'お問い合わせ',
@@ -85,7 +86,7 @@ class SettingPage extends ConsumerWidget {
                 ref.read(launchURLProvider(url));
               },
             ),
-            const SizedBox(height: 24),
+            const Gap(24),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.star),
               label: 'レビューで応援する',
@@ -93,26 +94,26 @@ class SettingPage extends ConsumerWidget {
                   .read(inAppReviewProvider)
                   .openStoreListing(appStoreId: appleId),
             ),
-            const SizedBox(height: 32),
+            const Gap(32),
 
             // アプリについて
             Text(
               'アプリについて',
               style: Theme.of(context).textTheme.titleSmall,
             ),
-            const SizedBox(height: 8),
+            const Gap(8),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.doc_text),
               label: '利用規約',
               onTap: () => ref.read(launchURLProvider(termPageUrl)),
             ),
-            const SizedBox(height: 24),
+            const Gap(24),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.exclamationmark_shield),
               label: 'プライバシーポリシー',
               onTap: () => ref.read(launchURLProvider(privacyPolicyPageUrl)),
             ),
-            const SizedBox(height: 24),
+            const Gap(24),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.tag),
               label: 'ライセンス',
@@ -120,11 +121,11 @@ class SettingPage extends ConsumerWidget {
                 await context.navigateTo(const MyLicenseRoute());
               },
             ),
-            const SizedBox(height: 24),
+            const Gap(24),
             Row(
               children: [
                 const Icon(CupertinoIcons.info),
-                const SizedBox(width: 8),
+                const Gap(8),
                 Expanded(
                   child: Text(
                     'バージョン',
@@ -154,15 +155,15 @@ class SettingPage extends ConsumerWidget {
                     },
                   ),
                 ),
-                const SizedBox(width: 4),
+                const Gap(4),
               ],
             ),
-            const SizedBox(height: 72),
+            const Gap(72),
             const Align(
               alignment: Alignment.topCenter,
               child: DeleteAccountButton(),
             ),
-            const SizedBox(height: 40),
+            const Gap(40),
           ],
         ),
       ),
@@ -190,7 +191,7 @@ class SettingTileButton extends StatelessWidget {
       child: Row(
         children: [
           trailingIcon,
-          const SizedBox(width: 8),
+          const Gap(8),
           Expanded(
             child: Text(
               label,

--- a/lib/core/page/user_list_following_or_follower_page.dart
+++ b/lib/core/page/user_list_following_or_follower_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/common_widget/button/to_search_user_button.dart';
-import '../../../../core/common_widget/simple_widget_for_empty.dart';
+import '../../../../core/common_widget/simple_empty_widget.dart';
 import '../../../../core/common_widget/stickey_tab_bar_deligate.dart';
 import '../../../../util/extension/scroll_controller_extension.dart';
 import '../../feature/auth/application/auth_state.dart';
@@ -90,7 +90,7 @@ class UserListFollowingOrFollowerPage extends ConsumerWidget {
                   userListType: UserListType.following,
                   targetUserId: targetUserId,
                   targetDefinitionId: null,
-                  emptyWidget: const SimpleWidgetForEmpty(
+                  emptyWidget: const SimpleEmptyWidget(
                     message: 'フォロー中のユーザーがいません🌱',
                   ),
                   additionalOnRefresh: () =>
@@ -100,7 +100,7 @@ class UserListFollowingOrFollowerPage extends ConsumerWidget {
                   userListType: UserListType.follower,
                   targetUserId: targetUserId,
                   targetDefinitionId: null,
-                  emptyWidget: const SimpleWidgetForEmpty(
+                  emptyWidget: const SimpleEmptyWidget(
                     message: 'フォロワーがいません🌴',
                   ),
                   additionalOnRefresh: () =>

--- a/lib/core/page/user_list_liked_page.dart
+++ b/lib/core/page/user_list_liked_page.dart
@@ -2,7 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/common_widget/simple_widget_for_empty.dart';
+import '../../../../core/common_widget/simple_empty_widget.dart';
 import '../../../../util/extension/scroll_controller_extension.dart';
 import '../../feature/user_list/presentation/profile_list.dart';
 import '../../feature/user_list/util/user_list_type.dart';
@@ -42,7 +42,7 @@ class UserListLikedPage extends ConsumerWidget {
             targetUserId: null,
             targetDefinitionId: definitionId,
             // いいねが0件の場合、[LikeUserPage] には遷移しない想定だが念のため設定しておく
-            emptyWidget: const SimpleWidgetForEmpty(
+            emptyWidget: const SimpleEmptyWidget(
               message: 'まだいいね！されていません',
             ),
           ),

--- a/lib/core/page/user_list_muted_page.dart
+++ b/lib/core/page/user_list_muted_page.dart
@@ -3,11 +3,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/common_widget/button/other_user_action_icon_button.dart';
 import '../../../../core/common_widget/error_and_retry_widget.dart';
 import '../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../util/logger.dart';
 import '../../feature/user_config/application/user_config_state.dart';
+import '../../feature/user_config/presentation/other_user_action_icon_button.dart';
 import '../../feature/user_profile/presentation/profile_tile.dart';
 
 @RoutePage()

--- a/lib/core/page/user_list_muted_page.dart
+++ b/lib/core/page/user_list_muted_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/common_widget/error_and_retry_widget.dart';
-import '../../../../core/common_widget/simple_widget_for_empty.dart';
+import '../../../../core/common_widget/simple_empty_widget.dart';
 import '../../../../util/logger.dart';
 import '../../feature/user_config/application/user_config_state.dart';
 import '../../feature/user_config/presentation/other_user_action_icon_button.dart';
@@ -25,7 +25,7 @@ class UserListMutedPage extends ConsumerWidget {
       body: asyncMutedUserIdList.when(
         data: (mutedUserIdList) {
           if (mutedUserIdList.isEmpty) {
-            return const SimpleWidgetForEmpty(message: 'ミュート中のユーザーはいません。🌻');
+            return const SimpleEmptyWidget(message: 'ミュート中のユーザーはいません。🌻');
           }
 
           return Padding(

--- a/lib/core/page/word_list_page.dart
+++ b/lib/core/page/word_list_page.dart
@@ -12,7 +12,7 @@ import '../../feature/word_list/application/word_list_state_by_initial.dart';
 import '../../util/constant/initial_main_group.dart';
 import '../../util/extension/scroll_controller_extension.dart';
 import '../common_widget/infinity_scroll_widget.dart';
-import '../common_widget/simple_widget_for_empty.dart';
+import '../common_widget/simple_empty_widget.dart';
 
 @RoutePage()
 class WordListPage extends ConsumerWidget {
@@ -74,7 +74,7 @@ class WordListPage extends ConsumerWidget {
             contentPadding: const EdgeInsets.symmetric(horizontal: 16),
             shimmerTile: const WordTileShimmer(),
             shimmerTileNumber: 10,
-            emptyWidget: SimpleWidgetForEmpty(
+            emptyWidget: SimpleEmptyWidget(
               message: generateEmptyMessage(selectedInitialSubGroup.label),
             ),
             showBannerAd: true,

--- a/lib/core/page/word_list_page.dart
+++ b/lib/core/page/word_list_page.dart
@@ -4,13 +4,13 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../feature/definition/presentation/post_definition_fab.dart';
 import '../../feature/word/domain/word.dart';
 import '../../feature/word/presentation/word_tile.dart';
 import '../../feature/word/presentation/word_tile_shimmer.dart';
 import '../../feature/word_list/application/word_list_state_by_initial.dart';
 import '../../util/constant/initial_main_group.dart';
 import '../../util/extension/scroll_controller_extension.dart';
-import '../common_widget/button/post_definition_fab.dart';
 import '../common_widget/infinity_scroll_widget.dart';
 import '../common_widget/simple_widget_for_empty.dart';
 

--- a/lib/core/page/word_search_result_page.dart
+++ b/lib/core/page/word_search_result_page.dart
@@ -5,13 +5,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
+import '../../feature/definition/presentation/post_definition_fab.dart';
 import '../../feature/word/domain/word.dart';
 import '../../feature/word/presentation/word_tile.dart';
 import '../../feature/word/presentation/word_tile_shimmer.dart';
 import '../../feature/word_list/application/word_list_state_by_search_word.dart';
 import '../../feature/word_list/presentation/search_word_text_field.dart';
 import '../../util/extension/scroll_controller_extension.dart';
-import '../common_widget/button/post_definition_fab.dart';
 import '../common_widget/infinity_scroll_widget.dart';
 import '../common_widget/simple_widget_for_empty.dart';
 

--- a/lib/core/page/word_search_result_page.dart
+++ b/lib/core/page/word_search_result_page.dart
@@ -13,7 +13,7 @@ import '../../feature/word_list/application/word_list_state_by_search_word.dart'
 import '../../feature/word_list/presentation/search_word_text_field.dart';
 import '../../util/extension/scroll_controller_extension.dart';
 import '../common_widget/infinity_scroll_widget.dart';
-import '../common_widget/simple_widget_for_empty.dart';
+import '../common_widget/simple_empty_widget.dart';
 
 @RoutePage()
 class WordSearchResultPage extends ConsumerWidget {
@@ -76,7 +76,7 @@ class WordSearchResultPage extends ConsumerWidget {
                   contentPadding: const EdgeInsets.symmetric(horizontal: 16),
                   shimmerTile: const WordTileShimmer(),
                   shimmerTileNumber: 2,
-                  emptyWidget: SimpleWidgetForEmpty(
+                  emptyWidget: SimpleEmptyWidget(
                     message: generateEmptyMessage(searchWord),
                   ),
                 ),

--- a/lib/core/page/word_search_result_page.dart
+++ b/lib/core/page/word_search_result_page.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/word/domain/word.dart';
 import '../../feature/word/presentation/word_tile.dart';
@@ -61,12 +62,12 @@ class WordSearchResultPage extends ConsumerWidget {
           },
           body: Column(
             children: [
-              const SizedBox(height: 24),
+              const Gap(24),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 36),
                 child: SearchWordTextField(defaultText: searchWord),
               ),
-              const SizedBox(height: 32),
+              const Gap(32),
               Expanded(
                 child: InfinityScrollWidget(
                   listStateNotifierProvider: wordListProvider,

--- a/lib/core/page/word_top_page.dart
+++ b/lib/core/page/word_top_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
+import '../../feature/definition/presentation/post_definition_fab.dart';
 import '../../feature/definition_list/presentation/definition_list.dart';
 import '../../feature/definition_list/util/definition_feed_type.dart';
 import '../../feature/word/application/word_state.dart';
@@ -11,7 +12,6 @@ import '../../feature/word/presentation/word_page_shimmer.dart';
 import '../../feature/word/presentation/word_widget.dart';
 import '../../util/extension/scroll_controller_extension.dart';
 import '../../util/logger.dart';
-import '../common_widget/button/post_definition_fab.dart';
 import '../common_widget/error_and_retry_widget.dart';
 import '../common_widget/stickey_tab_bar_deligate.dart';
 

--- a/lib/core/page/word_top_page.dart
+++ b/lib/core/page/word_top_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../feature/definition_list/presentation/definition_list.dart';
 import '../../feature/definition_list/util/definition_feed_type.dart';
@@ -46,7 +47,7 @@ class WordTopPage extends ConsumerWidget {
                       color: Theme.of(context).colorScheme.error,
                       size: 24,
                     ),
-                    const SizedBox(height: 16),
+                    const Gap(16),
                     Align(
                       alignment: Alignment.topCenter,
                       child: Text(
@@ -54,7 +55,7 @@ class WordTopPage extends ConsumerWidget {
                         style: Theme.of(context).textTheme.titleLarge,
                       ),
                     ),
-                    const SizedBox(height: 8),
+                    const Gap(8),
                     const Text('投稿が0件になり、語句が削除された可能性があります。'),
                   ],
                 ),

--- a/lib/feature/definition/presentation/definition_tile.dart
+++ b/lib/feature/definition/presentation/definition_tile.dart
@@ -5,12 +5,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/adaptive_overflow_text.dart';
-import '../../../../core/common_widget/avatar_network_image_widget.dart';
 import '../../../../core/common_widget/error_and_retry_widget.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../util/extension/date_time_extension.dart';
 import '../../../../util/logger.dart';
 import '../../definition_like/presentation/like_widget.dart';
+import '../../user_profile/presentation/avatar_network_image_widget.dart';
 import '../application/definition_state.dart';
 import 'definition_tile_shimmer.dart';
 

--- a/lib/feature/definition/presentation/definition_tile.dart
+++ b/lib/feature/definition/presentation/definition_tile.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/adaptive_overflow_text.dart';
 import '../../../../core/common_widget/avatar_network_image_widget.dart';
@@ -51,7 +52,7 @@ class DefinitionTile extends ConsumerWidget {
                         imageUrl: definition.authorImageUrl,
                       ),
                     ),
-                    const SizedBox(width: 8),
+                    const Gap(8),
                     Expanded(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -67,7 +68,7 @@ class DefinitionTile extends ConsumerWidget {
                                   overflow: TextOverflow.ellipsis,
                                 ),
                               ),
-                              const SizedBox(width: 4),
+                              const Gap(4),
                               definition.isPublic
                                   ? const SizedBox.shrink()
                                   : Row(
@@ -79,7 +80,7 @@ class DefinitionTile extends ConsumerWidget {
                                               .colorScheme
                                               .onSurfaceVariant,
                                         ),
-                                        const SizedBox(width: 4),
+                                        const Gap(4),
                                       ],
                                     ),
                               Text(
@@ -92,12 +93,12 @@ class DefinitionTile extends ConsumerWidget {
                             overflow: TextOverflow.clip,
                             style: Theme.of(context).textTheme.titleLarge,
                           ),
-                          const SizedBox(height: 8),
+                          const Gap(8),
                           AdaptiveOverflowText(
                             text: definition.definition,
                             maxLines: 5,
                           ),
-                          const SizedBox(height: 8),
+                          const Gap(8),
                           Align(
                             alignment: Alignment.centerLeft,
                             child: LikeWidget(definition: definition),
@@ -118,9 +119,9 @@ class DefinitionTile extends ConsumerWidget {
         if (asyncDefinition.isRefreshing) {
           return const Column(
             children: [
-              SizedBox(height: 16),
+              Gap(16),
               CupertinoActivityIndicator(),
-              SizedBox(height: 24),
+              Gap(24),
               Divider(),
             ],
           );
@@ -131,11 +132,11 @@ class DefinitionTile extends ConsumerWidget {
         );
         return Column(
           children: [
-            const SizedBox(height: 16),
+            const Gap(16),
             SimpleErrorAndRetryWidget(
               onRetry: () => ref.invalidate(definitionProvider(definitionId)),
             ),
-            const SizedBox(height: 16),
+            const Gap(16),
             const Divider(),
           ],
         );

--- a/lib/feature/definition/presentation/definition_tile_shimmer.dart
+++ b/lib/feature/definition/presentation/definition_tile_shimmer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/shimmer_widget.dart';
 
@@ -15,7 +16,7 @@ class DefinitionTileShimmer extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               ShimmerWidget.circular(width: 48, height: 48),
-              SizedBox(width: 16),
+              Gap(16),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -33,18 +34,18 @@ class DefinitionTileShimmer extends StatelessWidget {
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    Gap(8),
                     ShimmerWidget.rectangular(
                       height: 24,
                       width: 200,
                     ),
-                    SizedBox(height: 8),
+                    Gap(8),
                     ShimmerWidget.rectangular(height: 72),
-                    SizedBox(height: 8),
+                    Gap(8),
                   ],
                 ),
               ),
-              SizedBox(width: 8),
+              Gap(8),
             ],
           ),
         ),

--- a/lib/feature/definition/presentation/post_definition_fab.dart
+++ b/lib/feature/definition/presentation/post_definition_fab.dart
@@ -2,8 +2,8 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-import '../../../feature/definition/presentation/write_definition_base_page.dart';
-import '../../router/app_router.dart';
+import '../../../core/router/app_router.dart';
+import 'write_definition_base_page.dart';
 
 /// 定義投稿画面へ遷移するFAB
 class PostDefinitionFAB extends StatelessWidget {

--- a/lib/feature/definition/presentation/select_post_type_button.dart
+++ b/lib/feature/definition/presentation/select_post_type_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 import 'package:pull_down_button/pull_down_button.dart';
 
 import '../application/definition_for_write_notifier.dart';
@@ -72,12 +73,12 @@ class SelectPostTypeButton extends ConsumerWidget {
               color: Theme.of(context).colorScheme.onSurface,
               size: postType.largeIconSize,
             ),
-            const SizedBox(width: 8),
+            const Gap(8),
             Text(
               postType.labelForWrite,
               style: Theme.of(context).textTheme.titleLarge,
             ),
-            const SizedBox(width: 8),
+            const Gap(8),
             Icon(
               CupertinoIcons.arrowtriangle_down_fill,
               color: Theme.of(context).colorScheme.onSurface,

--- a/lib/feature/definition/presentation/self_definition_action_icon_button.dart
+++ b/lib/feature/definition/presentation/self_definition_action_icon_button.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 import 'package:pull_down_button/pull_down_button.dart';
 
 import '../../../../core/common_provider/dialog_controller.dart';
@@ -141,7 +142,7 @@ class _CannotEditAlertDialog extends StatelessWidget {
             '編集は投稿してから1時間以内にしかできません。',
             overflow: TextOverflow.clip,
           ),
-          SizedBox(height: 8),
+          Gap(8),
           Text(
             '代わりに、この投稿の内容をもとに新規投稿を作成しませんか？',
             overflow: TextOverflow.clip,

--- a/lib/feature/definition/presentation/write_definition_base_page.dart
+++ b/lib/feature/definition/presentation/write_definition_base_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_provider/dialog_controller.dart';
 import '../../../../core/common_widget/dialog/confirm_dialog.dart';
@@ -62,7 +63,7 @@ class WriteDefinitionBasePage extends ConsumerWidget {
         ),
         actions: [
           Center(child: appBarActionWidget),
-          const SizedBox(width: 24),
+          const Gap(24),
         ],
       ),
       body: GestureDetector(
@@ -72,7 +73,7 @@ class WriteDefinitionBasePage extends ConsumerWidget {
             padding: const EdgeInsets.all(24),
             child: ListView(
               children: [
-                const SizedBox(height: 8),
+                const Gap(8),
                 TextFormField(
                   initialValue: definitionForWrite.word,
                   autofocus: autoFocusForm == WriteDefinitionFormType.word,
@@ -104,7 +105,7 @@ class WriteDefinitionBasePage extends ConsumerWidget {
                     border: InputBorder.none,
                   ),
                 ),
-                const SizedBox(height: 16),
+                const Gap(16),
                 TextFormField(
                   initialValue: definitionForWrite.definition,
                   autofocus:
@@ -119,7 +120,7 @@ class WriteDefinitionBasePage extends ConsumerWidget {
                     border: InputBorder.none,
                   ),
                 ),
-                const SizedBox(height: 300),
+                const Gap(300),
               ],
             ),
           ),

--- a/lib/feature/definition_list/presentation/individual_dictionary_definition_list.dart
+++ b/lib/feature/definition_list/presentation/individual_dictionary_definition_list.dart
@@ -5,11 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
-import '../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../util/constant/initial_main_group.dart';
 import '../../../util/extension/scroll_controller_extension.dart';
 import '../../auth/application/auth_state.dart';
+import '../../definition/presentation/post_definition_fab.dart';
 import '../../user_profile/presentation/dictionary_author_widget.dart';
 import '../util/definition_feed_type.dart';
 import 'definition_list.dart';

--- a/lib/feature/definition_list/presentation/individual_dictionary_definition_list.dart
+++ b/lib/feature/definition_list/presentation/individual_dictionary_definition_list.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../core/common_widget/simple_widget_for_empty.dart';
@@ -74,9 +75,9 @@ class IndividualDictionaryDefinitionListPage extends ConsumerWidget {
           },
           body: Column(
             children: [
-              const SizedBox(height: 16),
+              const Gap(16),
               DictionaryAuthorWidget(targetUserId: targetUserId),
-              const SizedBox(height: 16),
+              const Gap(16),
               Expanded(
                 child: DefinitionList(
                   definitionFeedType: DefinitionFeedType.individualIndex,

--- a/lib/feature/definition_list/presentation/individual_dictionary_definition_list.dart
+++ b/lib/feature/definition_list/presentation/individual_dictionary_definition_list.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
-import '../../../core/common_widget/simple_widget_for_empty.dart';
+import '../../../core/common_widget/simple_empty_widget.dart';
 import '../../../util/constant/initial_main_group.dart';
 import '../../../util/extension/scroll_controller_extension.dart';
 import '../../auth/application/auth_state.dart';
@@ -84,7 +84,7 @@ class IndividualDictionaryDefinitionListPage extends ConsumerWidget {
                   targetUserId: targetUserId,
                   initialSubGroup: initialSubGroup,
                   shimmerTileNumber: 1,
-                  emptyWidget: SimpleWidgetForEmpty(
+                  emptyWidget: SimpleEmptyWidget(
                     message: generateEmptyMessage(initialSubGroup.label),
                   ),
                 ),

--- a/lib/feature/force_event/presentation/overlay_force_update_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_force_update_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../core/common_provider/launch_url.dart';
 import '../../../core/common_widget/button/filled_button.dart';
@@ -32,13 +33,13 @@ class OverlayForceUpdateDialog extends ConsumerWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const SizedBox(height: 8),
+                  const Gap(8),
                   Text(
                     '新たなバージョンが配信されています。\nアップデートをお願いします',
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
-                  const SizedBox(height: 16),
+                  const Gap(16),
                   PrimaryFilledButton(
                     onPressed: () {
                       // platform に応じたURLを開く。

--- a/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../core/common_provider/launch_url.dart';
 import '../../../core/common_widget/button/filled_button.dart';
@@ -33,21 +34,21 @@ class OverlayInMaintenanceDialog extends ConsumerWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const SizedBox(height: 8),
+                  const Gap(8),
                   Text(
                     '🤖現在メンテナンス中です🤖'
                     '\n終了予定は${appMaintenance.scheduledEndTime}です。',
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
-                  const SizedBox(height: 16),
+                  const Gap(16),
                   Text(
                     'ご不便をおかけし申し訳ございません🙇‍♂\n'
                     '詳しい情報は下記からご確認いただけます。',
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
-                  const SizedBox(height: 16),
+                  const Gap(16),
                   PrimaryFilledButton(
                     onPressed: () {
                       ref.read(launchURLProvider(latestInformationPageUrl));

--- a/lib/feature/setting/presentation/delete_account_button.dart
+++ b/lib/feature/setting/presentation/delete_account_button.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../core/common_provider/dialog_controller.dart';
 import '../../../core/common_widget/button/filled_button.dart';
@@ -29,13 +30,13 @@ class DeleteAccountButton extends ConsumerWidget with PresentationMixin {
                       'ご利用ありがとうございました。',
                       textAlign: TextAlign.center,
                     ),
-                    const SizedBox(height: 16),
+                    const Gap(16),
                     Text(
                       '新たにアカウントを作成する場合は、\n「新規作成」ボタンをタップしてください',
                       style: Theme.of(context).textTheme.bodyMedium,
                       textAlign: TextAlign.center,
                     ),
-                    const SizedBox(height: 8),
+                    const Gap(8),
                     PrimaryFilledButton(
                       onPressed: () async =>
                           context.navigateTo(const BaseRoute()),

--- a/lib/feature/user_config/presentation/other_user_action_icon_button.dart
+++ b/lib/feature/user_config/presentation/other_user_action_icon_button.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pull_down_button/pull_down_button.dart';
 
-import '../../../feature/auth/application/auth_state.dart';
-import '../../../feature/user_config/application/user_config_service.dart';
-import '../../../feature/user_config/application/user_config_state.dart';
-import '../../../feature/user_profile/application/user_profile_state.dart';
-import '../../../feature/user_profile/domain/user_profile.dart';
+import '../../../core/common_provider/launch_url.dart';
 import '../../../util/constant/url.dart';
 import '../../../util/mixin/presentation_mixin.dart';
-import '../../common_provider/launch_url.dart';
+import '../../auth/application/auth_state.dart';
+import '../../user_profile/application/user_profile_state.dart';
+import '../../user_profile/domain/user_profile.dart';
+import '../application/user_config_service.dart';
+import '../application/user_config_state.dart';
 
 class OtherUserActionIconButton extends ConsumerWidget with PresentationMixin {
   OtherUserActionIconButton({

--- a/lib/feature/user_follow/presentation/following_and_follower_count_widget.dart
+++ b/lib/feature/user_follow/presentation/following_and_follower_count_widget.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/shimmer_widget.dart';
 import '../../../../core/router/app_router.dart';
@@ -42,12 +43,12 @@ class FollowingAndFollowerCountWidget extends ConsumerWidget {
                         .bodyMedium!
                         .copyWith(fontWeight: FontWeight.bold),
                   ),
-                  const SizedBox(width: 4),
+                  const Gap(4),
                   const Text('フォロー中'),
                 ],
               ),
             ),
-            const SizedBox(width: 16),
+            const Gap(16),
             InkWell(
               onTap: () async {
                 await context.pushRoute(
@@ -66,7 +67,7 @@ class FollowingAndFollowerCountWidget extends ConsumerWidget {
                         .bodyMedium!
                         .copyWith(fontWeight: FontWeight.bold),
                   ),
-                  const SizedBox(width: 4),
+                  const Gap(4),
                   const Text('フォロワー'),
                 ],
               ),
@@ -78,11 +79,11 @@ class FollowingAndFollowerCountWidget extends ConsumerWidget {
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           ShimmerWidget.rectangular(width: 16, height: 24),
-          SizedBox(height: 8),
+          Gap(8),
           ShimmerWidget.rectangular(width: 48, height: 16),
-          SizedBox(width: 16),
+          Gap(16),
           ShimmerWidget.rectangular(width: 16, height: 24),
-          SizedBox(height: 8),
+          Gap(8),
           ShimmerWidget.rectangular(width: 48, height: 16),
         ],
       ),

--- a/lib/feature/user_profile/presentation/avatar_network_image_widget.dart
+++ b/lib/feature/user_profile/presentation/avatar_network_image_widget.dart
@@ -1,7 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
-import 'shimmer_widget.dart';
+import '../../../core/common_widget/shimmer_widget.dart';
 
 class AvatarNetworkImageWidget extends StatelessWidget {
   const AvatarNetworkImageWidget({

--- a/lib/feature/user_profile/presentation/changeable_profile_image.dart
+++ b/lib/feature/user_profile/presentation/changeable_profile_image.dart
@@ -6,10 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:pull_down_button/pull_down_button.dart';
 
-import '../../../core/common_widget/avatar_network_image_widget.dart';
 import '../../../util/mixin/presentation_mixin.dart';
 import '../application/user_profile_for_write_notifier.dart';
 import '../domain/user_profile.dart';
+import 'avatar_network_image_widget.dart';
 
 class ChangeableProfileImage extends ConsumerWidget with PresentationMixin {
   const ChangeableProfileImage({

--- a/lib/feature/user_profile/presentation/dictionary_author_widget.dart
+++ b/lib/feature/user_profile/presentation/dictionary_author_widget.dart
@@ -4,11 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
-import '../../../../core/common_widget/avatar_network_image_widget.dart';
 import '../../../../core/common_widget/error_and_retry_widget.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../util/logger.dart';
 import '../application/user_profile_state.dart';
+import 'avatar_network_image_widget.dart';
 
 class DictionaryAuthorWidget extends ConsumerWidget {
   const DictionaryAuthorWidget({

--- a/lib/feature/user_profile/presentation/dictionary_author_widget.dart
+++ b/lib/feature/user_profile/presentation/dictionary_author_widget.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/avatar_network_image_widget.dart';
 import '../../../../core/common_widget/error_and_retry_widget.dart';
@@ -30,7 +31,7 @@ class DictionaryAuthorWidget extends ConsumerWidget {
               'Written by',
               style: Theme.of(context).textTheme.titleMedium,
             ),
-            const SizedBox(width: 16),
+            const Gap(16),
             InkWell(
               onTap: () {
                 context.pushRoute(
@@ -44,7 +45,7 @@ class DictionaryAuthorWidget extends ConsumerWidget {
                   AvatarNetworkImageWidget(
                     imageUrl: targetUserProfile.profileImageUrl,
                   ),
-                  const SizedBox(width: 16),
+                  const Gap(16),
                   Text(
                     targetUserProfile.name,
                     style: Theme.of(context).textTheme.titleMedium,

--- a/lib/feature/user_profile/presentation/profile_tile.dart
+++ b/lib/feature/user_profile/presentation/profile_tile.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/adaptive_overflow_text.dart';
 import '../../../../core/common_widget/avatar_network_image_widget.dart';
@@ -57,7 +58,7 @@ class ProfileTile extends ConsumerWidget {
                     AvatarNetworkImageWidget(
                       imageUrl: targetUserProfile.profileImageUrl,
                     ),
-                    const SizedBox(width: 8),
+                    const Gap(8),
                     Expanded(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -74,16 +75,16 @@ class ProfileTile extends ConsumerWidget {
                                   overflow: TextOverflow.ellipsis,
                                 ),
                               ),
-                              const SizedBox(width: 4),
+                              const Gap(4),
                               button,
                             ],
                           ),
-                          const SizedBox(height: 8),
+                          const Gap(8),
                           AdaptiveOverflowText(
                             text: targetUserProfile.bio,
                             maxLines: 5,
                           ),
-                          const SizedBox(height: 8),
+                          const Gap(8),
                         ],
                       ),
                     ),
@@ -103,20 +104,20 @@ class ProfileTile extends ConsumerWidget {
             children: [
               Row(
                 children: [
-                  const SizedBox(width: 20),
+                  const Gap(20),
                   Icon(
                     CupertinoIcons.exclamationmark_circle_fill,
                     color: Theme.of(context).colorScheme.error,
                     size: 40,
                   ),
-                  const SizedBox(width: 16),
+                  const Gap(16),
                   const Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        SizedBox(height: 16),
+                        Gap(16),
                         Text('存在しないユーザーです。\n削除された可能性があります。'),
-                        SizedBox(height: 16),
+                        Gap(16),
                       ],
                     ),
                   ),
@@ -131,9 +132,9 @@ class ProfileTile extends ConsumerWidget {
         if (asyncTargetUserProfile.isRefreshing) {
           return const Column(
             children: [
-              SizedBox(height: 16),
+              Gap(16),
               CupertinoActivityIndicator(),
-              SizedBox(height: 24),
+              Gap(24),
               Divider(),
             ],
           );
@@ -144,11 +145,11 @@ class ProfileTile extends ConsumerWidget {
         );
         return Column(
           children: [
-            const SizedBox(height: 16),
+            const Gap(16),
             SimpleErrorAndRetryWidget(
               onRetry: () => ref.invalidate(userProfileProvider(targetUserId)),
             ),
-            const SizedBox(height: 16),
+            const Gap(16),
             const Divider(),
           ],
         );

--- a/lib/feature/user_profile/presentation/profile_tile.dart
+++ b/lib/feature/user_profile/presentation/profile_tile.dart
@@ -5,12 +5,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/adaptive_overflow_text.dart';
-import '../../../../core/common_widget/avatar_network_image_widget.dart';
 import '../../../../core/common_widget/error_and_retry_widget.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../util/exception/database_exception.dart';
 import '../../../../util/logger.dart';
 import '../application/user_profile_state.dart';
+import 'avatar_network_image_widget.dart';
 import 'profile_tile_shimmer.dart';
 
 class ProfileTile extends ConsumerWidget {

--- a/lib/feature/user_profile/presentation/profile_tile_shimmer.dart
+++ b/lib/feature/user_profile/presentation/profile_tile_shimmer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/common_widget/shimmer_widget.dart';
 
@@ -15,7 +16,7 @@ class ProfileTileShimmer extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const ShimmerWidget.circular(width: 48, height: 48),
-              const SizedBox(width: 8),
+              const Gap(8),
               Expanded(
                 child: Column(
                   children: [
@@ -35,16 +36,16 @@ class ProfileTileShimmer extends StatelessWidget {
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
+                    const Gap(8),
                     const ShimmerWidget.rectangular(height: 16),
-                    const SizedBox(height: 8),
+                    const Gap(8),
                     const ShimmerWidget.rectangular(height: 16),
-                    const SizedBox(height: 8),
+                    const Gap(8),
                     const Align(
                       alignment: Alignment.centerLeft,
                       child: ShimmerWidget.rectangular(width: 240, height: 16),
                     ),
-                    const SizedBox(height: 24),
+                    const Gap(24),
                   ],
                 ),
               ),

--- a/lib/feature/user_profile/presentation/profile_widget.dart
+++ b/lib/feature/user_profile/presentation/profile_widget.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
-import '../../../../../core/common_widget/avatar_network_image_widget.dart';
 import '../../../../../core/common_widget/button/outlined_button.dart';
 import '../../../../../core/common_widget/error_and_retry_widget.dart';
 import '../../../../../core/router/app_router.dart';
@@ -13,6 +12,7 @@ import '../../auth/application/auth_state.dart';
 import '../../user_follow/presentation/follow_or_unfollow_button.dart';
 import '../../user_follow/presentation/following_and_follower_count_widget.dart';
 import '../application/user_profile_state.dart';
+import 'avatar_network_image_widget.dart';
 import 'profile_widget_shimmer.dart';
 
 class ProfileWidget extends ConsumerWidget {

--- a/lib/feature/user_profile/presentation/profile_widget.dart
+++ b/lib/feature/user_profile/presentation/profile_widget.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../../core/common_widget/avatar_network_image_widget.dart';
 import '../../../../../core/common_widget/button/outlined_button.dart';
@@ -31,7 +32,7 @@ class ProfileWidget extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const SizedBox(height: 24),
+              const Gap(24),
               Row(
                 children: [
                   AvatarNetworkImageWidget(
@@ -51,7 +52,7 @@ class ProfileWidget extends ConsumerWidget {
                         ),
                 ],
               ),
-              const SizedBox(height: 16),
+              const Gap(16),
               Text(
                 targetUserProfile.name,
                 style: Theme.of(context).textTheme.titleLarge,
@@ -62,14 +63,14 @@ class ProfileWidget extends ConsumerWidget {
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
               ),
-              const SizedBox(height: 8),
+              const Gap(8),
               Text(
                 targetUserProfile.bio,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
-              const SizedBox(height: 16),
+              const Gap(16),
               FollowingAndFollowerCountWidget(targetUserId: targetUserId),
-              const SizedBox(height: 16),
+              const Gap(16),
               InkWell(
                 onTap: () async {
                   await context.pushRoute(
@@ -85,7 +86,7 @@ class ProfileWidget extends ConsumerWidget {
                       '辞書を見る',
                       style: Theme.of(context).textTheme.bodyMedium,
                     ),
-                    const SizedBox(width: 4),
+                    const Gap(4),
                     Icon(
                       CupertinoIcons.chevron_forward,
                       size: 16,
@@ -94,7 +95,7 @@ class ProfileWidget extends ConsumerWidget {
                   ],
                 ),
               ),
-              const SizedBox(height: 8),
+              const Gap(8),
             ],
           ),
         );

--- a/lib/feature/user_profile/presentation/profile_widget_shimmer.dart
+++ b/lib/feature/user_profile/presentation/profile_widget_shimmer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../../core/common_widget/shimmer_widget.dart';
 
@@ -12,7 +13,7 @@ class ProfileWidgetShimmer extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const SizedBox(height: 24),
+          const Gap(24),
           const Row(
             children: [
               ShimmerWidget.circular(width: 72, height: 72),
@@ -20,15 +21,15 @@ class ProfileWidgetShimmer extends StatelessWidget {
               
             ],
           ),
-          const SizedBox(height: 16),
+          const Gap(16),
           const ShimmerWidget.rectangular(width: 240, height: 24),
-          const SizedBox(height: 16),
+          const Gap(16),
           const ShimmerWidget.rectangular(height: 16),
-          const SizedBox(height: 8),
+          const Gap(8),
           const ShimmerWidget.rectangular(height: 16),
-          const SizedBox(height: 8),
+          const Gap(8),
           const ShimmerWidget.rectangular(width: 240, height: 16),
-          const SizedBox(height: 24),
+          const Gap(24),
           Align(
             alignment: Alignment.topCenter,
             child: ShimmerWidget.circular(

--- a/lib/feature/word/presentation/word_page_shimmer.dart
+++ b/lib/feature/word/presentation/word_page_shimmer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../../core/common_widget/shimmer_widget.dart';
 import '../../definition/presentation/definition_tile_shimmer.dart';
@@ -15,13 +16,13 @@ class WordPageShimmer extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const SizedBox(height: 24),
+              const Gap(24),
               const ShimmerWidget.rectangular(width: 160, height: 24),
-              const SizedBox(height: 8),
+              const Gap(8),
               const ShimmerWidget.rectangular(width: 120, height: 16),
-              const SizedBox(height: 26),
+              const Gap(26),
               const ShimmerWidget.rectangular(width: 32, height: 16),
-              const SizedBox(height: 16),
+              const Gap(16),
               Center(
                 child: ShimmerWidget.circular(
                   width: 232,
@@ -31,7 +32,7 @@ class WordPageShimmer extends StatelessWidget {
                   ),
                 ),
               ),
-              const SizedBox(height: 32),
+              const Gap(32),
               const Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
@@ -42,7 +43,7 @@ class WordPageShimmer extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 16),
+        const Gap(16),
         const DefinitionTileShimmer(),
       ],
     );

--- a/lib/feature/word/presentation/word_tile.dart
+++ b/lib/feature/word/presentation/word_tile.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../core/router/app_router.dart';
 import '../domain/word.dart';
@@ -56,7 +57,7 @@ class WordTile extends StatelessWidget {
                                 Theme.of(context).colorScheme.onSurfaceVariant,
                           ),
                     ),
-                    const SizedBox(width: 4),
+                    const Gap(4),
                     Icon(
                       CupertinoIcons.chevron_forward,
                       color: Theme.of(context).colorScheme.onSurfaceVariant,

--- a/lib/feature/word/presentation/word_tile_shimmer.dart
+++ b/lib/feature/word/presentation/word_tile_shimmer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../../core/common_widget/shimmer_widget.dart';
 
@@ -20,7 +21,7 @@ class WordTileShimmer extends StatelessWidget {
               ShimmerWidget.rectangular(width: 64, height: 24),
             ],
           ),
-          SizedBox(height: 8),
+          Gap(8),
           ShimmerWidget.rectangular(width: 120, height: 20),
           Divider(),
         ],

--- a/lib/feature/word/presentation/word_widget.dart
+++ b/lib/feature/word/presentation/word_widget.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../../../../core/common_widget/button/filled_button.dart';
 import '../../../../../core/router/app_router.dart';
@@ -21,7 +22,7 @@ class WordWidget extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const SizedBox(height: 24),
+          const Gap(24),
           Text(
             word.word,
             style: Theme.of(context).textTheme.titleLarge,
@@ -33,14 +34,14 @@ class WordWidget extends ConsumerWidget {
                   fontWeight: FontWeight.bold,
                 ),
           ),
-          const SizedBox(height: 24),
+          const Gap(24),
           Text(
             '${word.postedDefinitionCount}投稿',
             style: Theme.of(context).textTheme.titleMedium!.copyWith(
                   color: Theme.of(context).colorScheme.onSurfaceVariant,
                 ),
           ),
-          const SizedBox(height: 8),
+          const Gap(8),
           Center(
             child: PrimaryFilledButton(
               onPressed: () {
@@ -57,7 +58,7 @@ class WordWidget extends ConsumerWidget {
               text: 'この語句の定義を投稿する',
             ),
           ),
-          const SizedBox(height: 8),
+          const Gap(8),
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -709,6 +709,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
+  gap:
+    dependency: "direct main"
+    description:
+      name: gap
+      sha256: f19387d4e32f849394758b91377f9153a1b41d79513ef7668c088c77dbc6955d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_riverpod: ^2.4.3
   fluttertoast: ^8.2.3
   freezed_annotation: ^2.4.1
+  gap: ^3.0.1
   google_mobile_ads: ^3.1.0
   image_cropper: ^5.0.0
   image_picker: ^1.0.4


### PR DESCRIPTION
# 対象Issue

- #162 

# やった事

- 余白をつけることを目的としたSizedBoxをGapに置き換え
- その他軽微なリファクタリング

# やらなかった事

# 動作確認

- Pixel 6a (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリに検索機能を追加しました。
  - UIのレイアウトとスペーシングを管理するために`Gap`ウィジェットを導入しました。

- **バグ修正**
  - 特定のUIコンポーネントのスペーシング問題を修正しました。

- **ドキュメント**
  - ユーザーインターフェースの変更に関するドキュメントを更新しました。

- **リファクタ**
  - `SizedBox`を`Gap`に置き換えて、コードの一貫性を向上させました。

- **スタイル**
  - 検索バーのスタイルを追加し、視覚的な魅力を高めました。

- **テスト**
  - 新しい検索機能に対するテストケースを追加しました。

- **チョア**
  - 依存関係を更新し、`gap`パッケージをプロジェクトに追加しました。

- **リバート**
  - なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->