### PR TITLE
feat: 言葉・定義・いいね API を実装

### DIFF
--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -137,6 +137,7 @@ Issue `#185` の Flutter クライアントは HEIC を含む元画像を切り�
 
 R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object の HTTP metadata に検証済み Content-Type を保存する。レスポンスの `avatarUrl` は環境変数 `AVATAR_BASE_URL` と key を結合して解決する。dev は対象 bucket の r2.dev URL、prod は R2 custom domain を `AVATAR_BASE_URL` に設定し、Worker を介さず直接配信する。
 
+<!-- @code server/src/words/word-service.ts#WordService -->
 ### 言葉
 
 - 登録前に前後空白を除去し NFC 正規化する。同一表記は409で既存言葉を返す
@@ -144,6 +145,7 @@ R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object �
 - 言葉の修正は登録後1時間以内かつ、登録者本人で、他ユーザーの定義または保存がない場合だけ許可する
 - 一覧は reading、id の安定順とし、指定された行、定義有無、検索語を適用する
 
+<!-- @code server/src/definitions/definition-service.ts#DefinitionService -->
 ### 定義
 
 - draft は `finalized_at=null`、public / private は初回確定時の `finalized_at` を持つ

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2130,6 +2130,16 @@
               }
             }
           },
+          "404": {
+            "description": "未登録・削除済みユーザー（user_not_found）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "409": {
             "description": "同一表記が登録済み（word_already_exists）。既存の言葉を返す",
             "content": {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2373,7 +2373,7 @@
             }
           },
           "404": {
-            "description": "言葉が存在しない（word_not_found）",
+            "description": "言葉が存在しない（word_not_found）・未登録・削除済みユーザー（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {
@@ -2551,7 +2551,7 @@
             }
           },
           "404": {
-            "description": "言葉が存在しない（word_not_found）",
+            "description": "言葉が存在しない（word_not_found）・未登録・削除済みユーザー（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {
@@ -2644,7 +2644,7 @@
             }
           },
           "404": {
-            "description": "言葉が存在しない（word_not_found）",
+            "description": "言葉が存在しない（word_not_found）・未登録・削除済みユーザー（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {
@@ -2891,7 +2891,7 @@
             }
           },
           "404": {
-            "description": "定義が存在しない（definition_not_found）",
+            "description": "定義が存在しない（definition_not_found）・未登録・削除済みユーザー（user_not_found）",
             "content": {
               "application/json": {
                 "schema": {

--- a/server/src/definitions/definition-service.ts
+++ b/server/src/definitions/definition-service.ts
@@ -1,0 +1,340 @@
+import { ApiError } from "../errors";
+import { decodeOpaqueCursor, encodeOpaqueCursor } from "../lib/cursor";
+import { uuidv7 } from "../lib/uuidv7";
+
+const editWindowMilliseconds = 60 * 60 * 1000;
+
+type DefinitionBindings = {
+  AVATAR_BASE_URL: string;
+  DB: D1Database;
+};
+
+type DefinitionStatus = "draft" | "public" | "private";
+
+type DefinitionRow = {
+  id: string;
+  word_id: string;
+  author_id: string;
+  body: string;
+  status: DefinitionStatus;
+  finalized_at: number | null;
+  is_edited: number;
+  created_at: number;
+  updated_at: number;
+};
+
+type DefinitionDetailRow = DefinitionRow & {
+  word: string;
+  reading: string;
+  author_public_id: string;
+  author_name: string;
+  author_avatar_key: string | null;
+  likes_count: number;
+  is_liked_by_me: number;
+};
+
+type LikedUserRow = {
+  id: string;
+  public_id: string;
+  name: string;
+  avatar_key: string | null;
+  liked_at: number;
+  is_followed_by_me: number;
+  is_muted_by_me: number;
+};
+
+type LikedUsersCursor = {
+  createdAt: number;
+  kind: "definition_likes";
+  userId: string;
+  version: 1;
+};
+
+export type CreateDefinitionInput = {
+  body: string;
+  status: DefinitionStatus;
+  wordId: string;
+};
+
+export type UpdateDefinitionInput = {
+  body?: string | undefined;
+  status?: DefinitionStatus | undefined;
+  wordId?: string | undefined;
+};
+
+function avatarUrl(baseUrl: string, key: string | null): string | null {
+  if (key === null) return null;
+  return `${baseUrl.replace(/\/+$/, "")}/${key}`;
+}
+
+function decodeLikedUsersCursor(value: string): LikedUsersCursor {
+  const parsed = decodeOpaqueCursor(value);
+  if (
+    parsed["version"] !== 1 ||
+    parsed["kind"] !== "definition_likes" ||
+    typeof parsed["createdAt"] !== "number" ||
+    !Number.isSafeInteger(parsed["createdAt"]) ||
+    typeof parsed["userId"] !== "string" ||
+    parsed["userId"].length === 0
+  ) {
+    throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+  }
+  return parsed as unknown as LikedUsersCursor;
+}
+
+function definitionNotFound(): never {
+  throw new ApiError(404, "definition_not_found", "Definition not found");
+}
+
+/**
+ * D1 上の定義の作成・取得・状態遷移・期限付き本文編集・論理削除・いいねを扱う。
+ *
+ * @doc doc/specs/workers-api-server.md#定義
+ */
+export class DefinitionService {
+  constructor(private readonly env: DefinitionBindings) {}
+
+  async #requireActiveUser(uid: string): Promise<void> {
+    const user = await this.env.DB.prepare(
+      "select id from users where id = ? and deleted_at is null",
+    )
+      .bind(uid)
+      .first();
+    if (user === null) throw new ApiError(404, "user_not_found", "User not found");
+  }
+
+  async #requireWordExists(wordId: string): Promise<void> {
+    const word = await this.env.DB.prepare("select id from words where id = ?")
+      .bind(wordId)
+      .first();
+    if (word === null) throw new ApiError(404, "word_not_found", "Word not found");
+  }
+
+  /** 削除済み・作者が論理削除済みの定義は存在しないものとして扱う。可視性判定は呼び出し側で行う。 */
+  async #findRow(id: string): Promise<DefinitionRow | null> {
+    return this.env.DB.prepare(
+      `select d.id, d.word_id, d.author_id, d.body, d.status, d.finalized_at, d.is_edited,
+              d.created_at, d.updated_at
+       from definitions d
+       join users u on u.id = d.author_id and u.deleted_at is null
+       where d.id = ? and d.deleted_at is null`,
+    )
+      .bind(id)
+      .first<DefinitionRow>();
+  }
+
+  /** 本人の全状態 + 他者の public だけを可視とする。それ以外は 404 で存在を秘匿する。 */
+  async #requireVisibleRow(uid: string, id: string): Promise<DefinitionRow> {
+    const row = await this.#findRow(id);
+    if (row === null || (row.author_id !== uid && row.status !== "public")) definitionNotFound();
+    return row;
+  }
+
+  async #getDetail(uid: string, id: string) {
+    const row = await this.env.DB.prepare(
+      `select
+         d.id, d.word_id, d.author_id, d.body, d.status, d.finalized_at, d.is_edited,
+         d.created_at, d.updated_at,
+         w.word, w.reading,
+         u.public_id as author_public_id,
+         u.name as author_name,
+         u.avatar_key as author_avatar_key,
+         (select count(*) from likes l
+          join users lu on lu.id = l.user_id and lu.deleted_at is null
+          where l.definition_id = d.id) as likes_count,
+         exists(select 1 from likes l
+          where l.definition_id = d.id and l.user_id = ?) as is_liked_by_me
+       from definitions d
+       join words w on w.id = d.word_id
+       join users u on u.id = d.author_id and u.deleted_at is null
+       where d.id = ? and d.deleted_at is null`,
+    )
+      .bind(uid, id)
+      .first<DefinitionDetailRow>();
+    if (row === null || (row.author_id !== uid && row.status !== "public")) definitionNotFound();
+
+    const editableUntil =
+      row.finalized_at === null ? null : row.finalized_at + editWindowMilliseconds;
+    return {
+      author: {
+        avatarUrl: avatarUrl(this.env.AVATAR_BASE_URL, row.author_avatar_key),
+        id: row.author_id,
+        name: row.author_name,
+        publicId: row.author_public_id,
+      },
+      body: row.body,
+      createdAt: new Date(row.created_at).toISOString(),
+      editableUntil: editableUntil === null ? null : new Date(editableUntil).toISOString(),
+      finalizedAt: row.finalized_at === null ? null : new Date(row.finalized_at).toISOString(),
+      id: row.id,
+      isEdited: row.is_edited !== 0,
+      isLikedByMe: row.is_liked_by_me !== 0,
+      likesCount: row.likes_count,
+      status: row.status,
+      updatedAt: new Date(row.updated_at).toISOString(),
+      word: { id: row.word_id, reading: row.reading, word: row.word },
+    };
+  }
+
+  async create(uid: string, input: CreateDefinitionInput) {
+    await this.#requireActiveUser(uid);
+    await this.#requireWordExists(input.wordId);
+
+    const id = uuidv7();
+    const now = Date.now();
+    await this.env.DB.prepare(
+      `insert into definitions (id, word_id, author_id, body, status, finalized_at, is_edited, created_at, updated_at)
+       values (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+    )
+      .bind(
+        id,
+        input.wordId,
+        uid,
+        input.body,
+        input.status,
+        input.status === "draft" ? null : now,
+        now,
+        now,
+      )
+      .run();
+    return this.#getDetail(uid, id);
+  }
+
+  async get(uid: string, id: string) {
+    return this.#getDetail(uid, id);
+  }
+
+  async update(uid: string, id: string, input: UpdateDefinitionInput) {
+    const row = await this.#findRow(id);
+    if (row === null || (row.author_id !== uid && row.status !== "public")) definitionNotFound();
+    if (row.author_id !== uid) throw new ApiError(403, "forbidden", "Forbidden");
+
+    const now = Date.now();
+    const wasFinalized = row.finalized_at !== null;
+    const nextStatus = input.status ?? row.status;
+
+    if (wasFinalized && nextStatus === "draft") {
+      throw new ApiError(400, "invalid_transition", "Cannot revert to draft");
+    }
+
+    const wordChanged = input.wordId !== undefined && input.wordId !== row.word_id;
+    if (wordChanged) {
+      if (wasFinalized) {
+        throw new ApiError(400, "invalid_transition", "Cannot change word after finalization");
+      }
+      await this.#requireWordExists(input.wordId!);
+    }
+
+    const bodyChanged = input.body !== undefined && input.body !== row.body;
+    if (bodyChanged && wasFinalized && now - row.finalized_at! >= editWindowMilliseconds) {
+      throw new ApiError(403, "edit_window_expired", "Edit window expired");
+    }
+
+    const finalizedAt = !wasFinalized && nextStatus !== "draft" ? now : row.finalized_at;
+    const isEdited = row.is_edited !== 0 || (bodyChanged && wasFinalized);
+
+    await this.env.DB.prepare(
+      `update definitions
+       set word_id = ?, body = ?, status = ?, finalized_at = ?, is_edited = ?, updated_at = ?
+       where id = ?`,
+    )
+      .bind(
+        wordChanged ? input.wordId! : row.word_id,
+        input.body ?? row.body,
+        nextStatus,
+        finalizedAt,
+        isEdited ? 1 : 0,
+        now,
+        id,
+      )
+      .run();
+    return this.#getDetail(uid, id);
+  }
+
+  async delete(uid: string, id: string): Promise<void> {
+    const row = await this.#findRow(id);
+    if (row === null || (row.author_id !== uid && row.status !== "public")) definitionNotFound();
+    if (row.author_id !== uid) throw new ApiError(403, "forbidden", "Forbidden");
+
+    const now = Date.now();
+    await this.env.DB.prepare("update definitions set deleted_at = ?, updated_at = ? where id = ?")
+      .bind(now, now, id)
+      .run();
+  }
+
+  async like(uid: string, id: string): Promise<void> {
+    await this.#requireActiveUser(uid);
+    await this.#requireVisibleRow(uid, id);
+    await this.env.DB.prepare(
+      "insert or ignore into likes (user_id, definition_id, created_at) values (?, ?, ?)",
+    )
+      .bind(uid, id, Date.now())
+      .run();
+  }
+
+  async unlike(uid: string, id: string): Promise<void> {
+    await this.env.DB.prepare("delete from likes where user_id = ? and definition_id = ?")
+      .bind(uid, id)
+      .run();
+  }
+
+  async listLikedUsers(uid: string, id: string, limit: number, cursorValue?: string) {
+    await this.#requireVisibleRow(uid, id);
+    const cursor = cursorValue === undefined ? null : decodeLikedUsersCursor(cursorValue);
+    const cursorClause =
+      cursor === null ? "" : "and (l.created_at < ? or (l.created_at = ? and l.user_id < ?))";
+    const statement = this.env.DB.prepare(
+      `select
+         u.id,
+         u.public_id,
+         u.name,
+         u.avatar_key,
+         l.created_at as liked_at,
+         exists(select 1 from follows mine
+          where mine.follower_id = ? and mine.following_id = u.id) as is_followed_by_me,
+         exists(select 1 from user_mutes mine
+          where mine.muter_id = ? and mine.muted_user_id = u.id) as is_muted_by_me
+       from likes l
+       join users u on u.id = l.user_id and u.deleted_at is null
+       where l.definition_id = ? ${cursorClause}
+       order by l.created_at desc, l.user_id desc
+       limit ?`,
+    );
+    const bound =
+      cursor === null
+        ? statement.bind(uid, uid, id, limit + 1)
+        : statement.bind(
+            uid,
+            uid,
+            id,
+            cursor.createdAt,
+            cursor.createdAt,
+            cursor.userId,
+            limit + 1,
+          );
+    const rows = (await bound.all<LikedUserRow>()).results;
+
+    const hasNextPage = rows.length > limit;
+    const pageRows = rows.slice(0, limit);
+    const last = pageRows.at(-1);
+    return {
+      items: pageRows.map((row) => ({
+        avatarUrl: avatarUrl(this.env.AVATAR_BASE_URL, row.avatar_key),
+        id: row.id,
+        isFollowedByMe: row.is_followed_by_me !== 0,
+        isMutedByMe: row.is_muted_by_me !== 0,
+        name: row.name,
+        publicId: row.public_id,
+      })),
+      nextCursor:
+        hasNextPage && last !== undefined
+          ? encodeOpaqueCursor({
+              createdAt: last.liked_at,
+              kind: "definition_likes",
+              userId: last.id,
+              version: 1,
+            } satisfies LikedUsersCursor)
+          : null,
+    };
+  }
+}

--- a/server/src/definitions/definition-service.ts
+++ b/server/src/definitions/definition-service.ts
@@ -274,10 +274,16 @@ export class DefinitionService {
   async like(uid: string, id: string): Promise<void> {
     await this.#requireActiveUser(uid);
     await this.#requireVisibleRow(uid, id);
+    // 可視性チェックと INSERT の間に削除・非公開化が入る TOCTOU を防ぐため、
+    // 可視条件を述語に含めた単一文で挿入する
     await this.env.DB.prepare(
-      "insert or ignore into likes (user_id, definition_id, created_at) values (?, ?, ?)",
+      `insert or ignore into likes (user_id, definition_id, created_at)
+       select ?, d.id, ?
+       from definitions d
+       join users u on u.id = d.author_id and u.deleted_at is null
+       where d.id = ? and d.deleted_at is null and (d.author_id = ? or d.status = 'public')`,
     )
-      .bind(uid, id, Date.now())
+      .bind(uid, Date.now(), id, uid)
       .run();
   }
 

--- a/server/src/definitions/definition-service.ts
+++ b/server/src/definitions/definition-service.ts
@@ -3,6 +3,8 @@ import { decodeOpaqueCursor, encodeOpaqueCursor } from "../lib/cursor";
 import { uuidv7 } from "../lib/uuidv7";
 
 const editWindowMilliseconds = 60 * 60 * 1000;
+// 楽観ロックの再試行上限。自分の定義への並行更新だけが対象のため衝突は稀
+const maxUpdateAttempts = 3;
 
 type DefinitionBindings = {
   AVATAR_BASE_URL: string;
@@ -205,50 +207,57 @@ export class DefinitionService {
   }
 
   async update(uid: string, id: string, input: UpdateDefinitionInput) {
-    const row = await this.#findRow(id);
-    if (row === null || (row.author_id !== uid && row.status !== "public")) definitionNotFound();
-    if (row.author_id !== uid) throw new ApiError(403, "forbidden", "Forbidden");
+    // 読み取りと更新の間に並行リクエストが割り込むと確定済み定義が draft へ巻き戻り得るため、
+    // 観測した status / updated_at を条件にした楽観ロックで更新し、外れたら再評価する
+    for (let attempt = 0; attempt < maxUpdateAttempts; attempt += 1) {
+      const row = await this.#findRow(id);
+      if (row === null || (row.author_id !== uid && row.status !== "public")) definitionNotFound();
+      if (row.author_id !== uid) throw new ApiError(403, "forbidden", "Forbidden");
 
-    const now = Date.now();
-    const wasFinalized = row.finalized_at !== null;
-    const nextStatus = input.status ?? row.status;
+      const now = Date.now();
+      const wasFinalized = row.finalized_at !== null;
+      const nextStatus = input.status ?? row.status;
 
-    if (wasFinalized && nextStatus === "draft") {
-      throw new ApiError(400, "invalid_transition", "Cannot revert to draft");
-    }
-
-    const wordChanged = input.wordId !== undefined && input.wordId !== row.word_id;
-    if (wordChanged) {
-      if (wasFinalized) {
-        throw new ApiError(400, "invalid_transition", "Cannot change word after finalization");
+      if (wasFinalized && nextStatus === "draft") {
+        throw new ApiError(400, "invalid_transition", "Cannot revert to draft");
       }
-      await this.#requireWordExists(input.wordId!);
-    }
 
-    const bodyChanged = input.body !== undefined && input.body !== row.body;
-    if (bodyChanged && wasFinalized && now - row.finalized_at! >= editWindowMilliseconds) {
-      throw new ApiError(403, "edit_window_expired", "Edit window expired");
-    }
+      const wordChanged = input.wordId !== undefined && input.wordId !== row.word_id;
+      if (wordChanged) {
+        if (wasFinalized) {
+          throw new ApiError(400, "invalid_transition", "Cannot change word after finalization");
+        }
+        await this.#requireWordExists(input.wordId!);
+      }
 
-    const finalizedAt = !wasFinalized && nextStatus !== "draft" ? now : row.finalized_at;
-    const isEdited = row.is_edited !== 0 || (bodyChanged && wasFinalized);
+      const bodyChanged = input.body !== undefined && input.body !== row.body;
+      if (bodyChanged && wasFinalized && now - row.finalized_at! >= editWindowMilliseconds) {
+        throw new ApiError(403, "edit_window_expired", "Edit window expired");
+      }
 
-    await this.env.DB.prepare(
-      `update definitions
-       set word_id = ?, body = ?, status = ?, finalized_at = ?, is_edited = ?, updated_at = ?
-       where id = ?`,
-    )
-      .bind(
-        wordChanged ? input.wordId! : row.word_id,
-        input.body ?? row.body,
-        nextStatus,
-        finalizedAt,
-        isEdited ? 1 : 0,
-        now,
-        id,
+      const finalizedAt = !wasFinalized && nextStatus !== "draft" ? now : row.finalized_at;
+      const isEdited = row.is_edited !== 0 || (bodyChanged && wasFinalized);
+
+      const result = await this.env.DB.prepare(
+        `update definitions
+         set word_id = ?, body = ?, status = ?, finalized_at = ?, is_edited = ?, updated_at = ?
+         where id = ? and status = ? and updated_at = ?`,
       )
-      .run();
-    return this.#getDetail(uid, id);
+        .bind(
+          wordChanged ? input.wordId! : row.word_id,
+          input.body ?? row.body,
+          nextStatus,
+          finalizedAt,
+          isEdited ? 1 : 0,
+          now,
+          id,
+          row.status,
+          row.updated_at,
+        )
+        .run();
+      if (result.meta.changes > 0) return this.#getDetail(uid, id);
+    }
+    throw new ApiError(500, "definition_update_conflict", "Internal Server Error");
   }
 
   async delete(uid: string, id: string): Promise<void> {

--- a/server/src/lib/cursor.ts
+++ b/server/src/lib/cursor.ts
@@ -1,0 +1,29 @@
+import { ApiError } from "../errors";
+
+/**
+ * keyset pagination の不透明カーソル。base64url でエンコードした JSON オブジェクトを持つ。
+ * payload の形状検証（kind・version の照合）は各サービス側で行う。
+ */
+export function encodeOpaqueCursor(payload: Record<string, unknown>): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+export function decodeOpaqueCursor(value: string): Record<string, unknown> {
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("cursor payload must be a JSON object");
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+  }
+}

--- a/server/src/lib/normalize.ts
+++ b/server/src/lib/normalize.ts
@@ -1,0 +1,4 @@
+/** 前後空白の除去 + NFC 正規化。言葉の表記・よみは保存前に必ずこれを通す。 */
+export function normalizeText(value: string): string {
+  return value.trim().normalize("NFC");
+}

--- a/server/src/lib/uuidv7.ts
+++ b/server/src/lib/uuidv7.ts
@@ -1,0 +1,17 @@
+/**
+ * RFC 9562 の UUIDv7 を生成する。先頭 48 ビットが unix ミリ秒のため、
+ * 生成時刻順で文字列ソートでき、keyset pagination のタイブレーカーに使える。
+ */
+export function uuidv7(now: number = Date.now()): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  for (let index = 0; index < 6; index += 1) {
+    bytes[index] = Math.floor(now / 2 ** (8 * (5 - index))) % 256;
+  }
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x70;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/server/src/routes/definitions.ts
+++ b/server/src/routes/definitions.ts
@@ -23,7 +23,9 @@ const createDefinitionRoute = createRoute({
   },
   responses: {
     201: jsonContent(definitionResponseSchema, "作成された定義"),
-    404: errorContent("言葉が存在しない（word_not_found）"),
+    404: errorContent(
+      "言葉が存在しない（word_not_found）・未登録・削除済みユーザー（user_not_found）",
+    ),
     ...authErrorResponses,
   },
 });
@@ -87,7 +89,9 @@ const likeRoute = createRoute({
   request: { params: definitionIdParams },
   responses: {
     204: { description: "いいね完了（冪等）" },
-    404: errorContent("定義が存在しない（definition_not_found）"),
+    404: errorContent(
+      "定義が存在しない（definition_not_found）・未登録・削除済みユーザー（user_not_found）",
+    ),
     ...authErrorResponses,
   },
 });

--- a/server/src/routes/definitions.ts
+++ b/server/src/routes/definitions.ts
@@ -1,4 +1,6 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { AuthenticationVariables } from "../auth/middleware";
+import { DefinitionService } from "../definitions/definition-service";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import {
   createDefinitionRequestSchema,
@@ -6,13 +8,7 @@ import {
   updateDefinitionRequestSchema,
 } from "../schemas/definition";
 import { userListItemSchema } from "../schemas/user";
-import {
-  authErrorResponses,
-  authenticatedSecurity,
-  errorContent,
-  jsonContent,
-  notImplemented,
-} from "./helpers";
+import { authErrorResponses, authenticatedSecurity, errorContent, jsonContent } from "./helpers";
 
 const definitionIdParams = z.object({ id: z.string() });
 
@@ -123,11 +119,62 @@ const listLikedUsersRoute = createRoute({
   },
 });
 
-export const definitionRoutes = new OpenAPIHono()
-  .openapi(createDefinitionRoute, notImplemented)
-  .openapi(getDefinitionRoute, notImplemented)
-  .openapi(updateDefinitionRoute, notImplemented)
-  .openapi(deleteDefinitionRoute, notImplemented)
-  .openapi(likeRoute, notImplemented)
-  .openapi(unlikeRoute, notImplemented)
-  .openapi(listLikedUsersRoute, notImplemented);
+type DefinitionRouteEnvironment = {
+  Bindings: { AVATAR_BASE_URL: string; DB: D1Database };
+  Variables: AuthenticationVariables;
+};
+
+export const definitionRoutes = new OpenAPIHono<DefinitionRouteEnvironment>()
+  .openapi(createDefinitionRoute, async (context) => {
+    const definition = await new DefinitionService(context.env).create(
+      context.get("firebaseUid"),
+      context.req.valid("json"),
+    );
+    return context.json(definition, 201);
+  })
+  .openapi(getDefinitionRoute, async (context) => {
+    const definition = await new DefinitionService(context.env).get(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+    );
+    return context.json(definition, 200);
+  })
+  .openapi(updateDefinitionRoute, async (context) => {
+    const definition = await new DefinitionService(context.env).update(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+      context.req.valid("json"),
+    );
+    return context.json(definition, 200);
+  })
+  .openapi(deleteDefinitionRoute, async (context) => {
+    await new DefinitionService(context.env).delete(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+    );
+    return context.body(null, 204);
+  })
+  .openapi(likeRoute, async (context) => {
+    await new DefinitionService(context.env).like(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+    );
+    return context.body(null, 204);
+  })
+  .openapi(unlikeRoute, async (context) => {
+    await new DefinitionService(context.env).unlike(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+    );
+    return context.body(null, 204);
+  })
+  .openapi(listLikedUsersRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new DefinitionService(context.env).listLikedUsers(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  });

--- a/server/src/routes/words.ts
+++ b/server/src/routes/words.ts
@@ -93,7 +93,9 @@ const updateWordRoute = createRoute({
     403: errorContent(
       "修正条件を満たさない（word_not_editable: 期限超過・他ユーザー操作あり・登録者以外）",
     ),
-    404: errorContent("言葉が存在しない（word_not_found）"),
+    404: errorContent(
+      "言葉が存在しない（word_not_found）・未登録・削除済みユーザー（user_not_found）",
+    ),
     409: {
       content: { "application/json": { schema: wordConflictResponseSchema } },
       description: "修正後の表記が登録済み（word_already_exists）",
@@ -133,7 +135,9 @@ const saveWordRoute = createRoute({
   request: { params: wordIdParams },
   responses: {
     204: { description: "保存完了（冪等）" },
-    404: errorContent("言葉が存在しない（word_not_found）"),
+    404: errorContent(
+      "言葉が存在しない（word_not_found）・未登録・削除済みユーザー（user_not_found）",
+    ),
     ...authErrorResponses,
   },
 });

--- a/server/src/routes/words.ts
+++ b/server/src/routes/words.ts
@@ -32,6 +32,7 @@ const createWordRoute = createRoute({
   },
   responses: {
     201: jsonContent(wordResponseSchema, "登録された言葉"),
+    404: errorContent("未登録・削除済みユーザー（user_not_found）"),
     409: {
       content: { "application/json": { schema: wordConflictResponseSchema } },
       description: "同一表記が登録済み（word_already_exists）。既存の言葉を返す",

--- a/server/src/routes/words.ts
+++ b/server/src/routes/words.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { AuthenticationVariables } from "../auth/middleware";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { definitionResponseSchema } from "../schemas/definition";
 import {
@@ -8,6 +9,7 @@ import {
   wordListItemSchema,
   wordResponseSchema,
 } from "../schemas/word";
+import { WordConflictError, WordService } from "../words/word-service";
 import {
   authErrorResponses,
   authenticatedSecurity,
@@ -148,11 +150,74 @@ const unsaveWordRoute = createRoute({
   },
 });
 
-export const wordRoutes = new OpenAPIHono()
-  .openapi(createWordRoute, notImplemented)
-  .openapi(listWordsRoute, notImplemented)
-  .openapi(getWordRoute, notImplemented)
-  .openapi(updateWordRoute, notImplemented)
+type WordRouteEnvironment = {
+  Bindings: { DB: D1Database };
+  Variables: AuthenticationVariables;
+};
+
+/** 登録・修正時の表記重複は 409 と既存の言葉で返す（レスポンス形状が通常のエラーと異なる）。 */
+function wordConflictResponse(error: WordConflictError) {
+  return {
+    error: { code: error.code, message: error.message },
+    existingWord: error.existingWord,
+  };
+}
+
+export const wordRoutes = new OpenAPIHono<WordRouteEnvironment>()
+  .openapi(createWordRoute, async (context) => {
+    const service = new WordService(context.env);
+    try {
+      const word = await service.create(context.get("firebaseUid"), context.req.valid("json"));
+      return context.json(word, 201);
+    } catch (error) {
+      if (error instanceof WordConflictError) {
+        return context.json(wordConflictResponse(error), 409);
+      }
+      throw error;
+    }
+  })
+  .openapi(listWordsRoute, async (context) => {
+    const result = await new WordService(context.env).list(
+      context.get("firebaseUid"),
+      context.req.valid("query"),
+    );
+    return context.json(result, 200);
+  })
+  .openapi(getWordRoute, async (context) => {
+    const word = await new WordService(context.env).get(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+    );
+    return context.json(word, 200);
+  })
+  .openapi(updateWordRoute, async (context) => {
+    const service = new WordService(context.env);
+    try {
+      const word = await service.update(
+        context.get("firebaseUid"),
+        context.req.valid("param").id,
+        context.req.valid("json"),
+      );
+      return context.json(word, 200);
+    } catch (error) {
+      if (error instanceof WordConflictError) {
+        return context.json(wordConflictResponse(error), 409);
+      }
+      throw error;
+    }
+  })
   .openapi(listWordDefinitionsRoute, notImplemented)
-  .openapi(saveWordRoute, notImplemented)
-  .openapi(unsaveWordRoute, notImplemented);
+  .openapi(saveWordRoute, async (context) => {
+    await new WordService(context.env).save(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+    );
+    return context.body(null, 204);
+  })
+  .openapi(unsaveWordRoute, async (context) => {
+    await new WordService(context.env).unsave(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+    );
+    return context.body(null, 204);
+  });

--- a/server/src/words/reading-sub-group.ts
+++ b/server/src/words/reading-sub-group.ts
@@ -1,0 +1,65 @@
+// 旧 Flutter 実装（lib/util/constant/initial_main_group.dart の InitialSubGroup.fromString）と
+// 同じ分類規則。words.reading_sub_group に保存するラベルを算出する。
+
+/** 濁音・半濁音・小書き・歴史的仮名遣いを清音ラベルへ寄せる対応。清音・を・ん は自分自身。 */
+const kanaConversions: ReadonlyArray<readonly [source: string, label: string]> = [
+  [
+    "あいうえおかきくけこさしすせそたちつてとなにぬねの",
+    "あいうえおかきくけこさしすせそたちつてとなにぬねの",
+  ],
+  ["はひふへほまみむめもやゆよらりるれろわをん", "はひふへほまみむめもやゆよらりるれろわをん"],
+  ["がぎぐげご", "かきくけこ"],
+  ["ざじずぜぞ", "さしすせそ"],
+  ["だぢづでど", "たちつてと"],
+  ["ばびぶべぼ", "はひふへほ"],
+  ["ぱぴぷぺぽ", "はひふへほ"],
+  ["ぁぃぅぇぉ", "あいうえお"],
+  ["ゃゅょ", "やゆよ"],
+  ["っ", "つ"],
+  ["ゔ", "う"],
+  ["ゐゑ", "いえ"],
+  ["ゎ", "わ"],
+];
+
+const kanaToLabel = new Map<string, string>(
+  kanaConversions.flatMap(([source, label]) =>
+    Array.from(source, (kana, index) => [kana, label[index]!] as const),
+  ),
+);
+
+/** ヷヸヹヺ は単純な符号シフトで変換できないため個別対応する。 */
+const irregularKatakana = new Map<string, string>([
+  ["ヷ", "わ"],
+  ["ヸ", "ゐ"],
+  ["ヹ", "ゑ"],
+  ["ヺ", "を"],
+]);
+
+const basicSymbolPattern = /^[!#$%&()*+,\-./:;<=>?@[\\\]^_`{|}~（）「」『』ー]$/;
+
+function katakanaToHiragana(character: string): string {
+  const irregular = irregularKatakana.get(character);
+  if (irregular !== undefined) return irregular;
+  const code = character.codePointAt(0)!;
+  // ァ（U+30A1）〜ヴ（U+30F4）はひらがなと 0x60 の固定オフセット
+  if (code < 0x30a1 || code > 0x30f4) return character;
+  return String.fromCodePoint(code - 0x60);
+}
+
+/**
+ * よみの先頭文字からあかさたな行のサブグループラベルを返す。
+ * かな → 清音 1 文字、英字 → 大文字 1 文字、それ以外 → 数字 / 記号 / その他。
+ */
+export function readingSubGroup(reading: string): string {
+  const trimmed = reading.trim();
+  if (trimmed === "") return "その他";
+
+  const initial = katakanaToHiragana(String.fromCodePoint(trimmed.codePointAt(0)!));
+
+  const kanaLabel = kanaToLabel.get(initial);
+  if (kanaLabel !== undefined) return kanaLabel;
+  if (/^[a-zA-Z]$/.test(initial)) return initial.toUpperCase();
+  if (/^[0-9]$/.test(initial)) return "数字";
+  if (basicSymbolPattern.test(initial)) return "記号";
+  return "その他";
+}

--- a/server/src/words/word-service.ts
+++ b/server/src/words/word-service.ts
@@ -165,6 +165,7 @@ export class WordService {
   }
 
   async create(uid: string, input: CreateWordInput) {
+    await this.#requireActiveUser(uid);
     const word = normalizeText(input.word);
     const reading = normalizeText(input.reading);
     await this.#throwIfWordTaken(word);
@@ -191,6 +192,7 @@ export class WordService {
   }
 
   async update(uid: string, id: string, input: UpdateWordInput) {
+    await this.#requireActiveUser(uid);
     const detail = await this.#requireDetail(uid, id);
     if (!toWordResponse(detail, uid, Date.now()).isEditableByMe) {
       throw new ApiError(403, "word_not_editable", "Word not editable");

--- a/server/src/words/word-service.ts
+++ b/server/src/words/word-service.ts
@@ -80,6 +80,14 @@ function decodeWordListCursor(value: string): WordListCursor {
   return parsed as unknown as WordListCursor;
 }
 
+/** zod は空白のみの入力を通すため、正規化後の空文字はここで拒否する。 */
+function requireNonEmpty(value: string, field: string): string {
+  if (value === "") {
+    throw new ApiError(400, "invalid_request", `${field} must not be empty`);
+  }
+  return value;
+}
+
 function escapeLikePattern(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
 }
@@ -166,8 +174,8 @@ export class WordService {
 
   async create(uid: string, input: CreateWordInput) {
     await this.#requireActiveUser(uid);
-    const word = normalizeText(input.word);
-    const reading = normalizeText(input.reading);
+    const word = requireNonEmpty(normalizeText(input.word), "word");
+    const reading = requireNonEmpty(normalizeText(input.reading), "reading");
     await this.#throwIfWordTaken(word);
 
     const id = uuidv7();
@@ -198,19 +206,49 @@ export class WordService {
       throw new ApiError(403, "word_not_editable", "Word not editable");
     }
 
-    const word = input.word === undefined ? detail.word : normalizeText(input.word);
-    const reading = input.reading === undefined ? detail.reading : normalizeText(input.reading);
+    const word =
+      input.word === undefined ? detail.word : requireNonEmpty(normalizeText(input.word), "word");
+    const reading =
+      input.reading === undefined
+        ? detail.reading
+        : requireNonEmpty(normalizeText(input.reading), "reading");
     if (word !== detail.word) await this.#throwIfWordTaken(word);
 
+    const now = Date.now();
+    let result: D1Response;
     try {
-      await this.env.DB.prepare(
-        "update words set word = ?, reading = ?, reading_sub_group = ?, updated_at = ? where id = ?",
+      // 編集可否チェックと更新の間に他ユーザーの操作が入る TOCTOU を防ぐため、
+      // 可否条件を WHERE に埋め込んだ単一文で原子的に更新する
+      result = await this.env.DB.prepare(
+        `update words
+         set word = ?, reading = ?, reading_sub_group = ?, updated_at = ?
+         where id = ?
+           and created_by = ?
+           and created_at > ?
+           and not exists(select 1 from definitions d
+            where d.word_id = words.id and d.author_id <> ? and d.deleted_at is null)
+           and not exists(select 1 from saved_words s
+            where s.word_id = words.id and s.user_id <> ?)`,
       )
-        .bind(word, reading, readingSubGroup(reading), Date.now(), id)
+        .bind(
+          word,
+          reading,
+          readingSubGroup(reading),
+          now,
+          id,
+          uid,
+          now - editWindowMilliseconds,
+          uid,
+          uid,
+        )
         .run();
     } catch (error) {
+      // UNIQUE 競合（同時登録）だけを 409 に変換し、それ以外は再送出する
       if (word !== detail.word) await this.#throwIfWordTaken(word);
       throw error;
+    }
+    if (result.meta.changes === 0) {
+      throw new ApiError(403, "word_not_editable", "Word not editable");
     }
     return this.get(uid, id);
   }

--- a/server/src/words/word-service.ts
+++ b/server/src/words/word-service.ts
@@ -1,0 +1,306 @@
+import { ApiError } from "../errors";
+import { decodeOpaqueCursor, encodeOpaqueCursor } from "../lib/cursor";
+import { normalizeText } from "../lib/normalize";
+import { uuidv7 } from "../lib/uuidv7";
+import { readingSubGroup } from "./reading-sub-group";
+
+const editWindowMilliseconds = 60 * 60 * 1000;
+
+type WordBindings = {
+  DB: D1Database;
+};
+
+type WordRow = {
+  id: string;
+  word: string;
+  reading: string;
+  reading_sub_group: string;
+  created_by: string | null;
+  created_at: number;
+};
+
+type WordDetailRow = WordRow & {
+  public_definition_count: number;
+  is_saved_by_me: number;
+  has_other_user_definition: number;
+  has_other_user_save: number;
+};
+
+type WordListRow = {
+  id: string;
+  word: string;
+  reading: string;
+  reading_sub_group: string;
+  public_definition_count: number;
+};
+
+type WordListCursor = {
+  id: string;
+  kind: "words";
+  reading: string;
+  version: 1;
+};
+
+export type CreateWordInput = {
+  reading: string;
+  word: string;
+};
+
+export type UpdateWordInput = {
+  reading?: string | undefined;
+  word?: string | undefined;
+};
+
+export type ListWordsInput = {
+  cursor?: string | undefined;
+  filter: "all" | "defined" | "undefined";
+  limit: number;
+  q?: string | undefined;
+  subGroup?: string | undefined;
+};
+
+/** 登録時に同一表記が存在した場合の 409。既存の言葉を添えて返す。 */
+export class WordConflictError extends ApiError {
+  constructor(readonly existingWord: { id: string; word: string; reading: string }) {
+    super(409, "word_already_exists", "Word already exists");
+  }
+}
+
+function decodeWordListCursor(value: string): WordListCursor {
+  const parsed = decodeOpaqueCursor(value);
+  if (
+    parsed["version"] !== 1 ||
+    parsed["kind"] !== "words" ||
+    typeof parsed["reading"] !== "string" ||
+    typeof parsed["id"] !== "string" ||
+    parsed["id"].length === 0
+  ) {
+    throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+  }
+  return parsed as unknown as WordListCursor;
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+function toWordResponse(row: WordDetailRow, uid: string, now: number) {
+  return {
+    id: row.id,
+    isEditableByMe:
+      row.created_by === uid &&
+      now - row.created_at < editWindowMilliseconds &&
+      row.has_other_user_definition === 0 &&
+      row.has_other_user_save === 0,
+    isSavedByMe: row.is_saved_by_me !== 0,
+    publicDefinitionCount: row.public_definition_count,
+    reading: row.reading,
+    readingSubGroup: row.reading_sub_group,
+    word: row.word,
+  };
+}
+
+/**
+ * D1 上の言葉の登録・一覧・取得・期限付き修正・保存を扱う。
+ *
+ * @doc doc/specs/workers-api-server.md#言葉
+ */
+export class WordService {
+  constructor(private readonly env: WordBindings) {}
+
+  async #findByWord(word: string): Promise<WordRow | null> {
+    return this.env.DB.prepare(
+      "select id, word, reading, reading_sub_group, created_by, created_at from words where word = ?",
+    )
+      .bind(word)
+      .first<WordRow>();
+  }
+
+  async #requireDetail(uid: string, id: string): Promise<WordDetailRow> {
+    const row = await this.env.DB.prepare(
+      `select
+         w.id,
+         w.word,
+         w.reading,
+         w.reading_sub_group,
+         w.created_by,
+         w.created_at,
+         (select count(*) from definitions d
+          where d.word_id = w.id and d.status = 'public' and d.deleted_at is null)
+           as public_definition_count,
+         exists(select 1 from saved_words s
+          where s.word_id = w.id and s.user_id = ?) as is_saved_by_me,
+         exists(select 1 from definitions d
+          where d.word_id = w.id and d.author_id <> ? and d.deleted_at is null)
+           as has_other_user_definition,
+         exists(select 1 from saved_words s
+          where s.word_id = w.id and s.user_id <> ?) as has_other_user_save
+       from words w
+       where w.id = ?`,
+    )
+      .bind(uid, uid, uid, id)
+      .first<WordDetailRow>();
+    if (row === null) throw new ApiError(404, "word_not_found", "Word not found");
+    return row;
+  }
+
+  async #requireActiveUser(uid: string): Promise<void> {
+    const user = await this.env.DB.prepare(
+      "select id from users where id = ? and deleted_at is null",
+    )
+      .bind(uid)
+      .first();
+    if (user === null) throw new ApiError(404, "user_not_found", "User not found");
+  }
+
+  async #throwIfWordTaken(word: string): Promise<void> {
+    const existing = await this.#findByWord(word);
+    if (existing !== null) {
+      throw new WordConflictError({
+        id: existing.id,
+        reading: existing.reading,
+        word: existing.word,
+      });
+    }
+  }
+
+  async create(uid: string, input: CreateWordInput) {
+    const word = normalizeText(input.word);
+    const reading = normalizeText(input.reading);
+    await this.#throwIfWordTaken(word);
+
+    const id = uuidv7();
+    const now = Date.now();
+    try {
+      await this.env.DB.prepare(
+        `insert into words (id, word, reading, reading_sub_group, created_by, created_at, updated_at)
+         values (?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(id, word, reading, readingSubGroup(reading), uid, now, now)
+        .run();
+    } catch (error) {
+      // UNIQUE 競合（同時登録）だけを 409 に変換し、それ以外は再送出する
+      await this.#throwIfWordTaken(word);
+      throw error;
+    }
+    return this.get(uid, id);
+  }
+
+  async get(uid: string, id: string) {
+    return toWordResponse(await this.#requireDetail(uid, id), uid, Date.now());
+  }
+
+  async update(uid: string, id: string, input: UpdateWordInput) {
+    const detail = await this.#requireDetail(uid, id);
+    if (!toWordResponse(detail, uid, Date.now()).isEditableByMe) {
+      throw new ApiError(403, "word_not_editable", "Word not editable");
+    }
+
+    const word = input.word === undefined ? detail.word : normalizeText(input.word);
+    const reading = input.reading === undefined ? detail.reading : normalizeText(input.reading);
+    if (word !== detail.word) await this.#throwIfWordTaken(word);
+
+    try {
+      await this.env.DB.prepare(
+        "update words set word = ?, reading = ?, reading_sub_group = ?, updated_at = ? where id = ?",
+      )
+        .bind(word, reading, readingSubGroup(reading), Date.now(), id)
+        .run();
+    } catch (error) {
+      if (word !== detail.word) await this.#throwIfWordTaken(word);
+      throw error;
+    }
+    return this.get(uid, id);
+  }
+
+  async list(uid: string, input: ListWordsInput) {
+    const cursor = input.cursor === undefined ? null : decodeWordListCursor(input.cursor);
+    const conditions: string[] = [];
+    const parameters: unknown[] = [];
+
+    if (input.subGroup !== undefined) {
+      conditions.push("w.reading_sub_group = ?");
+      parameters.push(input.subGroup);
+    }
+    if (input.q !== undefined && input.q !== "") {
+      const pattern = `%${escapeLikePattern(input.q)}%`;
+      conditions.push("(w.word like ? escape '\\' or w.reading like ? escape '\\')");
+      parameters.push(pattern, pattern);
+    }
+    if (input.filter === "defined") {
+      conditions.push(
+        "exists(select 1 from definitions d where d.word_id = w.id and d.status = 'public' and d.deleted_at is null)",
+      );
+    }
+    if (input.filter === "undefined") {
+      conditions.push(
+        "not exists(select 1 from definitions d where d.word_id = w.id and d.status = 'public' and d.deleted_at is null)",
+      );
+    }
+    if (cursor !== null) {
+      conditions.push("(w.reading > ? or (w.reading = ? and w.id > ?))");
+      parameters.push(cursor.reading, cursor.reading, cursor.id);
+    }
+
+    const whereClause = conditions.length === 0 ? "" : `where ${conditions.join(" and ")}`;
+    const rows = (
+      await this.env.DB.prepare(
+        `select
+           w.id,
+           w.word,
+           w.reading,
+           w.reading_sub_group,
+           (select count(*) from definitions d
+            where d.word_id = w.id and d.status = 'public' and d.deleted_at is null)
+             as public_definition_count
+         from words w
+         ${whereClause}
+         order by w.reading asc, w.id asc
+         limit ?`,
+      )
+        .bind(...parameters, input.limit + 1)
+        .all<WordListRow>()
+    ).results;
+
+    const hasNextPage = rows.length > input.limit;
+    const pageRows = rows.slice(0, input.limit);
+    const last = pageRows.at(-1);
+    return {
+      items: pageRows.map((row) => ({
+        id: row.id,
+        publicDefinitionCount: row.public_definition_count,
+        reading: row.reading,
+        readingSubGroup: row.reading_sub_group,
+        word: row.word,
+      })),
+      nextCursor:
+        hasNextPage && last !== undefined
+          ? encodeOpaqueCursor({
+              id: last.id,
+              kind: "words",
+              reading: last.reading,
+              version: 1,
+            } satisfies WordListCursor)
+          : null,
+    };
+  }
+
+  async save(uid: string, wordId: string): Promise<void> {
+    await this.#requireActiveUser(uid);
+    const word = await this.env.DB.prepare("select id from words where id = ?")
+      .bind(wordId)
+      .first();
+    if (word === null) throw new ApiError(404, "word_not_found", "Word not found");
+    await this.env.DB.prepare(
+      "insert or ignore into saved_words (user_id, word_id, created_at) values (?, ?, ?)",
+    )
+      .bind(uid, wordId, Date.now())
+      .run();
+  }
+
+  async unsave(uid: string, wordId: string): Promise<void> {
+    await this.env.DB.prepare("delete from saved_words where user_id = ? and word_id = ?")
+      .bind(uid, wordId)
+      .run();
+  }
+}

--- a/server/test/app-auth.test.ts
+++ b/server/test/app-auth.test.ts
@@ -47,7 +47,8 @@ describe("createApp", () => {
   });
 
   test("両トークンの検証後に認証必須ルートへ到達する", async () => {
-    const response = await testApp().request("/v1/words", {
+    // #193 実装までは未実装（501）の /v1/me/mutes で到達確認する
+    const response = await testApp().request("/v1/me/mutes", {
       headers: {
         Authorization: "Bearer valid-id-token",
         "X-Firebase-AppCheck": "valid-app-check",

--- a/server/test/lib/cursor.test.ts
+++ b/server/test/lib/cursor.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { ApiError } from "../../src/errors";
+import { decodeOpaqueCursor, encodeOpaqueCursor } from "../../src/lib/cursor";
+
+describe("opaque cursor", () => {
+  test("payload を不透明文字列にして復元できる", () => {
+    const payload = { id: "0189-abc", kind: "words", reading: "あんこ", version: 1 };
+
+    const encoded = encodeOpaqueCursor(payload);
+
+    expect(decodeOpaqueCursor(encoded)).toEqual(payload);
+  });
+
+  test("URL セーフな文字だけを使う", () => {
+    const encoded = encodeOpaqueCursor({ kind: "words", reading: "ぱんだ?/+", version: 1 });
+
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("base64url として不正な値は 400 invalid_cursor", () => {
+    expect(() => decodeOpaqueCursor("!!not-base64!!")).toThrow(ApiError);
+    try {
+      decodeOpaqueCursor("!!not-base64!!");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "invalid_cursor", status: 400 });
+    }
+  });
+
+  test("JSON オブジェクト以外を含む値は 400 invalid_cursor", () => {
+    const notAnObject = btoa(JSON.stringify("plain string"))
+      .replaceAll("+", "-")
+      .replaceAll("/", "_")
+      .replace(/=+$/, "");
+
+    expect(() => decodeOpaqueCursor(notAnObject)).toThrow(ApiError);
+  });
+});

--- a/server/test/lib/uuidv7.test.ts
+++ b/server/test/lib/uuidv7.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { uuidv7 } from "../../src/lib/uuidv7";
+
+describe("uuidv7", () => {
+  test("RFC 9562 の UUIDv7 形式（version 7・variant 10）で生成する", () => {
+    const value = uuidv7();
+
+    expect(value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  test("先頭 48 ビットに unix ミリ秒タイムスタンプを埋め込む", () => {
+    const timestamp = 0x0189_6544_3210;
+
+    const value = uuidv7(timestamp);
+
+    expect(value.slice(0, 8) + value.slice(9, 13)).toBe("018965443210");
+  });
+
+  test("同一タイムスタンプでも呼び出しごとに異なる値を生成する", () => {
+    const timestamp = Date.now();
+    const values = new Set(Array.from({ length: 1000 }, () => uuidv7(timestamp)));
+
+    expect(values.size).toBe(1000);
+  });
+
+  test("タイムスタンプが進むと文字列順も進む", () => {
+    const earlier = uuidv7(1000);
+    const later = uuidv7(2000);
+
+    expect(earlier < later).toBe(true);
+  });
+});

--- a/server/test/words/reading-sub-group.test.ts
+++ b/server/test/words/reading-sub-group.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeText } from "../../src/lib/normalize";
+import { readingSubGroup } from "../../src/words/reading-sub-group";
+
+// U+3099 は結合用濁点。「か」+ U+3099 は NFC で「が」に合成される。
+const combiningVoicedMark = String.fromCharCode(0x3099);
+
+describe("normalizeText", () => {
+  test("前後の空白を除去する", () => {
+    expect(normalizeText("  こんにちは \n")).toBe("こんにちは");
+  });
+
+  test("結合文字を NFC で合成する", () => {
+    const decomposed = `か${combiningVoicedMark}らす`;
+    expect(decomposed).toHaveLength(4);
+
+    const normalized = normalizeText(decomposed);
+
+    expect(normalized).toBe("がらす");
+    expect(normalized).toHaveLength(3);
+  });
+
+  test("合成済みの文字列はそのまま返す", () => {
+    expect(normalizeText("がらす")).toBe("がらす");
+  });
+});
+
+describe("readingSubGroup", () => {
+  test("ひらがな清音は先頭文字をそのまま返す", () => {
+    expect(readingSubGroup("あんこ")).toBe("あ");
+    expect(readingSubGroup("ん")).toBe("ん");
+    expect(readingSubGroup("をとめ")).toBe("を");
+  });
+
+  test("濁音・半濁音は清音の行に寄せる", () => {
+    expect(readingSubGroup("がっこう")).toBe("か");
+    expect(readingSubGroup("ずかん")).toBe("す");
+    expect(readingSubGroup("ぱんだ")).toBe("は");
+    expect(readingSubGroup("ゔぁいおりん")).toBe("う");
+  });
+
+  test("小書き・歴史的仮名遣いは対応する清音に寄せる", () => {
+    expect(readingSubGroup("ゃくざいし")).toBe("や");
+    expect(readingSubGroup("っち")).toBe("つ");
+    expect(readingSubGroup("ゐど")).toBe("い");
+    expect(readingSubGroup("ゑびす")).toBe("え");
+    expect(readingSubGroup("ゎっふる")).toBe("わ");
+  });
+
+  test("カタカナはひらがなに変換して判定する", () => {
+    expect(readingSubGroup("アイス")).toBe("あ");
+    expect(readingSubGroup("ガム")).toBe("か");
+    expect(readingSubGroup("ヴィンテージ")).toBe("う");
+    expect(readingSubGroup("ヷルツ")).toBe("わ");
+    expect(readingSubGroup("ヺング")).toBe("を");
+  });
+
+  test("アルファベットは大文字 1 文字を返す", () => {
+    expect(readingSubGroup("apple")).toBe("A");
+    expect(readingSubGroup("Zebra")).toBe("Z");
+  });
+
+  test("数字・記号・その他を分類する", () => {
+    expect(readingSubGroup("123ごう")).toBe("数字");
+    expect(readingSubGroup("ーめん")).toBe("記号");
+    expect(readingSubGroup("「かっこ」")).toBe("記号");
+    expect(readingSubGroup("")).toBe("その他");
+    expect(readingSubGroup("   ")).toBe("その他");
+  });
+});

--- a/server/worker-test/definitions.workers.ts
+++ b/server/worker-test/definitions.workers.ts
@@ -311,6 +311,57 @@ describe("PATCH /v1/definitions/{id}", () => {
     expect(response.status).toBe(200);
   });
 
+  test("並行する確定処理と競合しても draft へ巻き戻らない", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const draft = await createDefinition("alice", word.id, "draft");
+    // 本文編集 PATCH の読み取りと UPDATE の間に、別リクエストによる確定（draft→public）を割り込ませる
+    let intercepted = false;
+    const racingDatabase = {
+      prepare(query: string) {
+        const statement = env.DB.prepare(query);
+        if (!query.trimStart().startsWith("update definitions") || intercepted) return statement;
+        intercepted = true;
+        return {
+          bind: (...values: unknown[]) => {
+            const bound = statement.bind(...values);
+            return {
+              run: async () => {
+                const now = Date.now();
+                await env.DB.prepare(
+                  "update definitions set status = 'public', finalized_at = ?, updated_at = ? where id = ?",
+                )
+                  .bind(now, now + 1, draft.id)
+                  .run();
+                return bound.run();
+              },
+            };
+          },
+        } as unknown as D1PreparedStatement;
+      },
+    } as unknown as D1Database;
+
+    const response = await testApp("alice").request(
+      `/v1/definitions/${draft.id}`,
+      {
+        body: JSON.stringify({ body: "競合する本文編集" }),
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        method: "PATCH",
+      },
+      { ...env, DB: racingDatabase },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json<DefinitionResponse>();
+    expect(body.status).toBe("public");
+    expect(body.finalizedAt).not.toBeNull();
+    const row = await env.DB.prepare("select status, finalized_at from definitions where id = ?")
+      .bind(draft.id)
+      .first<{ status: string; finalized_at: number | null }>();
+    expect(row!.status).toBe("public");
+    expect(row!.finalized_at).not.toBeNull();
+  });
+
   test("他者の public 定義の編集は 403 forbidden", async () => {
     await createUser("alice");
     await createUser("bob");

--- a/server/worker-test/definitions.workers.ts
+++ b/server/worker-test/definitions.workers.ts
@@ -460,6 +460,51 @@ describe("PUT / DELETE /v1/definitions/{id}/like", () => {
     await expect(unliked.json()).resolves.toMatchObject({ isLikedByMe: false, likesCount: 0 });
   });
 
+  test("可視性チェック後に削除された定義にはいいね行を残さない", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+    // 可視性チェックと INSERT の間に定義の論理削除を割り込ませ、TOCTOU を再現する
+    let intercepted = false;
+    const racingDatabase = {
+      prepare(query: string) {
+        const statement = env.DB.prepare(query);
+        if (!query.trimStart().startsWith("insert or ignore into likes") || intercepted) {
+          return statement;
+        }
+        intercepted = true;
+        return {
+          bind: (...values: unknown[]) => {
+            const bound = statement.bind(...values);
+            return {
+              run: async () => {
+                const now = Date.now();
+                await env.DB.prepare(
+                  "update definitions set deleted_at = ?, updated_at = ? where id = ?",
+                )
+                  .bind(now, now, definition.id)
+                  .run();
+                return bound.run();
+              },
+            };
+          },
+        } as unknown as D1PreparedStatement;
+      },
+    } as unknown as D1Database;
+
+    await testApp("bob").request(
+      `/v1/definitions/${definition.id}/like`,
+      { headers: authHeaders, method: "PUT" },
+      { ...env, DB: racingDatabase },
+    );
+
+    const row = await env.DB.prepare("select count(*) as count from likes where definition_id = ?")
+      .bind(definition.id)
+      .first<{ count: number }>();
+    expect(row!.count).toBe(0);
+  });
+
   test("自分の draft にもいいねできる", async () => {
     await createUser("alice");
     const word = await createWord("alice", "ことば", "ことば");

--- a/server/worker-test/definitions.workers.ts
+++ b/server/worker-test/definitions.workers.ts
@@ -1,0 +1,489 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createApp } from "../src/app";
+
+const authHeaders = {
+  Authorization: "Bearer valid-id-token",
+  "X-Firebase-AppCheck": "valid-app-check",
+};
+
+const editWindowMilliseconds = 60 * 60 * 1000;
+
+type DefinitionResponse = {
+  id: string;
+  word: { id: string; word: string; reading: string };
+  author: { id: string; publicId: string; name: string; avatarUrl: string | null };
+  body: string;
+  status: "draft" | "public" | "private";
+  isEdited: boolean;
+  likesCount: number;
+  isLikedByMe: boolean;
+  finalizedAt: string | null;
+  editableUntil: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function testApp(uid: string) {
+  return createApp({
+    logRequest: () => {},
+    verifyAppCheck: async () => ({ appId: "test-app-id" }),
+    verifyFirebaseIdToken: async () => ({ uid }),
+  });
+}
+
+async function request(uid: string, path: string, init?: RequestInit) {
+  const headers = new Headers(authHeaders);
+  for (const [key, value] of new Headers(init?.headers)) headers.set(key, value);
+  return testApp(uid).request(path, { ...init, headers }, env);
+}
+
+async function requestJson(uid: string, path: string, method: string, body: unknown) {
+  return request(uid, path, {
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    method,
+  });
+}
+
+async function createUser(uid: string) {
+  const response = await requestJson(uid, "/v1/users", "POST", {
+    appVersion: "2.0.0",
+    bio: "",
+    name: uid,
+    osVersion: "iOS 19",
+  });
+  expect(response.status).toBe(201);
+}
+
+async function createWord(uid: string, word: string, reading: string) {
+  const response = await requestJson(uid, "/v1/words", "POST", { reading, word });
+  expect(response.status).toBe(201);
+  return response.json<{ id: string }>();
+}
+
+async function createDefinition(
+  uid: string,
+  wordId: string,
+  status: "draft" | "public" | "private",
+  body = "定義本文",
+) {
+  const response = await requestJson(uid, "/v1/definitions", "POST", { body, status, wordId });
+  expect(response.status).toBe(201);
+  return response.json<DefinitionResponse>();
+}
+
+async function ageFinalizedAt(definitionId: string, milliseconds: number) {
+  await env.DB.prepare("update definitions set finalized_at = finalized_at - ? where id = ?")
+    .bind(milliseconds, definitionId)
+    .run();
+}
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  await env.DB.batch([
+    env.DB.prepare("delete from users"),
+    env.DB.prepare("delete from words"),
+    env.DB.prepare("delete from app_config"),
+  ]);
+});
+
+describe("POST /v1/definitions", () => {
+  test("draft は finalizedAt / editableUntil なしで作成される", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+
+    const definition = await createDefinition("alice", word.id, "draft");
+
+    expect(definition).toMatchObject({
+      body: "定義本文",
+      editableUntil: null,
+      finalizedAt: null,
+      isEdited: false,
+      isLikedByMe: false,
+      likesCount: 0,
+      status: "draft",
+      word: { id: word.id, word: "ことば" },
+    });
+    expect(definition.author).toMatchObject({ id: "alice", name: "alice" });
+  });
+
+  test("public は finalizedAt と 1 時間後の editableUntil を持つ", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+
+    const definition = await createDefinition("alice", word.id, "public");
+
+    expect(definition.finalizedAt).not.toBeNull();
+    expect(definition.editableUntil).not.toBeNull();
+    expect(Date.parse(definition.editableUntil!) - Date.parse(definition.finalizedAt!)).toBe(
+      editWindowMilliseconds,
+    );
+  });
+
+  test("存在しない言葉への定義は 404 word_not_found", async () => {
+    await createUser("alice");
+
+    const response = await requestJson("alice", "/v1/definitions", "POST", {
+      body: "本文",
+      status: "draft",
+      wordId: "missing-word",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_not_found" },
+    });
+  });
+});
+
+describe("GET /v1/definitions/{id}", () => {
+  test("本人は draft / private を取得でき、他者の public も取得できる", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const draft = await createDefinition("alice", word.id, "draft");
+    const publicDefinition = await createDefinition("alice", word.id, "public");
+
+    const ownDraft = await request("alice", `/v1/definitions/${draft.id}`);
+    const othersPublic = await request("bob", `/v1/definitions/${publicDefinition.id}`);
+
+    expect(ownDraft.status).toBe(200);
+    expect(othersPublic.status).toBe(200);
+  });
+
+  test("他者の draft / private は 404 で存在を秘匿する", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const draft = await createDefinition("alice", word.id, "draft");
+    const privateDefinition = await createDefinition("alice", word.id, "private");
+
+    const draftResponse = await request("bob", `/v1/definitions/${draft.id}`);
+    const privateResponse = await request("bob", `/v1/definitions/${privateDefinition.id}`);
+
+    expect(draftResponse.status).toBe(404);
+    expect(privateResponse.status).toBe(404);
+    await expect(draftResponse.json()).resolves.toMatchObject({
+      error: { code: "definition_not_found" },
+    });
+  });
+
+  test("削除済みの定義は本人にも 404", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+    await request("alice", `/v1/definitions/${definition.id}`, { method: "DELETE" });
+
+    const response = await request("alice", `/v1/definitions/${definition.id}`);
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("PATCH /v1/definitions/{id}", () => {
+  test("draft から public へ確定すると finalizedAt が設定され isEdited は立たない", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const draft = await createDefinition("alice", word.id, "draft");
+
+    const response = await requestJson("alice", `/v1/definitions/${draft.id}`, "PATCH", {
+      body: "推敲した本文",
+      status: "public",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json<DefinitionResponse>();
+    expect(body).toMatchObject({ body: "推敲した本文", isEdited: false, status: "public" });
+    expect(body.finalizedAt).not.toBeNull();
+  });
+
+  test("下書き中は言葉を変更できる", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const anotherWord = await createWord("alice", "いみ", "いみ");
+    const draft = await createDefinition("alice", word.id, "draft");
+
+    const response = await requestJson("alice", `/v1/definitions/${draft.id}`, "PATCH", {
+      wordId: anotherWord.id,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      word: { id: anotherWord.id, word: "いみ" },
+    });
+  });
+
+  test("確定後の言葉変更は 400 invalid_transition", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const anotherWord = await createWord("alice", "いみ", "いみ");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const response = await requestJson("alice", `/v1/definitions/${definition.id}`, "PATCH", {
+      wordId: anotherWord.id,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "invalid_transition" },
+    });
+  });
+
+  test("public と private は相互に切り替えられ finalizedAt は変わらない", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const toPrivate = await requestJson("alice", `/v1/definitions/${definition.id}`, "PATCH", {
+      status: "private",
+    });
+    const toPublic = await requestJson("alice", `/v1/definitions/${definition.id}`, "PATCH", {
+      status: "public",
+    });
+
+    const privateBody = await toPrivate.json<DefinitionResponse>();
+    const publicBody = await toPublic.json<DefinitionResponse>();
+    expect(privateBody.status).toBe("private");
+    expect(privateBody.finalizedAt).toBe(definition.finalizedAt);
+    expect(publicBody.status).toBe("public");
+    expect(publicBody.finalizedAt).toBe(definition.finalizedAt);
+  });
+
+  test("確定後に draft へ戻すのは 400 invalid_transition", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const response = await requestJson("alice", `/v1/definitions/${definition.id}`, "PATCH", {
+      status: "draft",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "invalid_transition" },
+    });
+  });
+
+  test("確定後 1 時間以内の本文編集は isEdited を立てる", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const response = await requestJson("alice", `/v1/definitions/${definition.id}`, "PATCH", {
+      body: "編集後の本文",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      body: "編集後の本文",
+      isEdited: true,
+    });
+  });
+
+  test("確定後 1 時間を超えた本文編集は 403 edit_window_expired", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+    await ageFinalizedAt(definition.id, editWindowMilliseconds + 1000);
+
+    const response = await requestJson("alice", `/v1/definitions/${definition.id}`, "PATCH", {
+      body: "遅すぎる編集",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "edit_window_expired" },
+    });
+  });
+
+  test("確定後 1 時間を超えても公開範囲は切り替えられる", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+    await ageFinalizedAt(definition.id, editWindowMilliseconds + 1000);
+
+    const response = await requestJson("alice", `/v1/definitions/${definition.id}`, "PATCH", {
+      status: "private",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("他者の public 定義の編集は 403 forbidden", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const response = await requestJson("bob", `/v1/definitions/${definition.id}`, "PATCH", {
+      body: "改ざん",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "forbidden" },
+    });
+  });
+
+  test("他者の private 定義の編集は 404 で存在を秘匿する", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "private");
+
+    const response = await requestJson("bob", `/v1/definitions/${definition.id}`, "PATCH", {
+      body: "改ざん",
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("DELETE /v1/definitions/{id}", () => {
+  test("本人は削除でき、以後 404 になる", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const deleteResponse = await request("alice", `/v1/definitions/${definition.id}`, {
+      method: "DELETE",
+    });
+
+    expect(deleteResponse.status).toBe(204);
+    const getResponse = await request("alice", `/v1/definitions/${definition.id}`);
+    expect(getResponse.status).toBe(404);
+  });
+
+  test("他者の public 定義の削除は 403 forbidden", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const response = await request("bob", `/v1/definitions/${definition.id}`, {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  test("他者の draft 定義の削除は 404 で存在を秘匿する", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "draft");
+
+    const response = await request("bob", `/v1/definitions/${definition.id}`, {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("PUT / DELETE /v1/definitions/{id}/like", () => {
+  test("他者の public 定義へのいいねは冪等で、件数と isLikedByMe に反映される", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+
+    const like1 = await request("bob", `/v1/definitions/${definition.id}/like`, { method: "PUT" });
+    const like2 = await request("bob", `/v1/definitions/${definition.id}/like`, { method: "PUT" });
+    expect(like1.status).toBe(204);
+    expect(like2.status).toBe(204);
+    const liked = await request("bob", `/v1/definitions/${definition.id}`);
+    await expect(liked.json()).resolves.toMatchObject({ isLikedByMe: true, likesCount: 1 });
+
+    const unlike1 = await request("bob", `/v1/definitions/${definition.id}/like`, {
+      method: "DELETE",
+    });
+    const unlike2 = await request("bob", `/v1/definitions/${definition.id}/like`, {
+      method: "DELETE",
+    });
+    expect(unlike1.status).toBe(204);
+    expect(unlike2.status).toBe(204);
+    const unliked = await request("bob", `/v1/definitions/${definition.id}`);
+    await expect(unliked.json()).resolves.toMatchObject({ isLikedByMe: false, likesCount: 0 });
+  });
+
+  test("自分の draft にもいいねできる", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    const draft = await createDefinition("alice", word.id, "draft");
+
+    const response = await request("alice", `/v1/definitions/${draft.id}/like`, { method: "PUT" });
+
+    expect(response.status).toBe(204);
+  });
+
+  test("他者の draft / private へのいいねは 404 で存在を秘匿する", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const draft = await createDefinition("alice", word.id, "draft");
+    const privateDefinition = await createDefinition("alice", word.id, "private");
+
+    const draftLike = await request("bob", `/v1/definitions/${draft.id}/like`, { method: "PUT" });
+    const privateLike = await request("bob", `/v1/definitions/${privateDefinition.id}/like`, {
+      method: "PUT",
+    });
+
+    expect(draftLike.status).toBe(404);
+    expect(privateLike.status).toBe(404);
+  });
+});
+
+describe("GET /v1/definitions/{id}/likes", () => {
+  test("いいね日時の降順で keyset pagination できる", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    await createUser("carol");
+    await createUser("dave");
+    const word = await createWord("alice", "ことば", "ことば");
+    const definition = await createDefinition("alice", word.id, "public");
+    for (const [index, uid] of ["bob", "carol", "dave"].entries()) {
+      await request(uid, `/v1/definitions/${definition.id}/like`, { method: "PUT" });
+      // created_at をずらして並び順を確定させる
+      await env.DB.prepare(
+        "update likes set created_at = ? where user_id = ? and definition_id = ?",
+      )
+        .bind(1000 * (index + 1), uid, definition.id)
+        .run();
+    }
+
+    const firstPage = await request("alice", `/v1/definitions/${definition.id}/likes?limit=2`);
+    expect(firstPage.status).toBe(200);
+    const firstBody = await firstPage.json<{
+      items: Array<{ id: string }>;
+      nextCursor: string | null;
+    }>();
+    expect(firstBody.items.map((item) => item.id)).toEqual(["dave", "carol"]);
+    expect(firstBody.nextCursor).not.toBeNull();
+
+    const secondPage = await request(
+      "alice",
+      `/v1/definitions/${definition.id}/likes?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor!)}`,
+    );
+    const secondBody = await secondPage.json<{
+      items: Array<{ id: string; isFollowedByMe: boolean; isMutedByMe: boolean }>;
+      nextCursor: string | null;
+    }>();
+    expect(secondBody.items.map((item) => item.id)).toEqual(["bob"]);
+    expect(secondBody.items[0]).toMatchObject({ isFollowedByMe: false, isMutedByMe: false });
+    expect(secondBody.nextCursor).toBeNull();
+  });
+
+  test("他者の private 定義のいいね一覧は 404 で存在を秘匿する", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    const privateDefinition = await createDefinition("alice", word.id, "private");
+
+    const response = await request("bob", `/v1/definitions/${privateDefinition.id}/likes`);
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/server/worker-test/words.workers.ts
+++ b/server/worker-test/words.workers.ts
@@ -1,0 +1,404 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createApp } from "../src/app";
+
+const authHeaders = {
+  Authorization: "Bearer valid-id-token",
+  "X-Firebase-AppCheck": "valid-app-check",
+};
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function testApp(uid: string) {
+  return createApp({
+    logRequest: () => {},
+    verifyAppCheck: async () => ({ appId: "test-app-id" }),
+    verifyFirebaseIdToken: async () => ({ uid }),
+  });
+}
+
+async function request(uid: string, path: string, init?: RequestInit) {
+  const headers = new Headers(authHeaders);
+  for (const [key, value] of new Headers(init?.headers)) headers.set(key, value);
+  return testApp(uid).request(path, { ...init, headers }, env);
+}
+
+async function requestJson(uid: string, path: string, method: string, body: unknown) {
+  return request(uid, path, {
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    method,
+  });
+}
+
+async function createUser(uid: string) {
+  const response = await requestJson(uid, "/v1/users", "POST", {
+    appVersion: "2.0.0",
+    bio: "",
+    name: uid,
+    osVersion: "iOS 19",
+  });
+  expect(response.status).toBe(201);
+}
+
+async function createWord(uid: string, word: string, reading: string) {
+  const response = await requestJson(uid, "/v1/words", "POST", { reading, word });
+  expect(response.status).toBe(201);
+  return response.json<{ id: string; word: string; reading: string }>();
+}
+
+async function insertWordRow(options: {
+  id: string;
+  word: string;
+  reading: string;
+  readingSubGroup: string;
+  createdBy: string;
+  createdAt: number;
+}) {
+  await env.DB.prepare(
+    `insert into words (id, word, reading, reading_sub_group, created_by, created_at, updated_at)
+     values (?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      options.id,
+      options.word,
+      options.reading,
+      options.readingSubGroup,
+      options.createdBy,
+      options.createdAt,
+      options.createdAt,
+    )
+    .run();
+}
+
+async function insertPublicDefinitionRow(id: string, wordId: string, authorId: string) {
+  const now = Date.now();
+  await env.DB.prepare(
+    `insert into definitions (id, word_id, author_id, body, status, finalized_at, is_edited, created_at, updated_at)
+     values (?, ?, ?, ?, 'public', ?, 0, ?, ?)`,
+  )
+    .bind(id, wordId, authorId, `${id} body`, now, now, now)
+    .run();
+}
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  // users の削除で definitions / saved_words / likes は CASCADE、words.created_by は SET NULL になる
+  await env.DB.batch([
+    env.DB.prepare("delete from users"),
+    env.DB.prepare("delete from words"),
+    env.DB.prepare("delete from app_config"),
+  ]);
+});
+
+describe("POST /v1/words", () => {
+  test("表記とよみを正規化して保存し、UUIDv7 の ID と読みグループを返す", async () => {
+    await createUser("alice");
+    const decomposedGa = `か${String.fromCharCode(0x3099)}`;
+
+    const response = await requestJson("alice", "/v1/words", "POST", {
+      reading: " ガラス ",
+      word: ` ${decomposedGa}らす `,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json<{
+      id: string;
+      word: string;
+      reading: string;
+      readingSubGroup: string;
+      publicDefinitionCount: number;
+      isSavedByMe: boolean;
+      isEditableByMe: boolean;
+    }>();
+    expect(body).toMatchObject({
+      isEditableByMe: true,
+      isSavedByMe: false,
+      publicDefinitionCount: 0,
+      reading: "ガラス",
+      readingSubGroup: "か",
+      word: "がらす",
+    });
+    expect(body.id).toMatch(uuidPattern);
+  });
+
+  test("正規化後に同一表記が存在する場合は 409 で既存の言葉を返す", async () => {
+    await createUser("alice");
+    const first = await createWord("alice", "りんご", "りんご");
+
+    const response = await requestJson("alice", "/v1/words", "POST", {
+      reading: "りんご",
+      word: "  りんご ",
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_already_exists" },
+      existingWord: { id: first.id, reading: "りんご", word: "りんご" },
+    });
+  });
+});
+
+describe("GET /v1/words/{id}", () => {
+  test("存在しない言葉は 404 word_not_found", async () => {
+    await createUser("alice");
+
+    const response = await request("alice", "/v1/words/missing-id");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_not_found" },
+    });
+  });
+
+  test("登録直後は登録者だけが編集可能と判定される", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+
+    const forCreator = await request("alice", `/v1/words/${word.id}`);
+    const forOther = await request("bob", `/v1/words/${word.id}`);
+
+    await expect(forCreator.json()).resolves.toMatchObject({ isEditableByMe: true });
+    await expect(forOther.json()).resolves.toMatchObject({ isEditableByMe: false });
+  });
+});
+
+describe("PATCH /v1/words/{id}", () => {
+  test("登録者は 1 時間以内なら表記とよみを修正でき、読みグループを再計算する", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "あんず", "あんず");
+
+    const response = await requestJson("alice", `/v1/words/${word.id}`, "PATCH", {
+      reading: "ガム",
+      word: "がむ",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      id: word.id,
+      reading: "ガム",
+      readingSubGroup: "か",
+      word: "がむ",
+    });
+  });
+
+  test("登録者以外の修正は 403 word_not_editable", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+
+    const response = await requestJson("bob", `/v1/words/${word.id}`, "PATCH", { word: "改変" });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_not_editable" },
+    });
+  });
+
+  test("登録から 1 時間を超えた修正は 403 word_not_editable", async () => {
+    await createUser("alice");
+    await insertWordRow({
+      createdAt: Date.now() - 60 * 60 * 1000 - 1000,
+      createdBy: "alice",
+      id: "word-old",
+      reading: "ふるい",
+      readingSubGroup: "ふ",
+      word: "ふるい",
+    });
+
+    const response = await requestJson("alice", "/v1/words/word-old", "PATCH", { word: "新しい" });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_not_editable" },
+    });
+  });
+
+  test("他ユーザーの定義がある言葉の修正は 403 word_not_editable", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    await insertPublicDefinitionRow("definition-1", word.id, "bob");
+
+    const response = await requestJson("alice", `/v1/words/${word.id}`, "PATCH", { word: "改" });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_not_editable" },
+    });
+  });
+
+  test("他ユーザーの保存がある言葉の修正は 403 word_not_editable", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    await request("bob", `/v1/words/${word.id}/save`, { method: "PUT" });
+
+    const response = await requestJson("alice", `/v1/words/${word.id}`, "PATCH", { word: "改" });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_not_editable" },
+    });
+  });
+
+  test("自分自身の定義や保存では編集可能なまま", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    await insertPublicDefinitionRow("definition-own", word.id, "alice");
+    await request("alice", `/v1/words/${word.id}/save`, { method: "PUT" });
+
+    const response = await requestJson("alice", `/v1/words/${word.id}`, "PATCH", { word: "言葉" });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("修正後の表記が既存の言葉と重複する場合は 409 で既存の言葉を返す", async () => {
+    await createUser("alice");
+    const existing = await createWord("alice", "りんご", "りんご");
+    const word = await createWord("alice", "みかん", "みかん");
+
+    const response = await requestJson("alice", `/v1/words/${word.id}`, "PATCH", {
+      word: " りんご ",
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "word_already_exists" },
+      existingWord: { id: existing.id },
+    });
+  });
+
+  test("存在しない言葉の修正は 404 word_not_found", async () => {
+    await createUser("alice");
+
+    const response = await requestJson("alice", "/v1/words/missing-id", "PATCH", { word: "x" });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("GET /v1/words", () => {
+  test("よみ順に並び、keyset pagination で続きを取得できる", async () => {
+    await createUser("alice");
+    await createWord("alice", "うめ", "うめ");
+    await createWord("alice", "あんこ", "あんこ");
+    await createWord("alice", "いちご", "いちご");
+
+    const firstPage = await request("alice", "/v1/words?limit=2");
+    expect(firstPage.status).toBe(200);
+    const firstBody = await firstPage.json<{
+      items: Array<{ word: string }>;
+      nextCursor: string | null;
+    }>();
+    expect(firstBody.items.map((item) => item.word)).toEqual(["あんこ", "いちご"]);
+    expect(firstBody.nextCursor).not.toBeNull();
+
+    const secondPage = await request(
+      "alice",
+      `/v1/words?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor!)}`,
+    );
+    const secondBody = await secondPage.json<{
+      items: Array<{ word: string }>;
+      nextCursor: string | null;
+    }>();
+    expect(secondBody.items.map((item) => item.word)).toEqual(["うめ"]);
+    expect(secondBody.nextCursor).toBeNull();
+  });
+
+  test("subGroup で行を絞り込める", async () => {
+    await createUser("alice");
+    await createWord("alice", "あんこ", "あんこ");
+    await createWord("alice", "がっこう", "ガッコウ");
+
+    const response = await request("alice", `/v1/words?subGroup=${encodeURIComponent("か")}`);
+
+    const body = await response.json<{ items: Array<{ word: string }> }>();
+    expect(body.items.map((item) => item.word)).toEqual(["がっこう"]);
+  });
+
+  test("filter で定義の有無を絞り込める", async () => {
+    await createUser("alice");
+    const defined = await createWord("alice", "ていぎずみ", "ていぎずみ");
+    await createWord("alice", "みていぎ", "みていぎ");
+    await insertPublicDefinitionRow("definition-1", defined.id, "alice");
+
+    const definedOnly = await request("alice", "/v1/words?filter=defined");
+    const undefinedOnly = await request("alice", "/v1/words?filter=undefined");
+
+    const definedBody = await definedOnly.json<{
+      items: Array<{ word: string; publicDefinitionCount: number }>;
+    }>();
+    expect(definedBody.items.map((item) => item.word)).toEqual(["ていぎずみ"]);
+    expect(definedBody.items[0]!.publicDefinitionCount).toBe(1);
+    const undefinedBody = await undefinedOnly.json<{ items: Array<{ word: string }> }>();
+    expect(undefinedBody.items.map((item) => item.word)).toEqual(["みていぎ"]);
+  });
+
+  test("q で表記・よみを部分一致検索できる", async () => {
+    await createUser("alice");
+    await createWord("alice", "青りんご", "あおりんご");
+    await createWord("alice", "みかん", "みかん");
+
+    const byWord = await request("alice", `/v1/words?q=${encodeURIComponent("りんご")}`);
+    const byReading = await request("alice", `/v1/words?q=${encodeURIComponent("あお")}`);
+
+    const byWordBody = await byWord.json<{ items: Array<{ word: string }> }>();
+    expect(byWordBody.items.map((item) => item.word)).toEqual(["青りんご"]);
+    const byReadingBody = await byReading.json<{ items: Array<{ word: string }> }>();
+    expect(byReadingBody.items.map((item) => item.word)).toEqual(["青りんご"]);
+  });
+
+  test("LIKE のワイルドカードをエスケープして検索する", async () => {
+    await createUser("alice");
+    await createWord("alice", "100%", "ひゃくぱーせんと");
+    await createWord("alice", "満点", "まんてん");
+
+    const response = await request("alice", `/v1/words?q=${encodeURIComponent("%")}`);
+
+    const body = await response.json<{ items: Array<{ word: string }> }>();
+    expect(body.items.map((item) => item.word)).toEqual(["100%"]);
+  });
+
+  test("不正な cursor は 400 invalid_cursor", async () => {
+    await createUser("alice");
+
+    const response = await request("alice", "/v1/words?cursor=broken");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "invalid_cursor" },
+    });
+  });
+});
+
+describe("PUT / DELETE /v1/words/{id}/save", () => {
+  test("保存と解除は冪等で、isSavedByMe に反映される", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+
+    const save1 = await request("alice", `/v1/words/${word.id}/save`, { method: "PUT" });
+    const save2 = await request("alice", `/v1/words/${word.id}/save`, { method: "PUT" });
+    expect(save1.status).toBe(204);
+    expect(save2.status).toBe(204);
+    const afterSave = await request("alice", `/v1/words/${word.id}`);
+    await expect(afterSave.json()).resolves.toMatchObject({ isSavedByMe: true });
+
+    const unsave1 = await request("alice", `/v1/words/${word.id}/save`, { method: "DELETE" });
+    const unsave2 = await request("alice", `/v1/words/${word.id}/save`, { method: "DELETE" });
+    expect(unsave1.status).toBe(204);
+    expect(unsave2.status).toBe(204);
+    const afterUnsave = await request("alice", `/v1/words/${word.id}`);
+    await expect(afterUnsave.json()).resolves.toMatchObject({ isSavedByMe: false });
+  });
+
+  test("存在しない言葉の保存は 404 word_not_found", async () => {
+    await createUser("alice");
+
+    const response = await request("alice", "/v1/words/missing-id/save", { method: "PUT" });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/server/worker-test/words.workers.ts
+++ b/server/worker-test/words.workers.ts
@@ -123,6 +123,20 @@ describe("POST /v1/words", () => {
     expect(body.id).toMatch(uuidPattern);
   });
 
+  test("正規化後に空になる表記・よみは 400 invalid_request", async () => {
+    await createUser("alice");
+
+    const response = await requestJson("alice", "/v1/words", "POST", {
+      reading: " ",
+      word: " ",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "invalid_request" },
+    });
+  });
+
   test("未登録ユーザーの言葉登録は 404 user_not_found", async () => {
     const response = await requestJson("unregistered", "/v1/words", "POST", {
       reading: "ことば",
@@ -293,6 +307,62 @@ describe("PATCH /v1/words/{id}", () => {
       error: { code: "word_already_exists" },
       existingWord: { id: existing.id },
     });
+  });
+
+  test("正規化後に空になる修正は 400 invalid_request", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+
+    const response = await requestJson("alice", `/v1/words/${word.id}`, "PATCH", { word: "  " });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "invalid_request" },
+    });
+  });
+
+  test("編集可否チェック後に他ユーザーの保存が入った場合も 403 word_not_editable", async () => {
+    await createUser("alice");
+    await createUser("bob");
+    const word = await createWord("alice", "ことば", "ことば");
+    // 編集可否チェックと UPDATE の間に bob の保存を割り込ませ、TOCTOU を再現する
+    let intercepted = false;
+    const racingDatabase = {
+      prepare(query: string) {
+        const statement = env.DB.prepare(query);
+        if (!query.trimStart().startsWith("update words") || intercepted) return statement;
+        intercepted = true;
+        return {
+          bind: (...values: unknown[]) => {
+            const bound = statement.bind(...values);
+            return {
+              run: async () => {
+                await env.DB.prepare(
+                  "insert into saved_words (user_id, word_id, created_at) values (?, ?, ?)",
+                )
+                  .bind("bob", word.id, Date.now())
+                  .run();
+                return bound.run();
+              },
+            };
+          },
+        } as unknown as D1PreparedStatement;
+      },
+    } as unknown as D1Database;
+
+    const response = await testApp("alice").request(
+      `/v1/words/${word.id}`,
+      {
+        body: JSON.stringify({ word: "改変" }),
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        method: "PATCH",
+      },
+      { ...env, DB: racingDatabase },
+    );
+
+    expect(response.status).toBe(403);
+    const row = await env.DB.prepare("select word from words where id = ?").bind(word.id).first();
+    expect(row).toMatchObject({ word: "ことば" });
   });
 
   test("論理削除済みユーザーは自分が登録した言葉も修正できない", async () => {

--- a/server/worker-test/words.workers.ts
+++ b/server/worker-test/words.workers.ts
@@ -123,6 +123,30 @@ describe("POST /v1/words", () => {
     expect(body.id).toMatch(uuidPattern);
   });
 
+  test("未登録ユーザーの言葉登録は 404 user_not_found", async () => {
+    const response = await requestJson("unregistered", "/v1/words", "POST", {
+      reading: "ことば",
+      word: "ことば",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "user_not_found" },
+    });
+  });
+
+  test("論理削除済みユーザーは言葉を登録できない", async () => {
+    await createUser("alice");
+    await request("alice", "/v1/users/me", { method: "DELETE" });
+
+    const response = await requestJson("alice", "/v1/words", "POST", {
+      reading: "ことば",
+      word: "ことば",
+    });
+
+    expect(response.status).toBe(404);
+  });
+
   test("正規化後に同一表記が存在する場合は 409 で既存の言葉を返す", async () => {
     await createUser("alice");
     const first = await createWord("alice", "りんご", "りんご");
@@ -269,6 +293,16 @@ describe("PATCH /v1/words/{id}", () => {
       error: { code: "word_already_exists" },
       existingWord: { id: existing.id },
     });
+  });
+
+  test("論理削除済みユーザーは自分が登録した言葉も修正できない", async () => {
+    await createUser("alice");
+    const word = await createWord("alice", "ことば", "ことば");
+    await request("alice", "/v1/users/me", { method: "DELETE" });
+
+    const response = await requestJson("alice", `/v1/words/${word.id}`, "PATCH", { word: "改" });
+
+    expect(response.status).toBe(404);
   });
 
   test("存在しない言葉の修正は 404 word_not_found", async () => {


### PR DESCRIPTION
closes #194

## 概要

Issue #184 フェーズ 3 の Slice 3 として、言葉・定義・いいね・保存 API を実装し、対象ルートの 501 を解消した。

## 実施内容

### 共通ヘルパー（bun test で単体テスト）
- `src/lib/uuidv7.ts` — RFC 9562 UUIDv7（新規 ID 規約）
- `src/lib/cursor.ts` — base64url JSON の不透明 keyset cursor（形式不正は 400 invalid_cursor）
- `src/lib/normalize.ts` — 前後トリム + NFC 正規化
- `src/words/reading-sub-group.ts` — 旧 `InitialSubGroup.fromString` と同一規則の読みグループ判定（濁音・小書き・カタカナ・英数字・記号）

### 言葉 API（`WordService`）
- `POST /v1/words` — 正規化後の完全一致で重複判定、409 は既存の言葉を返す（同時登録の UNIQUE 競合も 409 に変換）
- `GET /v1/words` — 読み順 keyset pagination、`subGroup` / `filter=defined|undefined` / `q`（LIKE ワイルドカードはエスケープ）
- `GET /v1/words/{id}` — `publicDefinitionCount` / `isSavedByMe` / `isEditableByMe`
- `PATCH /v1/words/{id}` — 登録後 1 時間以内・登録者本人・他ユーザーの定義/保存なしの場合のみ（403 word_not_editable）
- `PUT / DELETE /v1/words/{id}/save` — 冪等

### 定義 API（`DefinitionService`）
- `POST /v1/definitions` — draft は `finalizedAt=null`、public/private は確定時刻と `editableUntil`（+1h）を返す
- `GET /v1/definitions/{id}` — 本人は全状態、他者は public のみ。不可視は 404 で存在秘匿
- `PATCH /v1/definitions/{id}` — draft→public/private、public↔private のみ許可。確定後の draft 戻し・wordId 変更は 400、期限超過の本文編集は 403。確定後の本文編集のみ `isEdited` を立てる
- `DELETE /v1/definitions/{id}` — 所有者のみ論理削除
- `PUT / DELETE /v1/definitions/{id}/like` — 冪等。いいね対象は他者の public + 自分の全定義
- `GET /v1/definitions/{id}/likes` — いいね日時降順の keyset pagination

### その他
- `app-auth.test.ts` の 501 到達確認を未実装の `/v1/me/mutes`（#193 スコープ）へ差し替え
- 仕様書の「言葉」「定義」節と各サービスを DocBridge で双方向リンク

## スコープ外（#193 で実装）
- `GET /words/{id}/definitions` などの合成 DTO 一覧・辞書・タイムライン・検索

## 検証
- lint / typecheck / format check: ✅
- bun test（unit 73）+ Workers 結合テスト（60）: ✅
- OpenAPI 再生成: 差分なし
- DocBridge check: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xhkgjEZ7MBJrpkMBqDRNs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete word management, search, filtering, pagination, and save/unsave functionality.
  * Added definition creation, editing, deletion, visibility controls, likes, and liked-user listings.
  * Added text normalization and reading-group classification for consistent word organization.
* **Bug Fixes**
  * Duplicate words now return clear conflict responses.
  * Added handling for unregistered or deleted users.
* **Documentation**
  * Updated API documentation with new error responses and implementation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->