### PR TITLE
feat: ユーザー API と R2 アバターを実装

### DIFF
--- a/.github/workflows/docbridge.yml
+++ b/.github/workflows/docbridge.yml
@@ -51,8 +51,14 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate \
             -q '.[].filename' > changed-files.txt
           gate_status=0
-          nix develop --command bunx docbridge@0.5.2 related --stdin --gate \
-            < changed-files.txt > gate-output.txt 2>&1 || gate_status=$?
+          nix develop --command sh -c \
+            "bunx docbridge@0.5.2 related --stdin --gate < \"\$1\" > \"\$2\" 2> \"\$3\"" \
+            sh changed-files.txt gate-output.txt gate-error.txt || gate_status=$?
+          cat gate-error.txt >&2
+          if [ "$gate_status" != "0" ] && [ ! -s gate-output.txt ]; then
+            echo "DocBridge related-gate がレポートを生成できませんでした。詳細は CI ログを確認してください。" \
+              > gate-output.txt
+          fi
           echo "GATE_STATUS=${gate_status}" >> "$GITHUB_ENV"
           cat gate-output.txt
 

--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -118,19 +118,24 @@ JWT、Authorization、App Check token、プロフィール内容などの個人�
 
 運用時の変更は `wrangler d1 execute` で行い、管理 API は追加しない。
 
+<!-- @code server/src/users/user-service.ts#UserService -->
 ### ユーザー
 
 - `POST /v1/users` は認証 UID を主キーに初回登録し、9桁数字の publicId を暗号学的乱数で生成する。UNIQUE 競合時は再試行し、同じ UID が登録済みなら409 `user_already_exists` を返す
 - 自分の取得・更新は認証 UID だけを対象とし、他者の private 情報を返さない
 - 他者プロフィールと一覧は論理削除済みユーザーを除外する
 - フォローとミュートは自己指定を400で拒否し、対象が不可視なら404とする
+- フォローとミュートの追加・解除は冪等とする。フォロワー・フォロー中一覧は関係作成日時、ユーザー ID の降順で keyset pagination する
 - アカウント削除はユーザーと所有する定義へ `deleted_at` を設定し、通常 API から即時に不可視とする
 
+<!-- @code server/src/users/user-service.ts#AvatarService -->
 ### アバター
 
 `PUT /v1/users/me/avatar` は JPEG / PNG を受け付け、Content-Type とファイルシグネチャの両方を検証する。10 MiB を安全上限とし、Workers では画像変換しない。
 
 Issue `#185` の Flutter クライアントは HEIC を含む元画像を切り抜き、512 x 512 JPEG quality 85 に変換して送る。R2 key はユーザー単位で固定し、再アップロードは上書きする。削除は R2 object がなくても成功する。
+
+R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object の HTTP metadata に検証済み Content-Type を保存する。レスポンスの `avatarUrl` は環境変数 `AVATAR_BASE_URL` と key を結合して解決する。dev は対象 bucket の r2.dev URL、prod は R2 custom domain を `AVATAR_BASE_URL` に設定し、Worker を介さず直接配信する。
 
 ### 言葉
 

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -791,6 +791,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "未登録（user_not_found）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -818,6 +828,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "未登録（user_not_found）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -838,7 +858,13 @@
         "requestBody": {
           "description": "画像バイナリ",
           "content": {
-            "application/octet-stream": {
+            "image/jpeg": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "image/png": {
               "schema": {
                 "type": "string",
                 "format": "binary"
@@ -875,8 +901,28 @@
               }
             }
           },
+          "404": {
+            "description": "未登録（user_not_found）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "413": {
             "description": "画像サイズ超過（image_too_large）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "画像形式不正（unsupported_image_type）",
             "content": {
               "application/json": {
                 "schema": {
@@ -904,6 +950,16 @@
           },
           "401": {
             "description": "App Check または Firebase ID トークンが欠落・無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "未登録（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {
@@ -1549,6 +1605,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "操作ユーザーが存在しない（user_not_found）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1638,6 +1704,16 @@
           },
           "401": {
             "description": "App Check または Firebase ID トークンが欠落・無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "操作ユーザーが存在しない（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1596,6 +1596,16 @@
           "204": {
             "description": "解除完了（冪等）"
           },
+          "400": {
+            "description": "自分自身への指定（cannot_follow_self）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "App Check または Firebase ID トークンが欠落・無効",
             "content": {
@@ -1607,7 +1617,7 @@
             }
           },
           "404": {
-            "description": "操作ユーザーが存在しない（user_not_found）",
+            "description": "ユーザーが存在しない（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {
@@ -1702,6 +1712,16 @@
           "204": {
             "description": "解除完了（冪等）"
           },
+          "400": {
+            "description": "自分自身への指定（cannot_mute_self）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "App Check または Firebase ID トークンが欠落・無効",
             "content": {
@@ -1713,7 +1733,7 @@
             }
           },
           "404": {
-            "description": "操作ユーザーが存在しない（user_not_found）",
+            "description": "ユーザーが存在しない（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -21,10 +21,12 @@ import { definitionRoutes } from "./routes/definitions";
 import { meRoutes } from "./routes/me";
 import { searchRoutes } from "./routes/search";
 import { timelineRoutes } from "./routes/timeline";
-import { userRoutes } from "./routes/users";
+import { createUserRoutes } from "./routes/users";
 import { wordRoutes } from "./routes/words";
 
 export type Env = {
+  AVATARS: R2Bucket;
+  AVATAR_BASE_URL: string;
   DB: D1Database;
   FIREBASE_PROJECT_ID: string;
   FIREBASE_PROJECT_NUMBER: string;
@@ -36,6 +38,7 @@ type ServerEnvironment = {
 };
 
 type CreateAppOptions = {
+  generatePublicId?: () => string;
   generateRequestId?: () => string;
   logRequest?: (entry: RequestLogEntry) => void;
   verifyAppCheck?: (token: string, env: Env) => Promise<AppCheckIdentity>;
@@ -46,6 +49,7 @@ type CreateAppOptions = {
  * @doc doc/specs/workers-api-server.md#リクエスト処理順序
  */
 export function createApp({
+  generatePublicId,
   generateRequestId,
   logRequest,
   verifyAppCheck = (token, env) => verifyAppCheckToken(token, env.FIREBASE_PROJECT_NUMBER),
@@ -54,7 +58,7 @@ export function createApp({
 }: CreateAppOptions = {}) {
   const v1 = new OpenAPIHono<ServerEnvironment>()
     .route("/", appConfigRoutes)
-    .route("/", userRoutes)
+    .route("/", createUserRoutes(generatePublicId ? { generatePublicId } : {}))
     .route("/", meRoutes)
     .route("/", wordRoutes)
     .route("/", definitionRoutes)

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { AuthenticationVariables } from "../auth/middleware";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { definitionResponseSchema } from "../schemas/definition";
 import { userDictionaryItemSchema } from "../schemas/dictionary";
@@ -9,6 +10,7 @@ import {
   userListItemSchema,
   userResponseSchema,
 } from "../schemas/user";
+import { AvatarService, UserService, type UserServiceOptions } from "../users/user-service";
 import {
   authErrorResponses,
   authenticatedSecurity,
@@ -60,6 +62,7 @@ const updateMeRoute = createRoute({
   },
   responses: {
     200: jsonContent(meResponseSchema, "更新後の自分の情報"),
+    404: errorContent("未登録（user_not_found）"),
     ...authErrorResponses,
   },
 });
@@ -74,7 +77,10 @@ const uploadAvatarRoute = createRoute({
   request: {
     body: {
       content: {
-        "application/octet-stream": {
+        "image/jpeg": {
+          schema: z.string().openapi({ format: "binary" }),
+        },
+        "image/png": {
           schema: z.string().openapi({ format: "binary" }),
         },
       },
@@ -83,7 +89,9 @@ const uploadAvatarRoute = createRoute({
   },
   responses: {
     200: jsonContent(z.object({ avatarUrl: z.string() }), "保存後の配信 URL"),
+    404: errorContent("未登録（user_not_found）"),
     413: errorContent("画像サイズ超過（image_too_large）"),
+    415: errorContent("画像形式不正（unsupported_image_type）"),
     ...authErrorResponses,
   },
 });
@@ -96,6 +104,7 @@ const deleteAvatarRoute = createRoute({
   security: authenticatedSecurity,
   responses: {
     204: { description: "削除完了" },
+    404: errorContent("未登録（user_not_found）"),
     ...authErrorResponses,
   },
 });
@@ -108,6 +117,7 @@ const deleteMeRoute = createRoute({
   security: authenticatedSecurity,
   responses: {
     204: { description: "削除受付完了" },
+    404: errorContent("未登録（user_not_found）"),
     ...authErrorResponses,
   },
 });
@@ -231,6 +241,7 @@ const unfollowRoute = createRoute({
   request: { params: userIdParams },
   responses: {
     204: { description: "解除完了（冪等）" },
+    404: errorContent("操作ユーザーが存在しない（user_not_found）"),
     ...authErrorResponses,
   },
 });
@@ -259,24 +270,106 @@ const unmuteRoute = createRoute({
   request: { params: userIdParams },
   responses: {
     204: { description: "解除完了（冪等）" },
+    404: errorContent("操作ユーザーが存在しない（user_not_found）"),
     ...authErrorResponses,
   },
 });
 
-export const userRoutes = new OpenAPIHono()
-  .openapi(createUserRoute, notImplemented)
-  .openapi(getMeRoute, notImplemented)
-  .openapi(updateMeRoute, notImplemented)
-  .openapi(uploadAvatarRoute, notImplemented)
-  .openapi(deleteAvatarRoute, notImplemented)
-  .openapi(deleteMeRoute, notImplemented)
-  .openapi(getUserRoute, notImplemented)
-  .openapi(getUserDictionaryRoute, notImplemented)
-  .openapi(getUserDefinitionsRoute, notImplemented)
-  .openapi(getUserLikedDefinitionsRoute, notImplemented)
-  .openapi(getFollowersRoute, notImplemented)
-  .openapi(getFollowingRoute, notImplemented)
-  .openapi(followRoute, notImplemented)
-  .openapi(unfollowRoute, notImplemented)
-  .openapi(muteRoute, notImplemented)
-  .openapi(unmuteRoute, notImplemented);
+type UserRouteEnvironment = {
+  Bindings: {
+    AVATARS: R2Bucket;
+    AVATAR_BASE_URL: string;
+    DB: D1Database;
+  };
+  Variables: AuthenticationVariables;
+};
+
+export function createUserRoutes(options: UserServiceOptions = {}) {
+  const routes = new OpenAPIHono<UserRouteEnvironment>();
+  const users = (env: UserRouteEnvironment["Bindings"]) => new UserService(env, options);
+
+  return routes
+    .openapi(createUserRoute, async (context) => {
+      const user = await users(context.env).create(
+        context.get("firebaseUid"),
+        context.req.valid("json"),
+      );
+      return context.json(user, 201);
+    })
+    .openapi(getMeRoute, async (context) => {
+      const user = await users(context.env).getMe(context.get("firebaseUid"));
+      return context.json(user, 200);
+    })
+    .openapi(updateMeRoute, async (context) => {
+      const user = await users(context.env).update(
+        context.get("firebaseUid"),
+        context.req.valid("json"),
+      );
+      return context.json(user, 200);
+    })
+    .openapi(uploadAvatarRoute, async (context) => {
+      const resolvedAvatarUrl = await new AvatarService(context.env).upload(
+        context.get("firebaseUid"),
+        context.req.raw,
+      );
+      return context.json({ avatarUrl: resolvedAvatarUrl }, 200);
+    })
+    .openapi(deleteAvatarRoute, async (context) => {
+      await new AvatarService(context.env).delete(context.get("firebaseUid"));
+      return context.body(null, 204);
+    })
+    .openapi(deleteMeRoute, async (context) => {
+      await users(context.env).delete(context.get("firebaseUid"));
+      return context.body(null, 204);
+    })
+    .openapi(getUserRoute, async (context) => {
+      const user = await users(context.env).getPublic(
+        context.get("firebaseUid"),
+        context.req.valid("param").id,
+      );
+      return context.json(user, 200);
+    })
+    .openapi(getUserDictionaryRoute, notImplemented)
+    .openapi(getUserDefinitionsRoute, notImplemented)
+    .openapi(getUserLikedDefinitionsRoute, notImplemented)
+    .openapi(getFollowersRoute, async (context) => {
+      const query = context.req.valid("query");
+      const result = await users(context.env).listRelatedUsers(
+        context.get("firebaseUid"),
+        context.req.valid("param").id,
+        "followers",
+        query.limit,
+        query.cursor,
+      );
+      return context.json(result, 200);
+    })
+    .openapi(getFollowingRoute, async (context) => {
+      const query = context.req.valid("query");
+      const result = await users(context.env).listRelatedUsers(
+        context.get("firebaseUid"),
+        context.req.valid("param").id,
+        "following",
+        query.limit,
+        query.cursor,
+      );
+      return context.json(result, 200);
+    })
+    .openapi(followRoute, async (context) => {
+      await users(context.env).follow(context.get("firebaseUid"), context.req.valid("param").id);
+      return context.body(null, 204);
+    })
+    .openapi(unfollowRoute, async (context) => {
+      await users(context.env).unfollow(context.get("firebaseUid"), context.req.valid("param").id);
+      return context.body(null, 204);
+    })
+    .openapi(muteRoute, async (context) => {
+      await users(context.env).mute(context.get("firebaseUid"), context.req.valid("param").id);
+      return context.body(null, 204);
+    })
+    .openapi(unmuteRoute, async (context) => {
+      await users(context.env).unmute(context.get("firebaseUid"), context.req.valid("param").id);
+      return context.body(null, 204);
+    });
+}
+
+export const userRoutes = createUserRoutes();

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -241,7 +241,8 @@ const unfollowRoute = createRoute({
   request: { params: userIdParams },
   responses: {
     204: { description: "解除完了（冪等）" },
-    404: errorContent("操作ユーザーが存在しない（user_not_found）"),
+    400: errorContent("自分自身への指定（cannot_follow_self）"),
+    404: errorContent("ユーザーが存在しない（user_not_found）"),
     ...authErrorResponses,
   },
 });
@@ -270,7 +271,8 @@ const unmuteRoute = createRoute({
   request: { params: userIdParams },
   responses: {
     204: { description: "解除完了（冪等）" },
-    404: errorContent("操作ユーザーが存在しない（user_not_found）"),
+    400: errorContent("自分自身への指定（cannot_mute_self）"),
+    404: errorContent("ユーザーが存在しない（user_not_found）"),
     ...authErrorResponses,
   },
 });
@@ -371,5 +373,3 @@ export function createUserRoutes(options: UserServiceOptions = {}) {
       return context.body(null, 204);
     });
 }
-
-export const userRoutes = createUserRoutes();

--- a/server/src/users/user-service.ts
+++ b/server/src/users/user-service.ts
@@ -1,0 +1,473 @@
+import { ApiError } from "../errors";
+
+const maxPublicIdAttempts = 10;
+const maxAvatarBytes = 10 * 1024 * 1024;
+
+type UserBindings = {
+  AVATARS: R2Bucket;
+  AVATAR_BASE_URL: string;
+  DB: D1Database;
+};
+
+type UserRow = {
+  avatar_key: string | null;
+  bio: string;
+  created_at: number;
+  id: string;
+  name: string;
+  public_id: string;
+};
+
+type PublicUserRow = UserRow & {
+  follower_count: number;
+  following_count: number;
+  is_followed_by_me: number;
+  is_muted_by_me: number;
+  public_definition_count: number;
+};
+
+type UserListRow = UserRow & {
+  is_followed_by_me: number;
+  is_muted_by_me: number;
+  relation_created_at: number;
+};
+
+type UserListKind = "followers" | "following";
+
+type UserListCursor = {
+  createdAt: number;
+  kind: UserListKind;
+  userId: string;
+  version: 1;
+};
+
+export type CreateUserInput = {
+  appVersion: string;
+  bio: string;
+  name: string;
+  osVersion: string;
+};
+
+export type UpdateUserInput = {
+  appVersion?: string | undefined;
+  bio?: string | undefined;
+  name?: string | undefined;
+  osVersion?: string | undefined;
+};
+
+export type UserServiceOptions = {
+  generatePublicId?: () => string;
+  now?: () => number;
+};
+
+function defaultGeneratePublicId(): string {
+  const maximumUnbiasedValue = 4_000_000_000;
+  const values = new Uint32Array(1);
+  do {
+    crypto.getRandomValues(values);
+  } while ((values[0] ?? maximumUnbiasedValue) >= maximumUnbiasedValue);
+  return String((values[0] ?? 0) % 1_000_000_000).padStart(9, "0");
+}
+
+function avatarUrl(baseUrl: string, key: string | null): string | null {
+  if (key === null) return null;
+  return `${baseUrl.replace(/\/+$/, "")}/${key}`;
+}
+
+function toMeResponse(row: UserRow, baseUrl: string) {
+  return {
+    avatarUrl: avatarUrl(baseUrl, row.avatar_key),
+    bio: row.bio,
+    createdAt: new Date(row.created_at).toISOString(),
+    id: row.id,
+    name: row.name,
+    publicId: row.public_id,
+  };
+}
+
+function toListItem(row: UserListRow, baseUrl: string) {
+  return {
+    avatarUrl: avatarUrl(baseUrl, row.avatar_key),
+    id: row.id,
+    isFollowedByMe: row.is_followed_by_me !== 0,
+    isMutedByMe: row.is_muted_by_me !== 0,
+    name: row.name,
+    publicId: row.public_id,
+  };
+}
+
+function encodeCursor(cursor: UserListCursor): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(cursor));
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+function decodeCursor(value: string, expectedKind: UserListKind): UserListCursor {
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("version" in parsed) ||
+      parsed.version !== 1 ||
+      !("kind" in parsed) ||
+      parsed.kind !== expectedKind ||
+      !("createdAt" in parsed) ||
+      typeof parsed.createdAt !== "number" ||
+      !Number.isSafeInteger(parsed.createdAt) ||
+      !("userId" in parsed) ||
+      typeof parsed.userId !== "string" ||
+      parsed.userId.length === 0
+    ) {
+      throw new Error("invalid cursor payload");
+    }
+    return parsed as UserListCursor;
+  } catch {
+    throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+  }
+}
+
+async function findActiveUser(db: D1Database, id: string): Promise<UserRow | null> {
+  return db
+    .prepare(
+      `select id, public_id, name, bio, avatar_key, created_at
+       from users
+       where id = ? and deleted_at is null`,
+    )
+    .bind(id)
+    .first<UserRow>();
+}
+
+async function requireActiveUser(db: D1Database, id: string): Promise<UserRow> {
+  const user = await findActiveUser(db, id);
+  if (user === null) throw new ApiError(404, "user_not_found", "User not found");
+  return user;
+}
+
+/**
+ * D1 上のユーザー CRUD、フォロー、ミュート、関連一覧を扱う。
+ *
+ * @doc doc/specs/workers-api-server.md#ユーザー
+ */
+export class UserService {
+  readonly #generatePublicId: () => string;
+  readonly #now: () => number;
+
+  constructor(
+    private readonly env: UserBindings,
+    { generatePublicId = defaultGeneratePublicId, now = Date.now }: UserServiceOptions = {},
+  ) {
+    this.#generatePublicId = generatePublicId;
+    this.#now = now;
+  }
+
+  async create(uid: string, input: CreateUserInput) {
+    const existing = await this.env.DB.prepare("select id from users where id = ?")
+      .bind(uid)
+      .first();
+    if (existing !== null) {
+      throw new ApiError(409, "user_already_exists", "User already exists");
+    }
+
+    for (let attempt = 0; attempt < maxPublicIdAttempts; attempt += 1) {
+      const publicId = this.#generatePublicId();
+      if (!/^\d{9}$/.test(publicId)) {
+        throw new Error("generatePublicId must return exactly 9 digits");
+      }
+      const now = this.#now();
+      try {
+        await this.env.DB.prepare(
+          `insert into users
+             (id, public_id, name, bio, last_os_version, last_app_version, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+          .bind(uid, publicId, input.name, input.bio, input.osVersion, input.appVersion, now, now)
+          .run();
+        return toMeResponse(
+          {
+            avatar_key: null,
+            bio: input.bio,
+            created_at: now,
+            id: uid,
+            name: input.name,
+            public_id: publicId,
+          },
+          this.env.AVATAR_BASE_URL,
+        );
+      } catch (error) {
+        const concurrentlyCreated = await this.env.DB.prepare("select id from users where id = ?")
+          .bind(uid)
+          .first();
+        if (concurrentlyCreated !== null) {
+          throw new ApiError(409, "user_already_exists", "User already exists");
+        }
+        const publicIdCollision = await this.env.DB.prepare(
+          "select id from users where public_id = ?",
+        )
+          .bind(publicId)
+          .first();
+        if (publicIdCollision === null) throw error;
+      }
+    }
+
+    throw new ApiError(500, "public_id_generation_failed", "Internal Server Error");
+  }
+
+  async getMe(uid: string) {
+    return toMeResponse(await requireActiveUser(this.env.DB, uid), this.env.AVATAR_BASE_URL);
+  }
+
+  async update(uid: string, input: UpdateUserInput) {
+    const result = await this.env.DB.prepare(
+      `update users
+       set name = coalesce(?, name),
+           bio = coalesce(?, bio),
+           last_os_version = coalesce(?, last_os_version),
+           last_app_version = coalesce(?, last_app_version),
+           updated_at = ?
+       where id = ? and deleted_at is null`,
+    )
+      .bind(
+        input.name ?? null,
+        input.bio ?? null,
+        input.osVersion ?? null,
+        input.appVersion ?? null,
+        this.#now(),
+        uid,
+      )
+      .run();
+    if (result.meta.changes === 0) {
+      throw new ApiError(404, "user_not_found", "User not found");
+    }
+    return this.getMe(uid);
+  }
+
+  async delete(uid: string): Promise<void> {
+    await requireActiveUser(this.env.DB, uid);
+    const now = this.#now();
+    await this.env.DB.batch([
+      this.env.DB.prepare("update users set deleted_at = ?, updated_at = ? where id = ?").bind(
+        now,
+        now,
+        uid,
+      ),
+      this.env.DB.prepare(
+        "update definitions set deleted_at = ?, updated_at = ? where author_id = ? and deleted_at is null",
+      ).bind(now, now, uid),
+    ]);
+  }
+
+  async getPublic(viewerUid: string, userId: string) {
+    const row = await this.env.DB.prepare(
+      `select
+         u.id,
+         u.public_id,
+         u.name,
+         u.bio,
+         u.avatar_key,
+         u.created_at,
+         (select count(*) from definitions d
+          where d.author_id = u.id and d.status = 'public' and d.deleted_at is null)
+           as public_definition_count,
+         (select count(*) from follows f
+          join users followed on followed.id = f.following_id and followed.deleted_at is null
+          where f.follower_id = u.id) as following_count,
+         (select count(*) from follows f
+          join users follower on follower.id = f.follower_id and follower.deleted_at is null
+          where f.following_id = u.id) as follower_count,
+         exists(select 1 from follows f
+          where f.follower_id = ? and f.following_id = u.id) as is_followed_by_me,
+         exists(select 1 from user_mutes m
+          where m.muter_id = ? and m.muted_user_id = u.id) as is_muted_by_me
+       from users u
+       where u.id = ? and u.deleted_at is null`,
+    )
+      .bind(viewerUid, viewerUid, userId)
+      .first<PublicUserRow>();
+    if (row === null) throw new ApiError(404, "user_not_found", "User not found");
+
+    return {
+      ...toMeResponse(row, this.env.AVATAR_BASE_URL),
+      followerCount: row.follower_count,
+      followingCount: row.following_count,
+      isFollowedByMe: row.is_followed_by_me !== 0,
+      isMutedByMe: row.is_muted_by_me !== 0,
+      publicDefinitionCount: row.public_definition_count,
+    };
+  }
+
+  async follow(uid: string, targetId: string): Promise<void> {
+    if (uid === targetId) throw new ApiError(400, "cannot_follow_self", "Cannot follow self");
+    await Promise.all([
+      requireActiveUser(this.env.DB, uid),
+      requireActiveUser(this.env.DB, targetId),
+    ]);
+    await this.env.DB.prepare(
+      "insert or ignore into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+    )
+      .bind(uid, targetId, this.#now())
+      .run();
+  }
+
+  async unfollow(uid: string, targetId: string): Promise<void> {
+    await requireActiveUser(this.env.DB, uid);
+    await this.env.DB.prepare("delete from follows where follower_id = ? and following_id = ?")
+      .bind(uid, targetId)
+      .run();
+  }
+
+  async mute(uid: string, targetId: string): Promise<void> {
+    if (uid === targetId) throw new ApiError(400, "cannot_mute_self", "Cannot mute self");
+    await Promise.all([
+      requireActiveUser(this.env.DB, uid),
+      requireActiveUser(this.env.DB, targetId),
+    ]);
+    await this.env.DB.prepare(
+      "insert or ignore into user_mutes (muter_id, muted_user_id, created_at) values (?, ?, ?)",
+    )
+      .bind(uid, targetId, this.#now())
+      .run();
+  }
+
+  async unmute(uid: string, targetId: string): Promise<void> {
+    await requireActiveUser(this.env.DB, uid);
+    await this.env.DB.prepare("delete from user_mutes where muter_id = ? and muted_user_id = ?")
+      .bind(uid, targetId)
+      .run();
+  }
+
+  async listRelatedUsers(
+    viewerUid: string,
+    targetId: string,
+    kind: UserListKind,
+    limit: number,
+    cursorValue?: string,
+  ) {
+    await requireActiveUser(this.env.DB, targetId);
+    const cursor = cursorValue === undefined ? null : decodeCursor(cursorValue, kind);
+    const relationUserColumn = kind === "followers" ? "f.follower_id" : "f.following_id";
+    const targetColumn = kind === "followers" ? "f.following_id" : "f.follower_id";
+    const cursorClause =
+      cursor === null
+        ? ""
+        : `and (f.created_at < ? or (f.created_at = ? and ${relationUserColumn} < ?))`;
+    const statement = this.env.DB.prepare(
+      `select
+         u.id,
+         u.public_id,
+         u.name,
+         u.bio,
+         u.avatar_key,
+         u.created_at,
+         f.created_at as relation_created_at,
+         exists(select 1 from follows mine
+          where mine.follower_id = ? and mine.following_id = u.id) as is_followed_by_me,
+         exists(select 1 from user_mutes mine
+          where mine.muter_id = ? and mine.muted_user_id = u.id) as is_muted_by_me
+       from follows f
+       join users u on u.id = ${relationUserColumn} and u.deleted_at is null
+       where ${targetColumn} = ? ${cursorClause}
+       order by f.created_at desc, ${relationUserColumn} desc
+       limit ?`,
+    );
+    const bound =
+      cursor === null
+        ? statement.bind(viewerUid, viewerUid, targetId, limit + 1)
+        : statement.bind(
+            viewerUid,
+            viewerUid,
+            targetId,
+            cursor.createdAt,
+            cursor.createdAt,
+            cursor.userId,
+            limit + 1,
+          );
+    const rows = (await bound.all<UserListRow>()).results;
+    const hasNextPage = rows.length > limit;
+    const pageRows = rows.slice(0, limit);
+    const last = pageRows.at(-1);
+    return {
+      items: pageRows.map((row) => toListItem(row, this.env.AVATAR_BASE_URL)),
+      nextCursor:
+        hasNextPage && last !== undefined
+          ? encodeCursor({
+              createdAt: last.relation_created_at,
+              kind,
+              userId: last.id,
+              version: 1,
+            })
+          : null,
+    };
+  }
+}
+
+function hasJpegSignature(bytes: Uint8Array): boolean {
+  return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+}
+
+function hasPngSignature(bytes: Uint8Array): boolean {
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  return signature.every((value, index) => bytes[index] === value);
+}
+
+/**
+ * R2 アバターの形式・容量検証、固定キー保存、削除、公開 URL 解決を扱う。
+ *
+ * @doc doc/specs/workers-api-server.md#アバター
+ */
+export class AvatarService {
+  constructor(private readonly env: UserBindings) {}
+
+  async upload(uid: string, request: Request): Promise<string> {
+    await requireActiveUser(this.env.DB, uid);
+    const contentType = request.headers.get("Content-Type")?.split(";", 1)[0]?.trim().toLowerCase();
+    if (contentType !== "image/jpeg" && contentType !== "image/png") {
+      throw new ApiError(415, "unsupported_image_type", "Unsupported image type");
+    }
+    const contentLength = Number(request.headers.get("Content-Length"));
+    if (Number.isFinite(contentLength) && contentLength > maxAvatarBytes) {
+      throw new ApiError(413, "image_too_large", "Image too large");
+    }
+    const body = await request.arrayBuffer();
+    if (body.byteLength > maxAvatarBytes) {
+      throw new ApiError(413, "image_too_large", "Image too large");
+    }
+    const bytes = new Uint8Array(body);
+    const signatureMatches =
+      contentType === "image/jpeg" ? hasJpegSignature(bytes) : hasPngSignature(bytes);
+    if (!signatureMatches) {
+      throw new ApiError(415, "unsupported_image_type", "Unsupported image type");
+    }
+
+    const key = `avatars/${encodeURIComponent(uid)}`;
+    await this.env.AVATARS.put(key, body, { httpMetadata: { contentType } });
+    try {
+      await this.env.DB.prepare(
+        "update users set avatar_key = ?, updated_at = ? where id = ? and deleted_at is null",
+      )
+        .bind(key, Date.now(), uid)
+        .run();
+    } catch (error) {
+      await this.env.AVATARS.delete(key);
+      throw error;
+    }
+    return avatarUrl(this.env.AVATAR_BASE_URL, key)!;
+  }
+
+  async delete(uid: string): Promise<void> {
+    const user = await requireActiveUser(this.env.DB, uid);
+    const key = user.avatar_key ?? `avatars/${encodeURIComponent(uid)}`;
+    await this.env.AVATARS.delete(key);
+    await this.env.DB.prepare(
+      "update users set avatar_key = null, updated_at = ? where id = ? and deleted_at is null",
+    )
+      .bind(Date.now(), uid)
+      .run();
+  }
+}

--- a/server/src/users/user-service.ts
+++ b/server/src/users/user-service.ts
@@ -316,7 +316,11 @@ export class UserService {
   }
 
   async unfollow(uid: string, targetId: string): Promise<void> {
-    await requireActiveUser(this.env.DB, uid);
+    if (uid === targetId) throw new ApiError(400, "cannot_follow_self", "Cannot follow self");
+    await Promise.all([
+      requireActiveUser(this.env.DB, uid),
+      requireActiveUser(this.env.DB, targetId),
+    ]);
     await this.env.DB.prepare("delete from follows where follower_id = ? and following_id = ?")
       .bind(uid, targetId)
       .run();
@@ -336,7 +340,11 @@ export class UserService {
   }
 
   async unmute(uid: string, targetId: string): Promise<void> {
-    await requireActiveUser(this.env.DB, uid);
+    if (uid === targetId) throw new ApiError(400, "cannot_mute_self", "Cannot mute self");
+    await Promise.all([
+      requireActiveUser(this.env.DB, uid),
+      requireActiveUser(this.env.DB, targetId),
+    ]);
     await this.env.DB.prepare("delete from user_mutes where muter_id = ? and muted_user_id = ?")
       .bind(uid, targetId)
       .run();
@@ -416,6 +424,35 @@ function hasPngSignature(bytes: Uint8Array): boolean {
   return signature.every((value, index) => bytes[index] === value);
 }
 
+async function readBodyWithLimit(
+  body: ReadableStream<Uint8Array> | null,
+  maximumBytes: number,
+): Promise<Uint8Array> {
+  if (body === null) return new Uint8Array();
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const result = await reader.read();
+    if (result.done) break;
+    totalBytes += result.value.byteLength;
+    if (totalBytes > maximumBytes) {
+      await reader.cancel("image_too_large");
+      throw new ApiError(413, "image_too_large", "Image too large");
+    }
+    chunks.push(result.value);
+  }
+
+  const combined = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return combined;
+}
+
 /**
  * R2 アバターの形式・容量検証、固定キー保存、削除、公開 URL 解決を扱う。
  *
@@ -434,11 +471,7 @@ export class AvatarService {
     if (Number.isFinite(contentLength) && contentLength > maxAvatarBytes) {
       throw new ApiError(413, "image_too_large", "Image too large");
     }
-    const body = await request.arrayBuffer();
-    if (body.byteLength > maxAvatarBytes) {
-      throw new ApiError(413, "image_too_large", "Image too large");
-    }
-    const bytes = new Uint8Array(body);
+    const bytes = await readBodyWithLimit(request.body, maxAvatarBytes);
     const signatureMatches =
       contentType === "image/jpeg" ? hasJpegSignature(bytes) : hasPngSignature(bytes);
     if (!signatureMatches) {
@@ -446,15 +479,41 @@ export class AvatarService {
     }
 
     const key = `avatars/${encodeURIComponent(uid)}`;
-    await this.env.AVATARS.put(key, body, { httpMetadata: { contentType } });
+    const previousObject = await this.env.AVATARS.get(key);
+    const previousBody = previousObject === null ? null : await previousObject.arrayBuffer();
+    await this.env.AVATARS.put(key, bytes, { httpMetadata: { contentType } });
     try {
-      await this.env.DB.prepare(
+      const result = await this.env.DB.prepare(
         "update users set avatar_key = ?, updated_at = ? where id = ? and deleted_at is null",
       )
         .bind(key, Date.now(), uid)
         .run();
+      if (result.meta.changes === 0) {
+        throw new ApiError(404, "user_not_found", "User not found");
+      }
     } catch (error) {
-      await this.env.AVATARS.delete(key);
+      try {
+        if (previousObject === null || previousBody === null) {
+          await this.env.AVATARS.delete(key);
+        } else {
+          await this.env.AVATARS.put(key, previousBody, {
+            ...(previousObject.customMetadata
+              ? { customMetadata: previousObject.customMetadata }
+              : {}),
+            ...(previousObject.httpMetadata ? { httpMetadata: previousObject.httpMetadata } : {}),
+          });
+        }
+      } catch (compensationError) {
+        console.error(
+          JSON.stringify({
+            compensationErrorName:
+              compensationError instanceof Error ? compensationError.name : "UnknownError",
+            errorName: error instanceof Error ? error.name : "UnknownError",
+            event: "avatar_upload_compensation_failed",
+          }),
+        );
+        throw error;
+      }
       throw error;
     }
     return avatarUrl(this.env.AVATAR_BASE_URL, key)!;
@@ -463,11 +522,55 @@ export class AvatarService {
   async delete(uid: string): Promise<void> {
     const user = await requireActiveUser(this.env.DB, uid);
     const key = user.avatar_key ?? `avatars/${encodeURIComponent(uid)}`;
-    await this.env.AVATARS.delete(key);
-    await this.env.DB.prepare(
+    const result = await this.env.DB.prepare(
       "update users set avatar_key = null, updated_at = ? where id = ? and deleted_at is null",
     )
       .bind(Date.now(), uid)
       .run();
+    if (result.meta.changes === 0) {
+      throw new ApiError(404, "user_not_found", "User not found");
+    }
+
+    try {
+      await this.env.AVATARS.delete(key);
+    } catch (error) {
+      let objectStillExists = false;
+      try {
+        objectStillExists = (await this.env.AVATARS.head(key)) !== null;
+      } catch (stateCheckError) {
+        console.error(
+          JSON.stringify({
+            errorName: error instanceof Error ? error.name : "UnknownError",
+            event: "avatar_deletion_state_check_failed",
+            stateCheckErrorName:
+              stateCheckError instanceof Error ? stateCheckError.name : "UnknownError",
+          }),
+        );
+      }
+
+      if (objectStillExists && user.avatar_key !== null) {
+        try {
+          const compensation = await this.env.DB.prepare(
+            "update users set avatar_key = ?, updated_at = ? where id = ? and deleted_at is null",
+          )
+            .bind(user.avatar_key, Date.now(), uid)
+            .run();
+          if (compensation.meta.changes === 0) {
+            throw new ApiError(404, "user_not_found", "User not found");
+          }
+        } catch (compensationError) {
+          console.error(
+            JSON.stringify({
+              compensationErrorName:
+                compensationError instanceof Error ? compensationError.name : "UnknownError",
+              errorName: error instanceof Error ? error.name : "UnknownError",
+              event: "avatar_deletion_compensation_failed",
+            }),
+          );
+          throw error;
+        }
+      }
+      throw error;
+    }
   }
 }

--- a/server/test/app-auth.test.ts
+++ b/server/test/app-auth.test.ts
@@ -47,7 +47,7 @@ describe("createApp", () => {
   });
 
   test("両トークンの検証後に認証必須ルートへ到達する", async () => {
-    const response = await testApp().request("/v1/users/me", {
+    const response = await testApp().request("/v1/words", {
       headers: {
         Authorization: "Bearer valid-id-token",
         "X-Firebase-AppCheck": "valid-app-check",

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,11 +1,16 @@
-import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { cloudflareTest, readD1Migrations } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [
-    cloudflareTest({
+    cloudflareTest(async () => ({
+      miniflare: {
+        bindings: {
+          TEST_MIGRATIONS: await readD1Migrations("./drizzle"),
+        },
+      },
       wrangler: { configPath: "./wrangler.toml" },
-    }),
+    })),
   ],
   test: {
     include: ["worker-test/**/*.workers.ts"],

--- a/server/worker-test/env.d.ts
+++ b/server/worker-test/env.d.ts
@@ -1,5 +1,10 @@
-import type { Env } from "../src/app";
+import type { D1Migration } from "@cloudflare/vitest-pool-workers";
+import type { Env as AppEnv } from "../src/app";
 
-declare module "cloudflare:test" {
-  interface ProvidedEnv extends Env {}
+declare global {
+  namespace Cloudflare {
+    interface Env extends AppEnv {
+      TEST_MIGRATIONS: D1Migration[];
+    }
+  }
 }

--- a/server/worker-test/users.workers.ts
+++ b/server/worker-test/users.workers.ts
@@ -1,0 +1,368 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createApp } from "../src/app";
+
+const authHeaders = {
+  Authorization: "Bearer valid-id-token",
+  "X-Firebase-AppCheck": "valid-app-check",
+};
+
+function testApp(uid: string) {
+  return createApp({
+    logRequest: () => {},
+    verifyAppCheck: async () => ({ appId: "test-app-id" }),
+    verifyFirebaseIdToken: async () => ({ uid }),
+  });
+}
+
+async function request(uid: string, path: string, init?: RequestInit) {
+  const headers = new Headers(authHeaders);
+  for (const [key, value] of new Headers(init?.headers)) headers.set(key, value);
+  return testApp(uid).request(path, { ...init, headers }, env);
+}
+
+async function createUser(uid: string, name = uid) {
+  return request(uid, "/v1/users", {
+    body: JSON.stringify({
+      appVersion: "2.0.0",
+      bio: `${name} bio`,
+      name,
+      osVersion: "iOS 19",
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+}
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  await env.DB.batch([
+    env.DB.prepare("delete from users"),
+    env.DB.prepare("delete from words"),
+    env.DB.prepare("delete from app_config"),
+  ]);
+  const objects = await env.AVATARS.list();
+  if (objects.objects.length > 0) {
+    await env.AVATARS.delete(objects.objects.map((object) => object.key));
+  }
+});
+
+describe("user routes", () => {
+  test("publicId の UNIQUE 衝突時は新しい 9 桁 ID で再試行する", async () => {
+    const now = Date.now();
+    await env.DB.prepare(
+      "insert into users (id, public_id, name, bio, last_os_version, last_app_version, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+      .bind("existing", "123456789", "Existing", "", "iOS 19", "2.0.0", now, now)
+      .run();
+    const candidates = ["123456789", "987654321"];
+    const app = createApp({
+      generatePublicId: () => candidates.shift()!,
+      logRequest: () => {},
+      verifyAppCheck: async () => ({ appId: "test-app-id" }),
+      verifyFirebaseIdToken: async () => ({ uid: "alice" }),
+    } as Parameters<typeof createApp>[0]);
+
+    const response = await app.request(
+      "/v1/users",
+      {
+        body: JSON.stringify({
+          appVersion: "2.0.0",
+          bio: "",
+          name: "Alice",
+          osVersion: "iOS 19",
+        }),
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        method: "POST",
+      },
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({ publicId: "987654321" });
+  });
+
+  test("認証 UID でユーザーを登録し、自分の情報を取得・更新できる", async () => {
+    const created = await createUser("alice", "Alice");
+
+    expect(created.status).toBe(201);
+    const createdBody = await created.json<{
+      id: string;
+      publicId: string;
+      name: string;
+      bio: string;
+      avatarUrl: string | null;
+      createdAt: string;
+    }>();
+    expect(createdBody).toMatchObject({
+      avatarUrl: null,
+      bio: "Alice bio",
+      id: "alice",
+      name: "Alice",
+    });
+    expect(createdBody.publicId).toMatch(/^\d{9}$/);
+    expect(new Date(createdBody.createdAt).toISOString()).toBe(createdBody.createdAt);
+
+    const duplicate = await createUser("alice", "Duplicate");
+    expect(duplicate.status).toBe(409);
+    await expect(duplicate.json()).resolves.toEqual({
+      error: { code: "user_already_exists", message: "User already exists" },
+    });
+
+    const updated = await request("alice", "/v1/users/me", {
+      body: JSON.stringify({ bio: "updated", name: "Alicia" }),
+      headers: { "Content-Type": "application/json" },
+      method: "PATCH",
+    });
+    expect(updated.status).toBe(200);
+    await expect(updated.json()).resolves.toMatchObject({
+      bio: "updated",
+      id: "alice",
+      name: "Alicia",
+    });
+
+    const me = await request("alice", "/v1/users/me");
+    expect(me.status).toBe(200);
+    await expect(me.json()).resolves.toMatchObject({
+      bio: "updated",
+      id: "alice",
+      name: "Alicia",
+    });
+  });
+
+  test("公開プロフィールは件数と閲覧者のフォロー・ミュート状態を返す", async () => {
+    await createUser("alice", "Alice");
+    await createUser("bob", "Bob");
+    await createUser("carol", "Carol");
+    const now = Date.now();
+    await env.DB.batch([
+      env.DB.prepare(
+        "insert into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+      ).bind("alice", "bob", now),
+      env.DB.prepare(
+        "insert into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+      ).bind("carol", "bob", now),
+      env.DB.prepare(
+        "insert into user_mutes (muter_id, muted_user_id, created_at) values (?, ?, ?)",
+      ).bind("alice", "bob", now),
+      env.DB.prepare(
+        "insert into words (id, word, reading, reading_sub_group, created_by, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?)",
+      ).bind("word-1", "自由", "じゆう", "さ", "bob", now, now),
+      env.DB.prepare(
+        "insert into definitions (id, word_id, author_id, body, status, finalized_at, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+      ).bind("definition-1", "word-1", "bob", "body", "public", now, now, now),
+      env.DB.prepare(
+        "insert into definitions (id, word_id, author_id, body, status, finalized_at, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+      ).bind("definition-2", "word-1", "bob", "private", "private", now, now, now),
+    ]);
+
+    const response = await request("alice", "/v1/users/bob");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      followerCount: 2,
+      followingCount: 0,
+      id: "bob",
+      isFollowedByMe: true,
+      isMutedByMe: true,
+      publicDefinitionCount: 1,
+    });
+  });
+
+  test("アカウントを論理削除すると本人・公開プロフィール・所有定義が不可視になる", async () => {
+    await createUser("alice", "Alice");
+    const now = Date.now();
+    await env.DB.batch([
+      env.DB.prepare(
+        "insert into words (id, word, reading, reading_sub_group, created_by, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?)",
+      ).bind("word-1", "自由", "じゆう", "さ", "alice", now, now),
+      env.DB.prepare(
+        "insert into definitions (id, word_id, author_id, body, status, finalized_at, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+      ).bind("definition-1", "word-1", "alice", "body", "public", now, now, now),
+    ]);
+
+    const deleted = await request("alice", "/v1/users/me", { method: "DELETE" });
+    expect(deleted.status).toBe(204);
+    expect(await deleted.text()).toBe("");
+
+    const user = await env.DB.prepare("select deleted_at from users where id = ?")
+      .bind("alice")
+      .first<{ deleted_at: number | null }>();
+    const definition = await env.DB.prepare("select deleted_at from definitions where id = ?")
+      .bind("definition-1")
+      .first<{ deleted_at: number | null }>();
+    expect(user?.deleted_at).not.toBeNull();
+    expect(definition?.deleted_at).toBe(user?.deleted_at);
+
+    expect((await request("alice", "/v1/users/me")).status).toBe(404);
+    expect((await request("viewer", "/v1/users/alice")).status).toBe(404);
+  });
+});
+
+describe("follow and mute routes", () => {
+  beforeEach(async () => {
+    await createUser("alice", "Alice");
+    await createUser("bob", "Bob");
+    await createUser("carol", "Carol");
+  });
+
+  test("フォローとミュートは自己指定を拒否し、追加・解除を冪等に行う", async () => {
+    expect((await request("alice", "/v1/users/alice/follow", { method: "PUT" })).status).toBe(400);
+    expect((await request("alice", "/v1/users/alice/mute", { method: "PUT" })).status).toBe(400);
+
+    for (const suffix of ["follow", "mute"]) {
+      expect((await request("alice", `/v1/users/bob/${suffix}`, { method: "PUT" })).status).toBe(
+        204,
+      );
+      expect((await request("alice", `/v1/users/bob/${suffix}`, { method: "PUT" })).status).toBe(
+        204,
+      );
+      expect((await request("alice", `/v1/users/bob/${suffix}`, { method: "DELETE" })).status).toBe(
+        204,
+      );
+      expect((await request("alice", `/v1/users/bob/${suffix}`, { method: "DELETE" })).status).toBe(
+        204,
+      );
+    }
+
+    expect((await request("alice", "/v1/users/missing/follow", { method: "PUT" })).status).toBe(
+      404,
+    );
+    expect((await request("alice", "/v1/users/missing/mute", { method: "PUT" })).status).toBe(404);
+  });
+
+  test("フォロワー・フォロー中一覧を安定した cursor でページングする", async () => {
+    const now = Date.now();
+    await env.DB.batch([
+      env.DB.prepare(
+        "insert into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+      ).bind("alice", "bob", now + 2),
+      env.DB.prepare(
+        "insert into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+      ).bind("carol", "bob", now + 1),
+      env.DB.prepare(
+        "insert into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+      ).bind("bob", "alice", now),
+    ]);
+
+    const first = await request("carol", "/v1/users/bob/followers?limit=1");
+    expect(first.status).toBe(200);
+    const firstBody = await first.json<{
+      items: { id: string; isFollowedByMe: boolean; isMutedByMe: boolean }[];
+      nextCursor: string | null;
+    }>();
+    expect(firstBody.items.map((item) => item.id)).toEqual(["alice"]);
+    expect(firstBody.nextCursor).not.toBeNull();
+
+    const second = await request(
+      "carol",
+      `/v1/users/bob/followers?limit=1&cursor=${encodeURIComponent(firstBody.nextCursor!)}`,
+    );
+    const secondBody = await second.json<typeof firstBody>();
+    expect(secondBody.items.map((item) => item.id)).toEqual(["carol"]);
+    expect(secondBody.nextCursor).toBeNull();
+
+    const following = await request("carol", "/v1/users/alice/following");
+    const followingBody = await following.json<typeof firstBody>();
+    expect(followingBody.items.map((item) => item.id)).toEqual(["bob"]);
+
+    const invalidCursor = await request("carol", "/v1/users/bob/followers?cursor=invalid");
+    expect(invalidCursor.status).toBe(400);
+  });
+
+  test("Firebase UID が非 ASCII でも cursor を往復できる", async () => {
+    await createUser("ありす", "ありす");
+    const now = Date.now();
+    await env.DB.batch([
+      env.DB.prepare(
+        "insert into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+      ).bind("ありす", "bob", now + 1),
+      env.DB.prepare(
+        "insert into follows (follower_id, following_id, created_at) values (?, ?, ?)",
+      ).bind("alice", "bob", now),
+    ]);
+
+    const first = await request("carol", "/v1/users/bob/followers?limit=1");
+    expect(first.status).toBe(200);
+    const firstBody = await first.json<{ items: { id: string }[]; nextCursor: string | null }>();
+    expect(firstBody.items.map((item) => item.id)).toEqual(["ありす"]);
+
+    const second = await request(
+      "carol",
+      `/v1/users/bob/followers?limit=1&cursor=${encodeURIComponent(firstBody.nextCursor!)}`,
+    );
+    expect(second.status).toBe(200);
+    const secondBody = await second.json<typeof firstBody>();
+    expect(secondBody.items.map((item) => item.id)).toEqual(["alice"]);
+  });
+});
+
+describe("avatar routes", () => {
+  beforeEach(async () => {
+    await createUser("alice", "Alice");
+  });
+
+  test("JPEG を検証して固定キーへ保存し、公開 URL を返す", async () => {
+    const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+
+    const response = await request("alice", "/v1/users/me/avatar", {
+      body: jpeg,
+      headers: { "Content-Type": "image/jpeg" },
+      method: "PUT",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      avatarUrl: "https://avatars.local.invalid/avatars/alice",
+    });
+    const object = await env.AVATARS.get("avatars/alice");
+    expect(object).not.toBeNull();
+    expect(object?.httpMetadata?.contentType).toBe("image/jpeg");
+    expect(Array.from(new Uint8Array(await object!.arrayBuffer()))).toEqual(Array.from(jpeg));
+
+    const me = await request("alice", "/v1/users/me");
+    await expect(me.json()).resolves.toMatchObject({
+      avatarUrl: "https://avatars.local.invalid/avatars/alice",
+    });
+  });
+
+  test("Content-Type・シグネチャ不一致と 10 MiB 超過を拒否する", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const mismatch = await request("alice", "/v1/users/me/avatar", {
+      body: png,
+      headers: { "Content-Type": "image/jpeg" },
+      method: "PUT",
+    });
+    expect(mismatch.status).toBe(415);
+
+    const unsupported = await request("alice", "/v1/users/me/avatar", {
+      body: png,
+      headers: { "Content-Type": "application/octet-stream" },
+      method: "PUT",
+    });
+    expect(unsupported.status).toBe(415);
+
+    const tooLarge = new Uint8Array(10 * 1024 * 1024 + 1);
+    tooLarge.set(png);
+    const oversized = await request("alice", "/v1/users/me/avatar", {
+      body: tooLarge,
+      headers: { "Content-Type": "image/png" },
+      method: "PUT",
+    });
+    expect(oversized.status).toBe(413);
+  });
+
+  test("アバター削除は R2 object がなくても成功する", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await request("alice", "/v1/users/me/avatar", {
+      body: png,
+      headers: { "Content-Type": "image/png" },
+      method: "PUT",
+    });
+
+    expect((await request("alice", "/v1/users/me/avatar", { method: "DELETE" })).status).toBe(204);
+    expect(await env.AVATARS.get("avatars/alice")).toBeNull();
+    expect((await request("alice", "/v1/users/me/avatar", { method: "DELETE" })).status).toBe(204);
+  });
+});

--- a/server/worker-test/users.workers.ts
+++ b/server/worker-test/users.workers.ts
@@ -2,6 +2,7 @@ import { applyD1Migrations, env } from "cloudflare:test";
 import { beforeEach, describe, expect, test } from "vitest";
 
 import { createApp } from "../src/app";
+import { AvatarService } from "../src/users/user-service";
 
 const authHeaders = {
   Authorization: "Bearer valid-id-token",
@@ -33,6 +34,21 @@ async function createUser(uid: string, name = uid) {
     headers: { "Content-Type": "application/json" },
     method: "POST",
   });
+}
+
+function databaseFailingAvatarKeyUpdate(match: string): D1Database {
+  return {
+    prepare(query: string) {
+      if (!query.includes(match)) return env.DB.prepare(query);
+      return {
+        bind: () => ({
+          run: async () => {
+            throw new Error("simulated D1 update failure");
+          },
+        }),
+      } as unknown as D1PreparedStatement;
+    },
+  } as unknown as D1Database;
 }
 
 beforeEach(async () => {
@@ -230,6 +246,17 @@ describe("follow and mute routes", () => {
       404,
     );
     expect((await request("alice", "/v1/users/missing/mute", { method: "PUT" })).status).toBe(404);
+
+    expect((await request("alice", "/v1/users/alice/follow", { method: "DELETE" })).status).toBe(
+      400,
+    );
+    expect((await request("alice", "/v1/users/alice/mute", { method: "DELETE" })).status).toBe(400);
+    expect((await request("alice", "/v1/users/missing/follow", { method: "DELETE" })).status).toBe(
+      404,
+    );
+    expect((await request("alice", "/v1/users/missing/mute", { method: "DELETE" })).status).toBe(
+      404,
+    );
   });
 
   test("フォロワー・フォロー中一覧を安定した cursor でページングする", async () => {
@@ -351,6 +378,136 @@ describe("avatar routes", () => {
       method: "PUT",
     });
     expect(oversized.status).toBe(413);
+  });
+
+  test("Content-Length がなくても上限超過時点で body stream を中断する", async () => {
+    let pullCount = 0;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>(
+      {
+        cancel: () => {
+          cancelled = true;
+        },
+        pull(controller) {
+          pullCount += 1;
+          if (pullCount === 1) {
+            const first = new Uint8Array(6 * 1024 * 1024);
+            first.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+            controller.enqueue(first);
+            return;
+          }
+          if (pullCount === 2) {
+            controller.enqueue(new Uint8Array(5 * 1024 * 1024));
+            return;
+          }
+          throw new Error("stream was read after exceeding the limit");
+        },
+      },
+      { highWaterMark: 0 },
+    );
+    const service = new AvatarService(env);
+
+    await expect(
+      service.upload(
+        "alice",
+        new Request("https://example.com/v1/users/me/avatar", {
+          body,
+          headers: { "Content-Type": "image/png" },
+          method: "PUT",
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "image_too_large", status: 413 });
+    expect(pullCount).toBe(2);
+    expect(cancelled).toBe(true);
+  });
+
+  test("D1 更新失敗時も既存アバターと avatar_key の整合性を維持する", async () => {
+    const oldPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01]);
+    const newPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x02]);
+    await request("alice", "/v1/users/me/avatar", {
+      body: oldPng,
+      headers: { "Content-Type": "image/png" },
+      method: "PUT",
+    });
+
+    const uploadService = new AvatarService({
+      ...env,
+      DB: databaseFailingAvatarKeyUpdate("set avatar_key = ?"),
+    });
+    await expect(
+      uploadService.upload(
+        "alice",
+        new Request("https://example.com/v1/users/me/avatar", {
+          body: newPng,
+          headers: { "Content-Type": "image/png" },
+          method: "PUT",
+        }),
+      ),
+    ).rejects.toThrow("simulated D1 update failure");
+    const restored = await env.AVATARS.get("avatars/alice");
+    expect(Array.from(new Uint8Array(await restored!.arrayBuffer()))).toEqual(Array.from(oldPng));
+
+    const deleteService = new AvatarService({
+      ...env,
+      DB: databaseFailingAvatarKeyUpdate("set avatar_key = null"),
+    });
+    await expect(deleteService.delete("alice")).rejects.toThrow("simulated D1 update failure");
+    expect(await env.AVATARS.get("avatars/alice")).not.toBeNull();
+    const user = await env.DB.prepare("select avatar_key from users where id = ?")
+      .bind("alice")
+      .first<{ avatar_key: string | null }>();
+    expect(user?.avatar_key).toBe("avatars/alice");
+  });
+
+  test("R2 削除失敗時は avatar_key を復元する", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await request("alice", "/v1/users/me/avatar", {
+      body: png,
+      headers: { "Content-Type": "image/png" },
+      method: "PUT",
+    });
+    const service = new AvatarService({
+      ...env,
+      AVATARS: {
+        delete: async () => {
+          throw new Error("simulated R2 delete failure");
+        },
+        head: (key: string) => env.AVATARS.head(key),
+      } as unknown as R2Bucket,
+    });
+
+    await expect(service.delete("alice")).rejects.toThrow("simulated R2 delete failure");
+    const user = await env.DB.prepare("select avatar_key from users where id = ?")
+      .bind("alice")
+      .first<{ avatar_key: string | null }>();
+    expect(user?.avatar_key).toBe("avatars/alice");
+    expect(await env.AVATARS.get("avatars/alice")).not.toBeNull();
+  });
+
+  test("R2 削除が反映済みならエラー応答でも avatar_key を復元しない", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await request("alice", "/v1/users/me/avatar", {
+      body: png,
+      headers: { "Content-Type": "image/png" },
+      method: "PUT",
+    });
+    const service = new AvatarService({
+      ...env,
+      AVATARS: {
+        delete: async (key: string) => {
+          await env.AVATARS.delete(key);
+          throw new Error("simulated ambiguous R2 delete failure");
+        },
+        head: (key: string) => env.AVATARS.head(key),
+      } as unknown as R2Bucket,
+    });
+
+    await expect(service.delete("alice")).rejects.toThrow("simulated ambiguous R2 delete failure");
+    const user = await env.DB.prepare("select avatar_key from users where id = ?")
+      .bind("alice")
+      .first<{ avatar_key: string | null }>();
+    expect(user?.avatar_key).toBeNull();
+    expect(await env.AVATARS.get("avatars/alice")).toBeNull();
   });
 
   test("アバター削除は R2 object がなくても成功する", async () => {

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -6,9 +6,14 @@ compatibility_date = "2026-07-01"
 [vars]
 FIREBASE_PROJECT_ID = "everyone-teigi-dev"
 FIREBASE_PROJECT_NUMBER = "225028441501"
+AVATAR_BASE_URL = "https://avatars.local.invalid"
 
 [[d1_databases]]
 binding = "DB"
 database_name = "teigiii-local"
 database_id = "local"
 migrations_dir = "drizzle"
+
+[[r2_buckets]]
+binding = "AVATARS"
+bucket_name = "teigiii-local-avatars"


### PR DESCRIPTION
## 概要

- ユーザー登録・自他プロフィール取得・更新・論理削除を実装
- フォロー・ミュートとフォロワー/フォロー中の keyset pagination を実装
- JPEG/PNG・10 MiB 上限を検証する R2 アバター保存/削除と公開 URL 解決を実装
- D1/R2 の Workers 結合テスト、OpenAPI、DocBridge 仕様を同期

## スコープ境界

ユーザー配下の辞書・定義・いいね一覧は #193/#194 の担当として 501 を維持しています。

## DocBridge related-gate の判断

`doc/specs/workers-api-server.md` の変更箇所は「ユーザー」「アバター」節だけです。related-gate が列挙した既存7カウンターパートは、以下の理由で更新不要と判断しました。

- `createAppCheckMiddleware`: App Check の適用順序・失敗処理は変更していません。
- `createFirebaseAuthMiddleware`: Firebase Auth の適用順序・app-config 免除条件は変更していません。
- `AppCheckTokenVerifier`: 署名・issuer・audience・claim 検証条件は変更していません。
- `FirebaseIdTokenVerifier`: 署名・issuer・audience・時刻・UID 検証条件は変更していません。
- `FirebasePublicKeyProvider`: 公開鍵取得・期限・ローテーション・同時取得制御は変更していません。
- `ApiError`: HTTP status・code・message のエラー形式は変更していません。
- `createRequestContextMiddleware`: request ID、ログ項目、処理時間計測は変更していません。

## 検証

- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bun run test`（unit 56件、Workers 16件）
- `nix develop -c just docbridge-check`（0 errors, 0 warnings）

Closes #192