### PR TITLE
feat: 辞書・タイムライン・検索 API を実装

### DIFF
--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -155,6 +155,7 @@ R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object �
 - 削除は所有者だけが実行でき、`deleted_at` を設定する
 - いいね対象は他者が閲覧可能な public 定義と、自分が閲覧可能な自分の定義に限定する
 
+<!-- @code server/src/browse/browse-service.ts#BrowseService -->
 ### 辞書と一覧
 
 - 公開辞書は対象ユーザーの public 定義だけを言葉単位にまとめる
@@ -162,6 +163,7 @@ R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object �
 - 合成 DTO の likesCount、followingCount、followerCount は有効な行だけを集計する
 - `isLikedByMe`、`isFollowedByMe`、`isMutedByMe` は認証 UID を基準に算出する
 
+<!-- @code server/src/browse/browse-service.ts#BrowseService -->
 ### タイムラインと検索
 
 - 見つけるは public 定義を `finalized_at DESC`、言葉登録を `created_at DESC` として混在させる

--- a/server/src/browse/browse-service.ts
+++ b/server/src/browse/browse-service.ts
@@ -690,7 +690,7 @@ export class BrowseService {
       if (
         typeof parsed["sortAt"] !== "number" ||
         !Number.isSafeInteger(parsed["sortAt"]) ||
-        typeof parsed["type"] !== "string" ||
+        (parsed["type"] !== "definition" && parsed["type"] !== "wordRegistered") ||
         typeof parsed["id"] !== "string" ||
         parsed["id"].length === 0
       ) {
@@ -828,6 +828,7 @@ export class BrowseService {
       await this.env.DB.prepare(
         `select w.id, w.word, w.reading, w.reading_sub_group,
            (select count(*) from definitions d
+            join users author on author.id = d.author_id and author.deleted_at is null
             where d.word_id = w.id and d.status = 'public' and d.deleted_at is null)
              as public_definition_count
          from words w

--- a/server/src/browse/browse-service.ts
+++ b/server/src/browse/browse-service.ts
@@ -1,0 +1,892 @@
+import { ApiError } from "../errors";
+import { decodeOpaqueCursor, encodeOpaqueCursor } from "../lib/cursor";
+
+const editWindowMilliseconds = 60 * 60 * 1000;
+
+type BrowseBindings = {
+  AVATAR_BASE_URL: string;
+  DB: D1Database;
+};
+
+type DefinitionStatus = "draft" | "public" | "private";
+
+type DefinitionListRow = {
+  id: string;
+  word_id: string;
+  word: string;
+  reading: string;
+  author_id: string;
+  author_public_id: string;
+  author_name: string;
+  author_avatar_key: string | null;
+  body: string;
+  status: DefinitionStatus;
+  finalized_at: number | null;
+  is_edited: number;
+  created_at: number;
+  updated_at: number;
+  likes_count: number;
+  is_liked_by_me: number;
+  sort_at: number;
+};
+
+type WordListRow = {
+  id: string;
+  word: string;
+  reading: string;
+  reading_sub_group: string;
+  public_definition_count: number;
+};
+
+type UserListRow = {
+  id: string;
+  public_id: string;
+  name: string;
+  avatar_key: string | null;
+  is_followed_by_me: number;
+  is_muted_by_me: number;
+  relation_created_at: number;
+};
+
+type DescendingCursor = {
+  id: string;
+  kind: string;
+  sortAt: number;
+  version: 1;
+};
+
+type ReadingCursor = {
+  id: string;
+  kind: string;
+  reading: string;
+  version: 1;
+};
+
+type ReactionCursor = DescendingCursor & { likesCount: number };
+type DiscoverCursor = DescendingCursor & { type: string };
+
+function avatarUrl(baseUrl: string, key: string | null): string | null {
+  if (key === null) return null;
+  return `${baseUrl.replace(/\/+$/, "")}/${key}`;
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+function decodeCursor(value: string, kind: string): Record<string, unknown> {
+  const parsed = decodeOpaqueCursor(value);
+  if (parsed["version"] !== 1 || parsed["kind"] !== kind) {
+    throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+  }
+  return parsed;
+}
+
+function decodeDescendingCursor(value: string, kind: string): DescendingCursor {
+  const parsed = decodeCursor(value, kind);
+  if (
+    typeof parsed["sortAt"] !== "number" ||
+    !Number.isSafeInteger(parsed["sortAt"]) ||
+    typeof parsed["id"] !== "string" ||
+    parsed["id"].length === 0
+  ) {
+    throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+  }
+  return parsed as unknown as DescendingCursor;
+}
+
+function decodeReadingCursor(value: string, kind: string): ReadingCursor {
+  const parsed = decodeCursor(value, kind);
+  if (
+    typeof parsed["reading"] !== "string" ||
+    typeof parsed["id"] !== "string" ||
+    parsed["id"].length === 0
+  ) {
+    throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+  }
+  return parsed as unknown as ReadingCursor;
+}
+
+function activeLikesCount(definitionId = "d.id"): string {
+  return `(select count(*) from likes counted
+    join users liker on liker.id = counted.user_id and liker.deleted_at is null
+    where counted.definition_id = ${definitionId})`;
+}
+
+function definitionColumns(): string {
+  return `d.id, d.word_id, w.word, w.reading,
+    d.author_id, u.public_id as author_public_id, u.name as author_name,
+    u.avatar_key as author_avatar_key, d.body, d.status, d.finalized_at,
+    d.is_edited, d.created_at, d.updated_at,
+    ${activeLikesCount()} as likes_count,
+    exists(select 1 from likes mine
+     where mine.definition_id = d.id and mine.user_id = ?) as is_liked_by_me,
+    coalesce(d.finalized_at, d.updated_at) as sort_at`;
+}
+
+function toDefinition(row: DefinitionListRow, baseUrl: string) {
+  const editableUntil =
+    row.finalized_at === null ? null : row.finalized_at + editWindowMilliseconds;
+  return {
+    author: {
+      avatarUrl: avatarUrl(baseUrl, row.author_avatar_key),
+      id: row.author_id,
+      name: row.author_name,
+      publicId: row.author_public_id,
+    },
+    body: row.body,
+    createdAt: new Date(row.created_at).toISOString(),
+    editableUntil: editableUntil === null ? null : new Date(editableUntil).toISOString(),
+    finalizedAt: row.finalized_at === null ? null : new Date(row.finalized_at).toISOString(),
+    id: row.id,
+    isEdited: row.is_edited !== 0,
+    isLikedByMe: row.is_liked_by_me !== 0,
+    likesCount: row.likes_count,
+    status: row.status,
+    updatedAt: new Date(row.updated_at).toISOString(),
+    word: { id: row.word_id, reading: row.reading, word: row.word },
+  };
+}
+
+function wordItem(row: WordListRow) {
+  return {
+    id: row.id,
+    publicDefinitionCount: row.public_definition_count,
+    reading: row.reading,
+    readingSubGroup: row.reading_sub_group,
+    word: row.word,
+  };
+}
+
+function userItem(row: UserListRow, baseUrl: string) {
+  return {
+    avatarUrl: avatarUrl(baseUrl, row.avatar_key),
+    id: row.id,
+    isFollowedByMe: row.is_followed_by_me !== 0,
+    isMutedByMe: row.is_muted_by_me !== 0,
+    name: row.name,
+    publicId: row.public_id,
+  };
+}
+
+function page<T, R>(rows: R[], limit: number, map: (row: R) => T, cursor: (row: R) => string) {
+  const hasNextPage = rows.length > limit;
+  const pageRows = rows.slice(0, limit);
+  const last = pageRows.at(-1);
+  return {
+    items: pageRows.map(map),
+    nextCursor: hasNextPage && last !== undefined ? cursor(last) : null,
+  };
+}
+
+async function requireUser(db: D1Database, id: string): Promise<void> {
+  const row = await db
+    .prepare("select id from users where id = ? and deleted_at is null")
+    .bind(id)
+    .first();
+  if (row === null) throw new ApiError(404, "user_not_found", "User not found");
+}
+
+async function requireWord(db: D1Database, id: string): Promise<void> {
+  const row = await db.prepare("select id from words where id = ?").bind(id).first();
+  if (row === null) throw new ApiError(404, "word_not_found", "Word not found");
+}
+
+/**
+ * 一覧・辞書・タイムライン・検索の合成 DTO と keyset pagination を扱う。
+ *
+ * @doc doc/specs/workers-api-server.md#辞書と一覧
+ * @doc doc/specs/workers-api-server.md#タイムラインと検索
+ */
+export class BrowseService {
+  constructor(private readonly env: BrowseBindings) {}
+
+  async listUserDictionary(userId: string, limit: number, cursorValue?: string) {
+    await requireUser(this.env.DB, userId);
+    const cursor =
+      cursorValue === undefined ? null : decodeReadingCursor(cursorValue, "user_dictionary");
+    const cursorClause =
+      cursor === null ? "" : "and (w.reading > ? or (w.reading = ? and w.id > ?))";
+    const statement = this.env.DB.prepare(
+      `select w.id, w.word, w.reading, count(*) as public_count
+       from definitions d
+       join words w on w.id = d.word_id
+       join users u on u.id = d.author_id and u.deleted_at is null
+       where d.author_id = ? and d.status = 'public' and d.deleted_at is null ${cursorClause}
+       group by w.id, w.word, w.reading
+       order by w.reading asc, w.id asc
+       limit ?`,
+    );
+    type Row = { id: string; word: string; reading: string; public_count: number };
+    const rows = (
+      await (
+        cursor === null
+          ? statement.bind(userId, limit + 1)
+          : statement.bind(userId, cursor.reading, cursor.reading, cursor.id, limit + 1)
+      ).all<Row>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => ({
+        publicCount: row.public_count,
+        word: { id: row.id, reading: row.reading, word: row.word },
+      }),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "user_dictionary",
+          reading: row.reading,
+          version: 1,
+        } satisfies ReadingCursor),
+    );
+  }
+
+  async listUserDefinitions(
+    viewerUid: string,
+    userId: string,
+    input: {
+      cursor?: string | undefined;
+      limit: number;
+      sort: "newest" | "reading";
+      subGroup?: string | undefined;
+      wordId?: string | undefined;
+    },
+  ) {
+    await requireUser(this.env.DB, userId);
+    const own = viewerUid === userId;
+    const conditions = [
+      "d.author_id = ?",
+      "d.deleted_at is null",
+      own ? "d.status in ('public', 'private')" : "d.status = 'public'",
+    ];
+    const parameters: unknown[] = [viewerUid, userId];
+    if (input.wordId !== undefined) {
+      conditions.push("d.word_id = ?");
+      parameters.push(input.wordId);
+    }
+    if (input.subGroup !== undefined) {
+      conditions.push("w.reading_sub_group = ?");
+      parameters.push(input.subGroup);
+    }
+
+    let orderBy: string;
+    let cursorFactory: (row: DefinitionListRow) => string;
+    if (input.sort === "reading") {
+      const cursor =
+        input.cursor === undefined
+          ? null
+          : decodeReadingCursor(input.cursor, "user_definitions_reading");
+      if (cursor !== null) {
+        conditions.push("(w.reading > ? or (w.reading = ? and d.id > ?))");
+        parameters.push(cursor.reading, cursor.reading, cursor.id);
+      }
+      orderBy = "w.reading asc, d.id asc";
+      cursorFactory = (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "user_definitions_reading",
+          reading: row.reading,
+          version: 1,
+        } satisfies ReadingCursor);
+    } else {
+      const cursor =
+        input.cursor === undefined
+          ? null
+          : decodeDescendingCursor(input.cursor, "user_definitions_newest");
+      if (cursor !== null) {
+        conditions.push(
+          "(coalesce(d.finalized_at, d.updated_at) < ? or (coalesce(d.finalized_at, d.updated_at) = ? and d.id < ?))",
+        );
+        parameters.push(cursor.sortAt, cursor.sortAt, cursor.id);
+      }
+      orderBy = "sort_at desc, d.id desc";
+      cursorFactory = (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "user_definitions_newest",
+          sortAt: row.sort_at,
+          version: 1,
+        } satisfies DescendingCursor);
+    }
+    const rows = (
+      await this.env.DB.prepare(
+        `select ${definitionColumns()}
+         from definitions d
+         join words w on w.id = d.word_id
+         join users u on u.id = d.author_id and u.deleted_at is null
+         where ${conditions.join(" and ")}
+         order by ${orderBy}
+         limit ?`,
+      )
+        .bind(...parameters, input.limit + 1)
+        .all<DefinitionListRow>()
+    ).results;
+    return page(
+      rows,
+      input.limit,
+      (row) => toDefinition(row, this.env.AVATAR_BASE_URL),
+      cursorFactory,
+    );
+  }
+
+  async listLikedDefinitions(
+    viewerUid: string,
+    userId: string,
+    limit: number,
+    cursorValue?: string,
+  ) {
+    await requireUser(this.env.DB, userId);
+    const cursor =
+      cursorValue === undefined ? null : decodeDescendingCursor(cursorValue, "liked_definitions");
+    const cursorClause =
+      cursor === null ? "" : "and (liked.created_at < ? or (liked.created_at = ? and d.id < ?))";
+    const parameters: unknown[] = [viewerUid, userId, viewerUid];
+    if (cursor !== null) parameters.push(cursor.sortAt, cursor.sortAt, cursor.id);
+    const rows = (
+      await this.env.DB.prepare(
+        `select ${definitionColumns().replace(
+          "coalesce(d.finalized_at, d.updated_at) as sort_at",
+          "liked.created_at as sort_at",
+        )}
+         from likes liked
+         join definitions d on d.id = liked.definition_id and d.deleted_at is null
+         join words w on w.id = d.word_id
+         join users u on u.id = d.author_id and u.deleted_at is null
+         where liked.user_id = ? and (d.status = 'public' or d.author_id = ?) ${cursorClause}
+         order by liked.created_at desc, d.id desc
+         limit ?`,
+      )
+        .bind(...parameters, limit + 1)
+        .all<DefinitionListRow>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => toDefinition(row, this.env.AVATAR_BASE_URL),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "liked_definitions",
+          sortAt: row.sort_at,
+          version: 1,
+        } satisfies DescendingCursor),
+    );
+  }
+
+  async getMyOverview(uid: string) {
+    const counts = await this.env.DB.prepare(
+      `select
+         count(distinct d.word_id) as defined_word_count,
+         sum(case when d.status = 'draft' then 1 else 0 end) as draft_count,
+         (select count(*) from saved_words s where s.user_id = ?) as saved_word_count
+       from definitions d
+       where d.author_id = ? and d.deleted_at is null`,
+    )
+      .bind(uid, uid)
+      .first<{ defined_word_count: number; draft_count: number; saved_word_count: number }>();
+    const rows = (
+      await this.env.DB.prepare(
+        `select ${definitionColumns()}
+         from definitions d
+         join words w on w.id = d.word_id
+         join users u on u.id = d.author_id and u.deleted_at is null
+         where d.author_id = ? and d.deleted_at is null
+         order by d.updated_at desc, d.id desc
+         limit 5`,
+      )
+        .bind(uid, uid)
+        .all<DefinitionListRow>()
+    ).results;
+    return {
+      definedWordCount: counts?.defined_word_count ?? 0,
+      draftCount: counts?.draft_count ?? 0,
+      recentDefinitions: rows.map((row) => toDefinition(row, this.env.AVATAR_BASE_URL)),
+      savedWordCount: counts?.saved_word_count ?? 0,
+    };
+  }
+
+  async listDefinedWords(uid: string, limit: number, cursorValue?: string) {
+    const cursor =
+      cursorValue === undefined ? null : decodeReadingCursor(cursorValue, "defined_words");
+    const cursorClause =
+      cursor === null ? "" : "and (w.reading > ? or (w.reading = ? and w.id > ?))";
+    const statement = this.env.DB.prepare(
+      `select w.id, w.word, w.reading,
+         sum(case when d.status = 'public' then 1 else 0 end) as public_count,
+         sum(case when d.status = 'private' then 1 else 0 end) as private_count,
+         sum(case when d.status = 'draft' then 1 else 0 end) as draft_count
+       from definitions d join words w on w.id = d.word_id
+       where d.author_id = ? and d.deleted_at is null ${cursorClause}
+       group by w.id, w.word, w.reading
+       order by w.reading asc, w.id asc limit ?`,
+    );
+    type Row = {
+      id: string;
+      word: string;
+      reading: string;
+      public_count: number;
+      private_count: number;
+      draft_count: number;
+    };
+    const rows = (
+      await (
+        cursor === null
+          ? statement.bind(uid, limit + 1)
+          : statement.bind(uid, cursor.reading, cursor.reading, cursor.id, limit + 1)
+      ).all<Row>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => ({
+        draftCount: row.draft_count,
+        privateCount: row.private_count,
+        publicCount: row.public_count,
+        word: { id: row.id, reading: row.reading, word: row.word },
+      }),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "defined_words",
+          reading: row.reading,
+          version: 1,
+        } satisfies ReadingCursor),
+    );
+  }
+
+  async listMyDefinitions(
+    uid: string,
+    limit: number,
+    status?: DefinitionStatus,
+    cursorValue?: string,
+  ) {
+    const cursor =
+      cursorValue === undefined ? null : decodeDescendingCursor(cursorValue, "my_definitions");
+    const conditions = ["d.author_id = ?", "d.deleted_at is null"];
+    const parameters: unknown[] = [uid, uid];
+    if (status !== undefined) {
+      conditions.push("d.status = ?");
+      parameters.push(status);
+    }
+    if (cursor !== null) {
+      conditions.push("(d.updated_at < ? or (d.updated_at = ? and d.id < ?))");
+      parameters.push(cursor.sortAt, cursor.sortAt, cursor.id);
+    }
+    const rows = (
+      await this.env.DB.prepare(
+        `select ${definitionColumns().replace(
+          "coalesce(d.finalized_at, d.updated_at) as sort_at",
+          "d.updated_at as sort_at",
+        )}
+         from definitions d join words w on w.id = d.word_id
+         join users u on u.id = d.author_id and u.deleted_at is null
+         where ${conditions.join(" and ")}
+         order by d.updated_at desc, d.id desc limit ?`,
+      )
+        .bind(...parameters, limit + 1)
+        .all<DefinitionListRow>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => toDefinition(row, this.env.AVATAR_BASE_URL),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "my_definitions",
+          sortAt: row.sort_at,
+          version: 1,
+        } satisfies DescendingCursor),
+    );
+  }
+
+  async listSavedWords(uid: string, limit: number, cursorValue?: string) {
+    const cursor =
+      cursorValue === undefined ? null : decodeDescendingCursor(cursorValue, "saved_words");
+    const cursorClause =
+      cursor === null ? "" : "and (s.created_at < ? or (s.created_at = ? and w.id < ?))";
+    const parameters: unknown[] = [uid];
+    if (cursor !== null) parameters.push(cursor.sortAt, cursor.sortAt, cursor.id);
+    type Row = {
+      id: string;
+      word: string;
+      reading: string;
+      is_defined_by_me: number;
+      saved_at: number;
+    };
+    const rows = (
+      await this.env.DB.prepare(
+        `select w.id, w.word, w.reading, s.created_at as saved_at,
+           exists(select 1 from definitions d
+            where d.word_id = w.id and d.author_id = ? and d.deleted_at is null) as is_defined_by_me
+         from saved_words s join words w on w.id = s.word_id
+         where s.user_id = ? ${cursorClause}
+         order by s.created_at desc, w.id desc limit ?`,
+      )
+        .bind(uid, ...parameters, limit + 1)
+        .all<Row>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => ({
+        isDefinedByMe: row.is_defined_by_me !== 0,
+        word: { id: row.id, reading: row.reading, word: row.word },
+      }),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "saved_words",
+          sortAt: row.saved_at,
+          version: 1,
+        } satisfies DescendingCursor),
+    );
+  }
+
+  async listMutes(uid: string, limit: number, cursorValue?: string) {
+    const cursor = cursorValue === undefined ? null : decodeDescendingCursor(cursorValue, "mutes");
+    const cursorClause =
+      cursor === null ? "" : "and (m.created_at < ? or (m.created_at = ? and u.id < ?))";
+    const parameters: unknown[] = [uid, uid, uid];
+    if (cursor !== null) parameters.push(cursor.sortAt, cursor.sortAt, cursor.id);
+    const rows = (
+      await this.env.DB.prepare(
+        `select u.id, u.public_id, u.name, u.avatar_key, m.created_at as relation_created_at,
+           exists(select 1 from follows mine
+            where mine.follower_id = ? and mine.following_id = u.id) as is_followed_by_me,
+           exists(select 1 from user_mutes mine
+            where mine.muter_id = ? and mine.muted_user_id = u.id) as is_muted_by_me
+         from user_mutes m join users u on u.id = m.muted_user_id and u.deleted_at is null
+         where m.muter_id = ? ${cursorClause}
+         order by m.created_at desc, u.id desc limit ?`,
+      )
+        .bind(...parameters, limit + 1)
+        .all<UserListRow>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => userItem(row, this.env.AVATAR_BASE_URL),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "mutes",
+          sortAt: row.relation_created_at,
+          version: 1,
+        } satisfies DescendingCursor),
+    );
+  }
+
+  async listWordDefinitions(
+    uid: string,
+    wordId: string,
+    input: {
+      cursor?: string | undefined;
+      limit: number;
+      scope: "mine" | "others" | "all";
+      sort: "newest" | "reactions";
+    },
+  ) {
+    await requireWord(this.env.DB, wordId);
+    const visibility =
+      input.scope === "mine"
+        ? "d.author_id = ?"
+        : input.scope === "others"
+          ? "d.author_id <> ? and d.status = 'public'"
+          : "(d.author_id = ? or d.status = 'public')";
+    const conditions = ["d.word_id = ?", "d.deleted_at is null", visibility];
+    const parameters: unknown[] = [uid, wordId, uid];
+    let orderBy: string;
+    let cursorFactory: (row: DefinitionListRow) => string;
+    if (input.sort === "reactions") {
+      const parsed =
+        input.cursor === undefined
+          ? null
+          : decodeCursor(input.cursor, "word_definitions_reactions");
+      let cursor: ReactionCursor | null = null;
+      if (parsed !== null) {
+        if (
+          typeof parsed["likesCount"] !== "number" ||
+          !Number.isSafeInteger(parsed["likesCount"]) ||
+          typeof parsed["sortAt"] !== "number" ||
+          !Number.isSafeInteger(parsed["sortAt"]) ||
+          typeof parsed["id"] !== "string" ||
+          parsed["id"].length === 0
+        ) {
+          throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+        }
+        cursor = parsed as unknown as ReactionCursor;
+      }
+      if (cursor !== null) {
+        const likesCount = activeLikesCount();
+        conditions.push(
+          `(${likesCount} < ?
+           or (${likesCount} = ?
+             and (coalesce(d.finalized_at, d.updated_at) < ?
+               or (coalesce(d.finalized_at, d.updated_at) = ? and d.id < ?))))`,
+        );
+        parameters.push(
+          cursor.likesCount,
+          cursor.likesCount,
+          cursor.sortAt,
+          cursor.sortAt,
+          cursor.id,
+        );
+      }
+      orderBy = "likes_count desc, sort_at desc, d.id desc";
+      cursorFactory = (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "word_definitions_reactions",
+          likesCount: row.likes_count,
+          sortAt: row.sort_at,
+          version: 1,
+        } satisfies ReactionCursor);
+    } else {
+      const cursor =
+        input.cursor === undefined
+          ? null
+          : decodeDescendingCursor(input.cursor, "word_definitions_newest");
+      if (cursor !== null) {
+        conditions.push(
+          "(coalesce(d.finalized_at, d.updated_at) < ? or (coalesce(d.finalized_at, d.updated_at) = ? and d.id < ?))",
+        );
+        parameters.push(cursor.sortAt, cursor.sortAt, cursor.id);
+      }
+      orderBy = "sort_at desc, d.id desc";
+      cursorFactory = (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "word_definitions_newest",
+          sortAt: row.sort_at,
+          version: 1,
+        } satisfies DescendingCursor);
+    }
+    const rows = (
+      await this.env.DB.prepare(
+        `select ${definitionColumns()}
+         from definitions d join words w on w.id = d.word_id
+         join users u on u.id = d.author_id and u.deleted_at is null
+         where ${conditions.join(" and ")}
+         order by ${orderBy} limit ?`,
+      )
+        .bind(...parameters, input.limit + 1)
+        .all<DefinitionListRow>()
+    ).results;
+    return page(
+      rows,
+      input.limit,
+      (row) => toDefinition(row, this.env.AVATAR_BASE_URL),
+      cursorFactory,
+    );
+  }
+
+  async listDiscover(uid: string, limit: number, cursorValue?: string) {
+    const parsed =
+      cursorValue === undefined ? null : decodeCursor(cursorValue, "timeline_discover");
+    let cursor: DiscoverCursor | null = null;
+    if (parsed !== null) {
+      if (
+        typeof parsed["sortAt"] !== "number" ||
+        !Number.isSafeInteger(parsed["sortAt"]) ||
+        typeof parsed["type"] !== "string" ||
+        typeof parsed["id"] !== "string" ||
+        parsed["id"].length === 0
+      ) {
+        throw new ApiError(400, "invalid_cursor", "Invalid cursor");
+      }
+      cursor = parsed as unknown as DiscoverCursor;
+    }
+    const cursorClause =
+      cursor === null
+        ? ""
+        : `where (a.occurred_at < ?
+           or (a.occurred_at = ? and (a.type < ? or (a.type = ? and a.item_id < ?))))`;
+    const parameters: unknown[] = [uid, uid];
+    if (cursor !== null) {
+      parameters.push(cursor.sortAt, cursor.sortAt, cursor.type, cursor.type, cursor.id);
+    }
+    type DiscoverRow = DefinitionListRow & {
+      type: "definition" | "wordRegistered";
+      item_id: string;
+      occurred_at: number;
+      activity_word_id: string;
+      activity_word: string;
+      activity_reading: string;
+    };
+    const rows = (
+      await this.env.DB.prepare(
+        `with activities as (
+           select 'definition' as type, d.id as item_id, d.finalized_at as occurred_at
+           from definitions d join users author on author.id = d.author_id and author.deleted_at is null
+           where d.status = 'public' and d.deleted_at is null
+             and not exists(select 1 from user_mutes m
+              where m.muter_id = ? and m.muted_user_id = d.author_id)
+           union all
+           select 'wordRegistered', source.id, source.created_at
+           from words source
+           where source.created_by is null or not exists(select 1 from user_mutes m
+             where m.muter_id = ? and m.muted_user_id = source.created_by)
+         )
+         select a.type, a.item_id, a.occurred_at,
+           d.id, d.word_id, w.word, w.reading,
+           d.author_id, u.public_id as author_public_id, u.name as author_name,
+           u.avatar_key as author_avatar_key, d.body, d.status, d.finalized_at,
+           d.is_edited, d.created_at, d.updated_at,
+           ${activeLikesCount()} as likes_count,
+           exists(select 1 from likes mine where mine.definition_id = d.id and mine.user_id = ?) as is_liked_by_me,
+           a.occurred_at as sort_at,
+           w.id as activity_word_id, w.word as activity_word, w.reading as activity_reading
+         from activities a
+         left join definitions d on a.type = 'definition' and d.id = a.item_id
+         join words w on w.id = case when a.type = 'definition' then d.word_id else a.item_id end
+         left join users u on u.id = d.author_id and u.deleted_at is null
+         ${cursorClause}
+         order by a.occurred_at desc, a.type desc, a.item_id desc limit ?`,
+      )
+        .bind(uid, ...parameters, limit + 1)
+        .all<DiscoverRow>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) =>
+        row.type === "definition"
+          ? {
+              definition: toDefinition(row, this.env.AVATAR_BASE_URL),
+              occurredAt: new Date(row.occurred_at).toISOString(),
+              type: "definition" as const,
+            }
+          : {
+              occurredAt: new Date(row.occurred_at).toISOString(),
+              type: "wordRegistered" as const,
+              word: {
+                id: row.activity_word_id,
+                reading: row.activity_reading,
+                word: row.activity_word,
+              },
+            },
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.item_id,
+          kind: "timeline_discover",
+          sortAt: row.occurred_at,
+          type: row.type,
+          version: 1,
+        } satisfies DiscoverCursor),
+    );
+  }
+
+  async listFollowing(uid: string, limit: number, cursorValue?: string) {
+    const cursor =
+      cursorValue === undefined ? null : decodeDescendingCursor(cursorValue, "timeline_following");
+    const cursorClause =
+      cursor === null ? "" : "and (d.finalized_at < ? or (d.finalized_at = ? and d.id < ?))";
+    const parameters: unknown[] = [uid, uid, uid];
+    if (cursor !== null) parameters.push(cursor.sortAt, cursor.sortAt, cursor.id);
+    const rows = (
+      await this.env.DB.prepare(
+        `select ${definitionColumns().replace(
+          "coalesce(d.finalized_at, d.updated_at) as sort_at",
+          "d.finalized_at as sort_at",
+        )}
+         from definitions d join words w on w.id = d.word_id
+         join users u on u.id = d.author_id and u.deleted_at is null
+         where d.status = 'public' and d.deleted_at is null
+           and exists(select 1 from follows f where f.follower_id = ? and f.following_id = d.author_id)
+           and not exists(select 1 from user_mutes m where m.muter_id = ? and m.muted_user_id = d.author_id)
+           ${cursorClause}
+         order by d.finalized_at desc, d.id desc limit ?`,
+      )
+        .bind(...parameters, limit + 1)
+        .all<DefinitionListRow>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => toDefinition(row, this.env.AVATAR_BASE_URL),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "timeline_following",
+          sortAt: row.sort_at,
+          version: 1,
+        } satisfies DescendingCursor),
+    );
+  }
+
+  async searchWords(uid: string, query: string, limit: number, cursorValue?: string) {
+    const cursor =
+      cursorValue === undefined ? null : decodeReadingCursor(cursorValue, "search_words");
+    const cursorClause =
+      cursor === null ? "" : "and (w.reading > ? or (w.reading = ? and w.id > ?))";
+    const pattern = `%${escapeLikePattern(query)}%`;
+    const parameters: unknown[] = [pattern, pattern, uid];
+    if (cursor !== null) parameters.push(cursor.reading, cursor.reading, cursor.id);
+    const rows = (
+      await this.env.DB.prepare(
+        `select w.id, w.word, w.reading, w.reading_sub_group,
+           (select count(*) from definitions d
+            where d.word_id = w.id and d.status = 'public' and d.deleted_at is null)
+             as public_definition_count
+         from words w
+         where (w.word like ? escape '\\' or w.reading like ? escape '\\')
+           and (w.created_by is null or not exists(select 1 from user_mutes m
+             where m.muter_id = ? and m.muted_user_id = w.created_by))
+           ${cursorClause}
+         order by w.reading asc, w.id asc limit ?`,
+      )
+        .bind(...parameters, limit + 1)
+        .all<WordListRow>()
+    ).results;
+    return page(rows, limit, wordItem, (row) =>
+      encodeOpaqueCursor({
+        id: row.id,
+        kind: "search_words",
+        reading: row.reading,
+        version: 1,
+      } satisfies ReadingCursor),
+    );
+  }
+
+  async searchUsers(uid: string, query: string, limit: number, cursorValue?: string) {
+    const cursor =
+      cursorValue === undefined ? null : decodeReadingCursor(cursorValue, "search_users");
+    const cursorClause =
+      cursor === null ? "" : "and (u.public_id > ? or (u.public_id = ? and u.id > ?))";
+    const pattern = `%${escapeLikePattern(query)}%`;
+    const parameters: unknown[] = [uid, uid, pattern, pattern, uid];
+    if (cursor !== null) parameters.push(cursor.reading, cursor.reading, cursor.id);
+    const rows = (
+      await this.env.DB.prepare(
+        `select u.id, u.public_id, u.name, u.avatar_key, 0 as relation_created_at,
+           exists(select 1 from follows mine
+            where mine.follower_id = ? and mine.following_id = u.id) as is_followed_by_me,
+           exists(select 1 from user_mutes mine
+            where mine.muter_id = ? and mine.muted_user_id = u.id) as is_muted_by_me
+         from users u
+         where u.deleted_at is null
+           and (u.name like ? escape '\\' or u.public_id like ? escape '\\')
+           and not exists(select 1 from user_mutes muted
+            where muted.muter_id = ? and muted.muted_user_id = u.id)
+           ${cursorClause}
+         order by u.public_id asc, u.id asc limit ?`,
+      )
+        .bind(...parameters, limit + 1)
+        .all<UserListRow>()
+    ).results;
+    return page(
+      rows,
+      limit,
+      (row) => userItem(row, this.env.AVATAR_BASE_URL),
+      (row) =>
+        encodeOpaqueCursor({
+          id: row.id,
+          kind: "search_users",
+          reading: row.public_id,
+          version: 1,
+        } satisfies ReadingCursor),
+    );
+  }
+}

--- a/server/src/routes/me.ts
+++ b/server/src/routes/me.ts
@@ -1,4 +1,6 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { AuthenticationVariables } from "../auth/middleware";
+import { BrowseService } from "../browse/browse-service";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { definitionResponseSchema } from "../schemas/definition";
 import {
@@ -7,7 +9,7 @@ import {
   savedWordItemSchema,
 } from "../schemas/dictionary";
 import { userListItemSchema } from "../schemas/user";
-import { authErrorResponses, authenticatedSecurity, jsonContent, notImplemented } from "./helpers";
+import { authErrorResponses, authenticatedSecurity, jsonContent } from "./helpers";
 
 const getOverviewRoute = createRoute({
   method: "get",
@@ -77,9 +79,50 @@ const getMutesRoute = createRoute({
   },
 });
 
-export const meRoutes = new OpenAPIHono()
-  .openapi(getOverviewRoute, notImplemented)
-  .openapi(getDefinedWordsRoute, notImplemented)
-  .openapi(getMyDefinitionsRoute, notImplemented)
-  .openapi(getSavedWordsRoute, notImplemented)
-  .openapi(getMutesRoute, notImplemented);
+type MeRouteEnvironment = {
+  Bindings: { AVATAR_BASE_URL: string; DB: D1Database };
+  Variables: AuthenticationVariables;
+};
+
+export const meRoutes = new OpenAPIHono<MeRouteEnvironment>()
+  .openapi(getOverviewRoute, async (context) => {
+    const result = await new BrowseService(context.env).getMyOverview(context.get("firebaseUid"));
+    return context.json(result, 200);
+  })
+  .openapi(getDefinedWordsRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).listDefinedWords(
+      context.get("firebaseUid"),
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  })
+  .openapi(getMyDefinitionsRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).listMyDefinitions(
+      context.get("firebaseUid"),
+      query.limit,
+      query.status,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  })
+  .openapi(getSavedWordsRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).listSavedWords(
+      context.get("firebaseUid"),
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  })
+  .openapi(getMutesRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).listMutes(
+      context.get("firebaseUid"),
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  });

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -1,8 +1,10 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { AuthenticationVariables } from "../auth/middleware";
+import { BrowseService } from "../browse/browse-service";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { userListItemSchema } from "../schemas/user";
 import { wordListItemSchema } from "../schemas/word";
-import { authErrorResponses, authenticatedSecurity, jsonContent, notImplemented } from "./helpers";
+import { authErrorResponses, authenticatedSecurity, jsonContent } from "./helpers";
 
 const searchQuerySchema = paginationQuerySchema.extend({
   q: z.string().min(1),
@@ -34,6 +36,29 @@ const searchUsersRoute = createRoute({
   },
 });
 
-export const searchRoutes = new OpenAPIHono()
-  .openapi(searchWordsRoute, notImplemented)
-  .openapi(searchUsersRoute, notImplemented);
+type SearchRouteEnvironment = {
+  Bindings: { AVATAR_BASE_URL: string; DB: D1Database };
+  Variables: AuthenticationVariables;
+};
+
+export const searchRoutes = new OpenAPIHono<SearchRouteEnvironment>()
+  .openapi(searchWordsRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).searchWords(
+      context.get("firebaseUid"),
+      query.q,
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  })
+  .openapi(searchUsersRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).searchUsers(
+      context.get("firebaseUid"),
+      query.q,
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  });

--- a/server/src/routes/timeline.ts
+++ b/server/src/routes/timeline.ts
@@ -1,8 +1,10 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import type { AuthenticationVariables } from "../auth/middleware";
+import { BrowseService } from "../browse/browse-service";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { definitionResponseSchema } from "../schemas/definition";
 import { discoverFeedItemSchema } from "../schemas/timeline";
-import { authErrorResponses, authenticatedSecurity, jsonContent, notImplemented } from "./helpers";
+import { authErrorResponses, authenticatedSecurity, jsonContent } from "./helpers";
 
 const discoverRoute = createRoute({
   method: "get",
@@ -32,6 +34,27 @@ const followingRoute = createRoute({
   },
 });
 
-export const timelineRoutes = new OpenAPIHono()
-  .openapi(discoverRoute, notImplemented)
-  .openapi(followingRoute, notImplemented);
+type TimelineRouteEnvironment = {
+  Bindings: { AVATAR_BASE_URL: string; DB: D1Database };
+  Variables: AuthenticationVariables;
+};
+
+export const timelineRoutes = new OpenAPIHono<TimelineRouteEnvironment>()
+  .openapi(discoverRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).listDiscover(
+      context.get("firebaseUid"),
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  })
+  .openapi(followingRoute, async (context) => {
+    const query = context.req.valid("query");
+    const result = await new BrowseService(context.env).listFollowing(
+      context.get("firebaseUid"),
+      query.limit,
+      query.cursor,
+    );
+    return context.json(result, 200);
+  });

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { AuthenticationVariables } from "../auth/middleware";
+import { BrowseService } from "../browse/browse-service";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { definitionResponseSchema } from "../schemas/definition";
 import { userDictionaryItemSchema } from "../schemas/dictionary";
@@ -11,13 +12,7 @@ import {
   userResponseSchema,
 } from "../schemas/user";
 import { AvatarService, UserService, type UserServiceOptions } from "../users/user-service";
-import {
-  authErrorResponses,
-  authenticatedSecurity,
-  errorContent,
-  jsonContent,
-  notImplemented,
-} from "./helpers";
+import { authErrorResponses, authenticatedSecurity, errorContent, jsonContent } from "./helpers";
 
 const userIdParams = z.object({ id: z.string() });
 
@@ -331,9 +326,33 @@ export function createUserRoutes(options: UserServiceOptions = {}) {
       );
       return context.json(user, 200);
     })
-    .openapi(getUserDictionaryRoute, notImplemented)
-    .openapi(getUserDefinitionsRoute, notImplemented)
-    .openapi(getUserLikedDefinitionsRoute, notImplemented)
+    .openapi(getUserDictionaryRoute, async (context) => {
+      const query = context.req.valid("query");
+      const result = await new BrowseService(context.env).listUserDictionary(
+        context.req.valid("param").id,
+        query.limit,
+        query.cursor,
+      );
+      return context.json(result, 200);
+    })
+    .openapi(getUserDefinitionsRoute, async (context) => {
+      const result = await new BrowseService(context.env).listUserDefinitions(
+        context.get("firebaseUid"),
+        context.req.valid("param").id,
+        context.req.valid("query"),
+      );
+      return context.json(result, 200);
+    })
+    .openapi(getUserLikedDefinitionsRoute, async (context) => {
+      const query = context.req.valid("query");
+      const result = await new BrowseService(context.env).listLikedDefinitions(
+        context.get("firebaseUid"),
+        context.req.valid("param").id,
+        query.limit,
+        query.cursor,
+      );
+      return context.json(result, 200);
+    })
     .openapi(getFollowersRoute, async (context) => {
       const query = context.req.valid("query");
       const result = await users(context.env).listRelatedUsers(

--- a/server/src/routes/words.ts
+++ b/server/src/routes/words.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { AuthenticationVariables } from "../auth/middleware";
+import { BrowseService } from "../browse/browse-service";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { definitionResponseSchema } from "../schemas/definition";
 import {
@@ -10,13 +11,7 @@ import {
   wordResponseSchema,
 } from "../schemas/word";
 import { WordConflictError, WordService } from "../words/word-service";
-import {
-  authErrorResponses,
-  authenticatedSecurity,
-  errorContent,
-  jsonContent,
-  notImplemented,
-} from "./helpers";
+import { authErrorResponses, authenticatedSecurity, errorContent, jsonContent } from "./helpers";
 
 const wordIdParams = z.object({ id: z.string() });
 
@@ -156,7 +151,7 @@ const unsaveWordRoute = createRoute({
 });
 
 type WordRouteEnvironment = {
-  Bindings: { DB: D1Database };
+  Bindings: { AVATAR_BASE_URL: string; DB: D1Database };
   Variables: AuthenticationVariables;
 };
 
@@ -211,7 +206,14 @@ export const wordRoutes = new OpenAPIHono<WordRouteEnvironment>()
       throw error;
     }
   })
-  .openapi(listWordDefinitionsRoute, notImplemented)
+  .openapi(listWordDefinitionsRoute, async (context) => {
+    const result = await new BrowseService(context.env).listWordDefinitions(
+      context.get("firebaseUid"),
+      context.req.valid("param").id,
+      context.req.valid("query"),
+    );
+    return context.json(result, 200);
+  })
   .openapi(saveWordRoute, async (context) => {
     await new WordService(context.env).save(
       context.get("firebaseUid"),

--- a/server/test/app-auth.test.ts
+++ b/server/test/app-auth.test.ts
@@ -47,18 +47,15 @@ describe("createApp", () => {
   });
 
   test("両トークンの検証後に認証必須ルートへ到達する", async () => {
-    // #193 実装までは未実装（501）の /v1/me/mutes で到達確認する
-    const response = await testApp().request("/v1/me/mutes", {
+    // limit=0 のバリデーションエラーで、認証を通過して実ルートへ到達したことを確認する
+    const response = await testApp().request("/v1/me/mutes?limit=0", {
       headers: {
         Authorization: "Bearer valid-id-token",
         "X-Firebase-AppCheck": "valid-app-check",
       },
     });
 
-    expect(response.status).toBe(501);
-    expect(await response.json<unknown>()).toEqual({
-      error: { code: "not_implemented", message: "not implemented" },
-    });
+    expect(response.status).toBe(400);
   });
 
   test("認証で拒否したリクエストにも request ID と構造化ログを付ける", async () => {

--- a/server/worker-test/browse.workers.ts
+++ b/server/worker-test/browse.workers.ts
@@ -1,0 +1,322 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createApp } from "../src/app";
+
+const authHeaders = {
+  Authorization: "Bearer valid-id-token",
+  "X-Firebase-AppCheck": "valid-app-check",
+};
+
+type Page<T> = { items: T[]; nextCursor: string | null };
+
+function testApp(uid: string) {
+  return createApp({
+    logRequest: () => {},
+    verifyAppCheck: async () => ({ appId: "test-app-id" }),
+    verifyFirebaseIdToken: async () => ({ uid }),
+  });
+}
+
+async function request(uid: string, path: string) {
+  return testApp(uid).request(path, { headers: authHeaders }, env);
+}
+
+async function insertUser(id: string, name = id, publicId = `${id}-public`) {
+  await env.DB.prepare(
+    `insert into users
+       (id, public_id, name, bio, last_os_version, last_app_version, created_at, updated_at)
+     values (?, ?, ?, '', 'iOS 19', '2.0.0', 1, 1)`,
+  )
+    .bind(id, publicId, name)
+    .run();
+}
+
+async function insertWord(
+  id: string,
+  word: string,
+  reading: string,
+  createdBy: string,
+  createdAt: number,
+) {
+  await env.DB.prepare(
+    `insert into words
+       (id, word, reading, reading_sub_group, created_by, created_at, updated_at)
+     values (?, ?, ?, 'あ', ?, ?, ?)`,
+  )
+    .bind(id, word, reading, createdBy, createdAt, createdAt)
+    .run();
+}
+
+async function insertDefinition(
+  id: string,
+  wordId: string,
+  authorId: string,
+  status: "draft" | "public" | "private",
+  timestamp: number,
+) {
+  await env.DB.prepare(
+    `insert into definitions
+       (id, word_id, author_id, body, status, finalized_at, is_edited, created_at, updated_at)
+     values (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+  )
+    .bind(
+      id,
+      wordId,
+      authorId,
+      `${id} body`,
+      status,
+      status === "draft" ? null : timestamp,
+      timestamp,
+      timestamp,
+    )
+    .run();
+}
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  await env.DB.batch([
+    env.DB.prepare("delete from users"),
+    env.DB.prepare("delete from words"),
+    env.DB.prepare("delete from app_config"),
+  ]);
+});
+
+describe("dictionary and definition lists", () => {
+  test("公開辞書は public 定義だけを言葉単位に集計し、本人の定義一覧は非公開も返す", async () => {
+    await insertUser("alice");
+    await insertUser("bob");
+    await insertWord("w1", "朝", "あさ", "alice", 10);
+    await insertWord("w2", "夜", "よる", "alice", 20);
+    await insertDefinition("public-1", "w1", "alice", "public", 100);
+    await insertDefinition("public-2", "w1", "alice", "public", 200);
+    await insertDefinition("private", "w2", "alice", "private", 300);
+    await insertDefinition("draft", "w2", "alice", "draft", 400);
+
+    const dictionary = await request("bob", "/v1/users/alice/dictionary");
+    expect(dictionary.status).toBe(200);
+    await expect(dictionary.json()).resolves.toMatchObject({
+      items: [{ publicCount: 2, word: { id: "w1" } }],
+      nextCursor: null,
+    });
+
+    const own = await request("alice", "/v1/users/alice/definitions?limit=10");
+    expect(own.status).toBe(200);
+    const ownBody = await own.json<Page<{ id: string }>>();
+    expect(ownBody.items.map((item) => item.id)).toEqual(["private", "public-2", "public-1"]);
+
+    const other = await request("bob", "/v1/users/alice/definitions?limit=10");
+    const otherBody = await other.json<Page<{ id: string }>>();
+    expect(otherBody.items.map((item) => item.id)).toEqual(["public-2", "public-1"]);
+  });
+
+  test("いいね一覧はいいね日時順で、閲覧者から不可視な定義を除外する", async () => {
+    await insertUser("alice");
+    await insertUser("bob");
+    await insertUser("carol");
+    await insertWord("w1", "朝", "あさ", "alice", 10);
+    await insertDefinition("public", "w1", "alice", "public", 100);
+    await insertDefinition("private", "w1", "alice", "private", 200);
+    await env.DB.batch([
+      env.DB.prepare("insert into likes values ('carol', 'public', 10)"),
+      env.DB.prepare("insert into likes values ('carol', 'private', 20)"),
+    ]);
+
+    const response = await request("bob", "/v1/users/carol/liked-definitions");
+    expect(response.status).toBe(200);
+    const body = await response.json<Page<{ id: string }>>();
+    expect(body.items.map((item) => item.id)).toEqual(["public"]);
+  });
+});
+
+describe("my dictionary lists", () => {
+  test("概要・定義済み言葉・状態別定義・保存・ミュートを返す", async () => {
+    await insertUser("alice");
+    await insertUser("bob", "Bob");
+    await insertWord("w1", "朝", "あさ", "alice", 10);
+    await insertWord("w2", "夜", "よる", "bob", 20);
+    await insertDefinition("public", "w1", "alice", "public", 100);
+    await insertDefinition("private", "w1", "alice", "private", 200);
+    await insertDefinition("draft", "w2", "alice", "draft", 300);
+    await env.DB.batch([
+      env.DB.prepare("insert into saved_words values ('alice', 'w2', 400)"),
+      env.DB.prepare("insert into user_mutes values ('alice', 'bob', 500)"),
+    ]);
+
+    const overview = await request("alice", "/v1/me/dictionary/overview");
+    expect(overview.status).toBe(200);
+    await expect(overview.json()).resolves.toMatchObject({
+      definedWordCount: 2,
+      draftCount: 1,
+      savedWordCount: 1,
+      recentDefinitions: [{ id: "draft" }, { id: "private" }, { id: "public" }],
+    });
+
+    const definedWords = await request("alice", "/v1/me/defined-words");
+    await expect(definedWords.json()).resolves.toMatchObject({
+      items: [
+        { draftCount: 0, privateCount: 1, publicCount: 1, word: { id: "w1" } },
+        { draftCount: 1, privateCount: 0, publicCount: 0, word: { id: "w2" } },
+      ],
+    });
+
+    const drafts = await request("alice", "/v1/me/definitions?status=draft");
+    await expect(drafts.json()).resolves.toMatchObject({ items: [{ id: "draft" }] });
+
+    const saved = await request("alice", "/v1/me/saved-words");
+    await expect(saved.json()).resolves.toMatchObject({
+      items: [{ isDefinedByMe: true, word: { id: "w2" } }],
+    });
+
+    const mutes = await request("alice", "/v1/me/mutes");
+    await expect(mutes.json()).resolves.toMatchObject({
+      items: [{ id: "bob", isMutedByMe: true, name: "Bob" }],
+    });
+  });
+});
+
+describe("word definition lists", () => {
+  test("scope とリアクション順を適用し keyset で重複なくページングする", async () => {
+    await insertUser("alice");
+    await insertUser("bob");
+    await insertUser("carol");
+    await insertWord("w1", "朝", "あさ", "alice", 10);
+    await insertDefinition("mine-private", "w1", "alice", "private", 100);
+    await insertDefinition("bob-public", "w1", "bob", "public", 200);
+    await insertDefinition("carol-public", "w1", "carol", "public", 300);
+    await env.DB.batch([
+      env.DB.prepare("insert into likes values ('alice', 'bob-public', 1)"),
+      env.DB.prepare("insert into likes values ('carol', 'bob-public', 2)"),
+      env.DB.prepare("insert into likes values ('alice', 'carol-public', 3)"),
+    ]);
+
+    const first = await request(
+      "alice",
+      "/v1/words/w1/definitions?scope=all&sort=reactions&limit=1",
+    );
+    expect(first.status).toBe(200);
+    const firstBody = await first.json<Page<{ id: string }>>();
+    expect(firstBody.items.map((item) => item.id)).toEqual(["bob-public"]);
+    expect(firstBody.nextCursor).not.toBeNull();
+
+    const second = await request(
+      "alice",
+      `/v1/words/w1/definitions?scope=all&sort=reactions&limit=2&cursor=${firstBody.nextCursor}`,
+    );
+    const secondBody = await second.json<Page<{ id: string }>>();
+    expect(secondBody.items.map((item) => item.id)).toEqual(["carol-public", "mine-private"]);
+  });
+
+  test("論理削除済みユーザーのいいねは表示件数にもリアクション順にも含めない", async () => {
+    await insertUser("alice");
+    await insertUser("bob");
+    await insertUser("carol");
+    await insertUser("deleted");
+    await insertWord("w1", "朝", "あさ", "alice", 10);
+    await insertDefinition("older", "w1", "bob", "public", 100);
+    await insertDefinition("newer", "w1", "carol", "public", 200);
+    await env.DB.batch([
+      env.DB.prepare("insert into likes values ('alice', 'older', 1)"),
+      env.DB.prepare("insert into likes values ('deleted', 'older', 2)"),
+      env.DB.prepare("insert into likes values ('alice', 'newer', 3)"),
+      env.DB.prepare("update users set deleted_at = 4 where id = 'deleted'"),
+    ]);
+
+    const first = await request(
+      "alice",
+      "/v1/words/w1/definitions?scope=all&sort=reactions&limit=1",
+    );
+    const firstBody = await first.json<Page<{ id: string; likesCount: number }>>();
+    expect(firstBody.items).toMatchObject([{ id: "newer", likesCount: 1 }]);
+    expect(firstBody.nextCursor).not.toBeNull();
+
+    const second = await request(
+      "alice",
+      `/v1/words/w1/definitions?scope=all&sort=reactions&limit=1&cursor=${firstBody.nextCursor}`,
+    );
+    const secondBody = await second.json<Page<{ id: string; likesCount: number }>>();
+    expect(secondBody.items).toMatchObject([{ id: "older", likesCount: 1 }]);
+  });
+});
+
+describe("timelines and search", () => {
+  test("見つけるは定義と言葉を完全な新着順で混在し、ミュート対象を除外する", async () => {
+    await insertUser("alice");
+    await insertUser("bob");
+    await insertUser("carol");
+    await insertWord("old-word", "古", "ふる", "carol", 100);
+    await insertWord("muted-word", "無音", "むおん", "bob", 400);
+    await insertDefinition("new-definition", "old-word", "carol", "public", 300);
+    await insertDefinition("muted-definition", "old-word", "bob", "public", 500);
+    await env.DB.prepare("insert into user_mutes values ('alice', 'bob', 1)").run();
+
+    const response = await request("alice", "/v1/timeline/discover");
+    expect(response.status).toBe(200);
+    const body =
+      await response.json<
+        Page<{ type: string; definition?: { id: string }; word?: { id: string } }>
+      >();
+    expect(body.items).toMatchObject([
+      { definition: { id: "new-definition" }, type: "definition" },
+      { type: "wordRegistered", word: { id: "old-word" } },
+    ]);
+  });
+
+  test("フォロー中はフォロー対象の公開定義だけを返しミュートを優先する", async () => {
+    await insertUser("alice");
+    await insertUser("bob");
+    await insertUser("carol");
+    await insertWord("w1", "朝", "あさ", "bob", 10);
+    await insertDefinition("bob-public", "w1", "bob", "public", 200);
+    await insertDefinition("carol-public", "w1", "carol", "public", 300);
+    await env.DB.batch([
+      env.DB.prepare("insert into follows values ('alice', 'bob', 1)"),
+      env.DB.prepare("insert into follows values ('alice', 'carol', 2)"),
+      env.DB.prepare("insert into user_mutes values ('alice', 'carol', 3)"),
+    ]);
+
+    const response = await request("alice", "/v1/timeline/following");
+    const body = await response.json<Page<{ id: string }>>();
+    expect(body.items.map((item) => item.id)).toEqual(["bob-public"]);
+  });
+
+  test("言葉・ユーザーを部分一致検索し、ミュート対象とその登録語を除外する", async () => {
+    await insertUser("alice", "Alice", "111111111");
+    await insertUser("bob", "Bobby", "222222222");
+    await insertUser("carol", "Carol", "333333333");
+    await insertWord("w1", "朝焼け", "あさやけ", "bob", 10);
+    await insertWord("w2", "朝食", "ちょうしょく", "carol", 20);
+    await env.DB.prepare("insert into user_mutes values ('alice', 'bob', 1)").run();
+
+    const words = await request("alice", "/v1/search/words?q=%E6%9C%9D");
+    expect(words.status).toBe(200);
+    const wordBody = await words.json<Page<{ id: string }>>();
+    expect(wordBody.items.map((item) => item.id)).toEqual(["w2"]);
+
+    const users = await request("alice", "/v1/search/users?q=2");
+    const userBody = await users.json<Page<{ id: string }>>();
+    expect(userBody.items).toEqual([]);
+  });
+});
+
+describe("query plans", () => {
+  test("主要一覧は設計済みインデックスを使用できる", async () => {
+    const definitionPlan = await env.DB.prepare(
+      `explain query plan
+       select id from definitions
+       where status = 'public' and deleted_at is null
+       order by finalized_at desc, id desc limit 21`,
+    ).all<{ detail: string }>();
+    expect(definitionPlan.results.map((row) => row.detail).join("\n")).toContain(
+      "definitions_timeline_idx",
+    );
+
+    const wordPlan = await env.DB.prepare(
+      `explain query plan
+       select id from words order by reading_sub_group, reading, id limit 21`,
+    ).all<{ detail: string }>();
+    expect(wordPlan.results.map((row) => row.detail).join("\n")).toContain(
+      "words_reading_order_idx",
+    );
+  });
+});

--- a/server/worker-test/browse.workers.ts
+++ b/server/worker-test/browse.workers.ts
@@ -2,6 +2,8 @@ import { applyD1Migrations, env } from "cloudflare:test";
 import { beforeEach, describe, expect, test } from "vitest";
 
 import { createApp } from "../src/app";
+import { BrowseService } from "../src/browse/browse-service";
+import { encodeOpaqueCursor } from "../src/lib/cursor";
 
 const authHeaders = {
   Authorization: "Bearer valid-id-token",
@@ -9,6 +11,21 @@ const authHeaders = {
 };
 
 type Page<T> = { items: T[]; nextCursor: string | null };
+type RecordedQuery = { bindings: unknown[]; sql: string };
+
+function recordingDatabase(database: D1Database, queries: RecordedQuery[]): D1Database {
+  return {
+    prepare(sql: string) {
+      const statement = database.prepare(sql);
+      return {
+        bind(...bindings: unknown[]) {
+          queries.push({ bindings, sql });
+          return statement.bind(...bindings);
+        },
+      } as D1PreparedStatement;
+    },
+  } as D1Database;
+}
 
 function testApp(uid: string) {
   return createApp({
@@ -240,6 +257,23 @@ describe("word definition lists", () => {
 });
 
 describe("timelines and search", () => {
+  test("見つけるは未知の activity type を持つカーソルを拒否する", async () => {
+    const cursor = encodeOpaqueCursor({
+      id: "activity-id",
+      kind: "timeline_discover",
+      sortAt: 100,
+      type: "unknown",
+      version: 1,
+    });
+
+    const response = await request("alice", `/v1/timeline/discover?cursor=${cursor}`);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "invalid_cursor", message: "Invalid cursor" },
+    });
+  });
+
   test("見つけるは定義と言葉を完全な新着順で混在し、ミュート対象を除外する", async () => {
     await insertUser("alice");
     await insertUser("bob");
@@ -297,26 +331,65 @@ describe("timelines and search", () => {
     const userBody = await users.json<Page<{ id: string }>>();
     expect(userBody.items).toEqual([]);
   });
+
+  test("言葉検索の公開定義数は論理削除済み作者の定義を除外する", async () => {
+    await insertUser("alice");
+    await insertUser("deleted-author");
+    await insertWord("w1", "朝", "あさ", "alice", 10);
+    await insertDefinition("hidden", "w1", "deleted-author", "public", 100);
+    await env.DB.prepare("update users set deleted_at = 200 where id = 'deleted-author'").run();
+
+    const response = await request("alice", "/v1/search/words?q=%E6%9C%9D");
+    const body = await response.json<Page<{ id: string; publicDefinitionCount: number }>>();
+
+    expect(body.items).toMatchObject([{ id: "w1", publicDefinitionCount: 0 }]);
+  });
 });
 
 describe("query plans", () => {
-  test("主要一覧は設計済みインデックスを使用できる", async () => {
-    const definitionPlan = await env.DB.prepare(
-      `explain query plan
-       select id from definitions
-       where status = 'public' and deleted_at is null
-       order by finalized_at desc, id desc limit 21`,
-    ).all<{ detail: string }>();
+  test("主要一覧の本番クエリは設計済みアクセスパスを使用する", async () => {
+    const queries: RecordedQuery[] = [];
+    const service = new BrowseService({
+      AVATAR_BASE_URL: "https://example.com/avatars",
+      DB: recordingDatabase(env.DB, queries),
+    });
+    await service.listFollowing(
+      "alice",
+      20,
+      encodeOpaqueCursor({
+        id: "definition-id",
+        kind: "timeline_following",
+        sortAt: 100,
+        version: 1,
+      }),
+    );
+    await service.searchWords(
+      "alice",
+      "朝",
+      20,
+      encodeOpaqueCursor({
+        id: "word-id",
+        kind: "search_words",
+        reading: "あさ",
+        version: 1,
+      }),
+    );
+
+    const definitionQuery = queries.find((query) => query.sql.includes("from definitions d"));
+    expect(definitionQuery).toBeDefined();
+    const definitionPlan = await env.DB.prepare(`explain query plan ${definitionQuery!.sql}`)
+      .bind(...definitionQuery!.bindings)
+      .all<{ detail: string }>();
     expect(definitionPlan.results.map((row) => row.detail).join("\n")).toContain(
       "definitions_timeline_idx",
     );
 
-    const wordPlan = await env.DB.prepare(
-      `explain query plan
-       select id from words order by reading_sub_group, reading, id limit 21`,
-    ).all<{ detail: string }>();
-    expect(wordPlan.results.map((row) => row.detail).join("\n")).toContain(
-      "words_reading_order_idx",
-    );
+    const wordQuery = queries.find((query) => query.sql.includes("from words w"));
+    expect(wordQuery).toBeDefined();
+    const wordPlan = await env.DB.prepare(`explain query plan ${wordQuery!.sql}`)
+      .bind(...wordQuery!.bindings)
+      .all<{ detail: string }>();
+    // LIKE 検索本体の全走査は設計上許容する。公開定義数の相関サブクエリは複合 index を使う。
+    expect(wordPlan.results.map((row) => row.detail).join("\n")).toContain("definitions_word_idx");
   });
 });


### PR DESCRIPTION
## 概要

Issue #193 の辞書・一覧・タイムライン・検索 API を実装しました。

## 変更内容

- 自分・他者の辞書、定義、保存、ミュート一覧を実装
- 見つける / フォロー中タイムラインと検索をミュート除外込みで実装
- 全一覧に keyset pagination を適用
- 合成 DTO の有効行集計と主要クエリの EXPLAIN QUERY PLAN テストを追加
- DocBridge の双方向リンクを追加

## 検証

- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bun run test`（unit 73件、Workers 79件）
- `nix develop --command just docbridge-check`
- OpenAPI 再生成差分なし

## DocBridge related-gate 判断

- `辞書と一覧`: 論理削除済み作者を集計から除外する修正は、既存仕様の「有効な行だけを集計」に実装を一致させるもので、仕様更新は不要。
- `タイムラインと検索`: activity type のカーソル検証強化と EXPLAIN テストの実クエリ化であり、既存の並び順・ミュート除外・部分一致検索の契約は変更しないため、仕様更新は不要。
- CI が列挙した他の linked counterpart 12件: Markdown に BrowseService の backlink を追加したためファイル全体が変更扱いになったもの。認証・リクエスト処理・ユーザー・言葉・定義の各契約に変更はなく、コード更新は不要。

closes #193