### PR TITLE
feat: 物理削除 Cron と dev Workers 配備を完了

### DIFF
--- a/doc/plans/done/2026-07-15-workers-api-server-implementation.md
+++ b/doc/plans/done/2026-07-15-workers-api-server-implementation.md
@@ -11,7 +11,7 @@ Issue #184 のフェーズ 3 として、フェーズ 2 で定義済みの OpenA
 - `server/openapi.json` に定義済みの全エンドポイントの実ハンドラ
 - Firebase ID トークンと App Check トークンの検証
 - D1 を使うクエリ、状態遷移、認可、keyset pagination
-- R2 を使うアバターの保存・削除・公開 URL 解決
+- R2 を使うアバターの保存・削除・認証付き Worker URL 解決
 - 30 日経過した論理削除データの Scheduled Handler による物理削除
 - dev / prod の Wrangler 設定と Cloudflare リソース
 - 構造化ログ、テスト、仕様書、DocBridge リンク
@@ -33,7 +33,7 @@ Issue #184 のフェーズ 3 として、フェーズ 2 で定義済みの OpenA
 - Wrangler のローカル既定環境に加え、dev / prod を別 Worker・別 D1・別 R2 として構成する
 - dev / prod のリソースは作成する。#184 では dev のみ手動デプロイし、prod は設定検証までとする
 - `just server-deploy-dev` を手動デプロイの正規コマンドとし、自動デプロイは導入しない
-- アバターは dev では r2.dev、prod では R2 カスタムドメインから直接配信する
+- R2 bucket は非公開とし、アバターは App Check と Firebase ID token が必須の Workers API から配信する
 
 ### 認証と保護
 
@@ -60,6 +60,7 @@ Issue #184 のフェーズ 3 として、フェーズ 2 で定義済みの OpenA
 - サーバー上限は通常到達しない安全弁として 10 MiB とする
 - #185 で HEIC を含む選択元画像を 512 x 512 JPEG quality 85 に正規化してから送信する
 - R2 オブジェクトキーはユーザー単位で固定し、再アップロードは上書き、削除は冪等とする
+- `avatarUrl` は認証付き `GET /v1/avatars/{id}` を指し、Flutter 側も画像取得時に両認証ヘッダーを付ける
 
 ### 物理削除
 

--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -12,9 +12,9 @@ Flutter repository の接続、Firestore / Firebase Storage の既存データ�
 
 | 環境 | Worker | Firebase | D1 | R2 | 配信 |
 |---|---|---|---|---|---|
-| local | `wrangler dev` | dev project | local D1 | local R2 | ローカル |
-| dev | `teigiii-api-dev` | dev project | dev 専用 | dev 専用 | r2.dev |
-| prod | `teigiii-api-prod` | prod project | prod 専用 | prod 専用 | R2 custom domain |
+| local | `teigiii-api` | `everyone-teigi-dev` | `teigiii-local` | `teigiii-local-avatars` | 認証付き Worker API |
+| dev | `teigiii-api-dev` | `everyone-teigi-dev` | `teigiii-dev` | `teigiii-dev-avatars` | 認証付き Worker API |
+| prod | `teigiii-api-prod` | `everyone-teigi-prod` | `teigiii-prod` | `teigiii-prod-avatars` | 認証付き Worker API |
 
 Firebase project ID と project number は公開識別子として Wrangler vars に置く。トークン、秘密鍵、Cloudflare API token はコード、設定ファイル、ログへ保存しない。
 
@@ -112,6 +112,7 @@ JWT、Authorization、App Check token、プロフィール内容などの個人�
 
 ## API 振る舞い
 
+<!-- @code server/src/config/app-config-service.ts#AppConfigService -->
 ### App config
 
 `GET /v1/app-config` は D1 の `app_config` 単一行を返す。Firebase ID トークンは不要だが App Check は必須とする。単一行がなければ500とし、暗黙の既定値では起動を続けない。
@@ -135,7 +136,11 @@ JWT、Authorization、App Check token、プロフィール内容などの個人�
 
 Issue `#185` の Flutter クライアントは HEIC を含む元画像を切り抜き、512 x 512 JPEG quality 85 に変換して送る。R2 key はユーザー単位で固定し、再アップロードは上書きする。削除は R2 object がなくても成功する。
 
-R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object の HTTP metadata に検証済み Content-Type を保存する。レスポンスの `avatarUrl` は環境変数 `AVATAR_BASE_URL` と key を結合して解決する。dev は対象 bucket の r2.dev URL、prod は R2 custom domain を `AVATAR_BASE_URL` に設定し、Worker を介さず直接配信する。
+R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object の HTTP metadata に検証済み Content-Type を保存する。bucket に r2.dev URL または R2 custom domain を設定せず、object は公開しない。
+
+レスポンスの `avatarUrl` は `<AVATAR_BASE_URL>/avatars/<URL エンコード済み Firebase UID>` とする。`AVATAR_BASE_URL` は各環境の Worker API `/v1` URLを指す。`GET /v1/avatars/{id}` は App Check と Firebase ID token に加え、閲覧者と対象ユーザーが論理削除されていないことを検証してから R2 object を返す。応答は保存済み Content-Type、`ETag`、`Cache-Control: private, max-age=300`、`X-Content-Type-Options: nosniff` を設定する。URLだけを知る未認証者には画像を返さない。
+
+#185 の Flutter クライアントは通常 API と同様に画像取得へ `X-Firebase-AppCheck` と `Authorization` ヘッダーを付ける。
 
 <!-- @code server/src/words/word-service.ts#WordService -->
 ### 言葉
@@ -172,11 +177,14 @@ R2 key は `avatars/<URL エンコード済み Firebase UID>` とし、object �
 - 言葉検索は表記・よみの部分一致、ユーザー検索は表示名・publicId の部分一致を適用する
 - リアクション数順はページ移動中の件数変動による重複・欠落を許容する
 
+<!-- @code server/src/maintenance/physical-deletion.ts#runPhysicalDeletion -->
 ## 物理削除
 
 Scheduled Handler は30日以前に論理削除された定義とユーザーを物理削除する。ユーザー削除では R2 アバターを削除してから D1 ユーザーを削除し、FK CASCADE で関連行と定義を削除する。`words.created_by` は SET NULL とし、言葉自体は残す。
 
-処理は再実行可能とし、対象件数、成功件数、失敗件数を構造化ログへ記録する。dev ではローカル scheduled endpoint から手動検証し、prod Cron は #186 で有効化する。
+期限は Scheduled Event の `scheduledTime - 30日` とし、`deleted_at` が期限と同値の行も対象に含める。定義は一括削除し、ユーザーは R2 削除後に1件ずつ D1 から削除する。R2 またはユーザー D1 削除に失敗した場合は当該ユーザーを D1 に保持して他のユーザーを継続する。定義の一括削除に失敗した場合もユーザー削除は継続する。残った対象は次回実行で再試行するため、処理は冪等である。
+
+完了ログは定義とユーザーごとに `target`、`success`、`failure` を記録する。失敗ログは対象種別、`avatar_delete` / `database_delete` の段階、例外型だけを記録し、UID、R2 key、例外メッセージ、stack trace は含めない。dev では remote bindings を使う scheduled endpoint から手動検証し、prod Cron は #186 で有効化する。
 
 ## テストと検証
 
@@ -190,6 +198,44 @@ Scheduled Handler は30日以前に論理削除された定義とユーザーを
 
 ## 運用
 
-dev デプロイ後は認証付き smoke test で app-config、D1 読み書き、R2 アバター、Scheduled Handler を確認する。Cloudflare Dashboard では Workers request、D1 rows read / written、R2 storage / operation の利用量を確認する。
+### dev デプロイと smoke test
 
-prod の使用量通知設定とデプロイは #186 の切替チェックリストに含める。Firebase / Cloudflare の秘密情報は Wrangler secrets または GitHub secrets にのみ保存する。
+1. 初回 deploy で確定した `teigiii-api-dev` の workers.dev URL に `/v1` を付け、`server/wrangler.toml` の dev `AVATAR_BASE_URL` を置き換える。R2 public access は有効化しない。
+2. `just server-deploy-dev` を実行する。このコマンドは D1 migration、`app_config` 初期行の冪等な作成、`teigiii-api-dev` の deploy を順に行う。
+3. dev Firebase の正規トークンを shell 環境だけに設定し、次を実行する。トークンをファイル、shell history、ログへ保存しない。
+
+```bash
+TEIGIII_API_BASE_URL=https://teigiii-api-dev.tetsuo21ad.workers.dev \
+FIREBASE_ID_TOKEN='<dev Firebase ID token>' \
+FIREBASE_APP_CHECK_TOKEN='<dev App Check token>' \
+just server-smoke-dev
+```
+
+smoke test は app-config、認証、D1 のユーザー作成・更新、非公開 R2 アバターの upload・URL 単独アクセスの401・認証付き取得・delete を確認する。ユーザーが既存なら作成の409を許容し、更新で D1 write を検証する。
+
+Scheduled Handler は次のように remote dev D1 / R2 に対して手動検証する。
+
+```bash
+# terminal A
+just server-dev-remote-scheduled
+
+# terminal B
+curl 'http://localhost:8787/__scheduled?cron=0+3+*+*+*'
+```
+
+30日以前へ backdate した dev 専用 fixture を事前に用意し、HTTP 200、構造化ログの件数、D1 行と R2 object の削除を確認する。本番データを fixture に使わない。Wrangler 4.110 の `--remote --test-scheduled` は互換 endpoint `/__scheduled` を使う。
+
+### prod 切替前検証
+
+`just server-validate-prod` で `teigiii-api-prod`、`teigiii-prod`、`teigiii-prod-avatars`、prod Firebase vars の bundle / bindings 解決を dry-run する。#186 では prod `AVATAR_BASE_URL` の `.invalid` 値を実 Worker API `/v1` URLへ置き換え、R2 public access が無効であることを確認する。同コマンドを再実行してから prod deploy と Cron Trigger 有効化を行う。Cron は Wrangler 設定を正本とし、UTC の実行時刻を切替チェックリストで確定する。
+
+### 使用量監視と通知
+
+- Workers request / CPU、D1 rows read / written と storage、R2 storage / Class A / Class B operations を各 product の Analytics で確認する。
+- Pay-as-you-go account では Cloudflare Dashboard の `Manage Account > Billing > Billable Usage > Create budget alert` から account 全体の USD 閾値と通知先を設定する。
+- Professional 以上かつ Pay-as-you-go で product 別通知が利用できる場合は `Notifications > Add > Billable Usage` から Workers / R2 等の閾値を設定する。
+- budget alert と usage notification は停止・上限制御ではない。通知後は Billable Usage と product Analytics を確認し、想定外の呼び出し元、Cron 頻度、D1 query、R2 operation を切り分ける。
+
+参考: [Cloudflare Budget alerts](https://developers.cloudflare.com/billing/manage/budget-alerts/)、[Usage-based billing](https://developers.cloudflare.com/billing/understand/usage-based-billing/)、[Cron Triggers](https://developers.cloudflare.com/workers/configuration/cron-triggers/)
+
+Firebase / Cloudflare の秘密情報は Wrangler secrets、GitHub secrets、または実行中の shell 環境だけに置き、リポジトリやログへ保存しない。

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,9 @@
             pkgs.lcov
             pkgs.git
             pkgs.bun
+            pkgs.curl
+            pkgs.jq
+            pkgs.ripgrep
           ] ++ lib.optionals pkgs.stdenv.isDarwin [ pkgs.cocoapods ];
         in
         {

--- a/justfile
+++ b/justfile
@@ -56,3 +56,28 @@ server-generate:
 
 server-dev:
     cd server && bun run dev
+
+# dev D1 に未適用の migration を反映する
+server-migrate-dev:
+    cd server && bunx wrangler d1 migrations apply DB --env dev --remote
+
+# app-config の初期行だけを冪等に作成する
+server-seed-dev:
+    cd server && bunx wrangler d1 execute DB --env dev --remote --command "insert into app_config (id, min_app_version_ios, min_app_version_android, in_maintenance, maintenance_scheduled_end_time, updated_at) values (1, '0.0.0', '0.0.0', 0, null, unixepoch('now') * 1000) on conflict(id) do nothing"
+
+# migration と app-config 初期化を完了してから dev Worker を手動 deploy する
+server-deploy-dev: server-migrate-dev server-seed-dev
+    if rg -q 'AVATAR_BASE_URL = "https://api.dev.invalid/v1"' server/wrangler.toml; then echo 'Replace AVATAR_BASE_URL with the deployed dev Worker URL before deploy.' >&2; exit 1; fi
+    cd server && bunx wrangler deploy --env dev
+
+# 正規の Firebase ID token / App Check token を使って dev Worker を smoke test する
+server-smoke-dev:
+    server/scripts/smoke-dev.sh
+
+# remote dev bindings に対して Scheduled Handler を手動起動できる状態にする
+server-dev-remote-scheduled:
+    cd server && bunx wrangler dev --env dev --remote --test-scheduled
+
+# prod は #186 まで deploy せず、bundle と bindings の解決だけを検証する
+server-validate-prod:
+    cd server && bunx wrangler deploy --env prod --dry-run --outdir /tmp/teigiii-api-prod-dry-run

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -644,6 +644,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "アプリ設定が未初期化",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -960,6 +970,70 @@
           },
           "404": {
             "description": "未登録（user_not_found）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/avatars/{id}": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "認証付きアバター画像を取得",
+        "description": "非公開 R2 bucket の画像を認証済み利用者へ配信する。",
+        "security": [
+          {
+            "appCheck": [],
+            "firebaseIdToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "アバター画像",
+            "content": {
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "App Check または Firebase ID トークンが欠落・無効",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ユーザーまたはアバターが存在しない（avatar_not_found）",
             "content": {
               "application/json": {
                 "schema": {

--- a/server/scripts/smoke-dev.sh
+++ b/server/scripts/smoke-dev.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEIGIII_API_BASE_URL:?Set the deployed dev Worker URL}"
+: "${FIREBASE_ID_TOKEN:?Set a valid dev Firebase ID token}"
+: "${FIREBASE_APP_CHECK_TOKEN:?Set a valid dev Firebase App Check token}"
+
+api_base="${TEIGIII_API_BASE_URL%/}"
+response_file="$(mktemp)"
+avatar_file="$(mktemp)"
+trap 'rm -f "$response_file" "$avatar_file"' EXIT
+
+request() {
+  local expected_status="$1"
+  shift
+  local actual_status
+  actual_status="$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' "$@")"
+  if [ "$actual_status" != "$expected_status" ]; then
+    printf 'Expected HTTP %s, got %s\n' "$expected_status" "$actual_status" >&2
+    jq . "$response_file" >&2 2>/dev/null || sed -n '1,120p' "$response_file" >&2
+    return 1
+  fi
+}
+
+app_check_header="X-Firebase-AppCheck: $FIREBASE_APP_CHECK_TOKEN"
+authorization_header="Authorization: Bearer $FIREBASE_ID_TOKEN"
+
+request 200 \
+  --header "$app_check_header" \
+  "$api_base/v1/app-config"
+jq -e '.minAppVersionIos and .minAppVersionAndroid' "$response_file" >/dev/null
+
+create_status="$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+  --request POST \
+  --header "$app_check_header" \
+  --header "$authorization_header" \
+  --header 'Content-Type: application/json' \
+  --data '{"appVersion":"smoke","bio":"","name":"Smoke Test","osVersion":"smoke"}' \
+  "$api_base/v1/users")"
+if [ "$create_status" != "201" ] && [ "$create_status" != "409" ]; then
+  printf 'Expected user create HTTP 201 or 409, got %s\n' "$create_status" >&2
+  jq . "$response_file" >&2 2>/dev/null || sed -n '1,120p' "$response_file" >&2
+  exit 1
+fi
+
+request 200 \
+  --request PATCH \
+  --header "$app_check_header" \
+  --header "$authorization_header" \
+  --header 'Content-Type: application/json' \
+  --data '{"bio":"dev smoke verified","name":"Smoke Test"}' \
+  "$api_base/v1/users/me"
+
+png_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+if ! printf '%s' "$png_base64" | base64 --decode >"$avatar_file" 2>/dev/null; then
+  printf '%s' "$png_base64" | base64 -D >"$avatar_file"
+fi
+
+request 200 \
+  --request PUT \
+  --header "$app_check_header" \
+  --header "$authorization_header" \
+  --header 'Content-Type: image/png' \
+  --data-binary "@$avatar_file" \
+  "$api_base/v1/users/me/avatar"
+avatar_url="$(jq -er '.avatarUrl' "$response_file")"
+request 401 "$avatar_url"
+curl --fail --silent --show-error \
+  --header "$app_check_header" \
+  --header "$authorization_header" \
+  "$avatar_url" >/dev/null
+
+request 204 \
+  --request DELETE \
+  --header "$app_check_header" \
+  --header "$authorization_header" \
+  "$api_base/v1/users/me/avatar"
+
+printf 'dev smoke test passed: app-config, D1 read/write, authenticated routes, private R2 upload/read/delete\n'

--- a/server/src/config/app-config-service.ts
+++ b/server/src/config/app-config-service.ts
@@ -1,0 +1,41 @@
+import { ApiError } from "../errors";
+
+type AppConfigRow = {
+  in_maintenance: number;
+  maintenance_scheduled_end_time: number | null;
+  min_app_version_android: string;
+  min_app_version_ios: string;
+  updated_at: number;
+};
+
+/**
+ * @doc doc/specs/workers-api-server.md#app-config
+ */
+export class AppConfigService {
+  constructor(private readonly database: D1Database) {}
+
+  async get() {
+    const row = await this.database
+      .prepare(
+        `select min_app_version_ios, min_app_version_android, in_maintenance,
+                maintenance_scheduled_end_time, updated_at
+         from app_config
+         where id = 1`,
+      )
+      .first<AppConfigRow>();
+    if (row === null) {
+      throw new ApiError(500, "app_config_unavailable", "App config unavailable");
+    }
+
+    return {
+      inMaintenance: row.in_maintenance !== 0,
+      maintenanceScheduledEndTime:
+        row.maintenance_scheduled_end_time === null
+          ? null
+          : new Date(row.maintenance_scheduled_end_time).toISOString(),
+      minAppVersionAndroid: row.min_app_version_android,
+      minAppVersionIos: row.min_app_version_ios,
+      updatedAt: new Date(row.updated_at).toISOString(),
+    };
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,9 @@
-import { app } from "./app";
+import { app, type Env } from "./app";
+import { runPhysicalDeletion } from "./maintenance/physical-deletion";
 
-export default app;
+export default {
+  fetch: app.fetch,
+  scheduled(controller, env, context): void {
+    context.waitUntil(runPhysicalDeletion(env, controller.scheduledTime));
+  },
+} satisfies ExportedHandler<Env>;

--- a/server/src/maintenance/physical-deletion.ts
+++ b/server/src/maintenance/physical-deletion.ts
@@ -1,0 +1,123 @@
+import type { Env } from "../app";
+
+const retentionMs = 30 * 24 * 60 * 60 * 1000;
+
+type ExpiredUser = {
+  avatar_key: string | null;
+  id: string;
+};
+
+type Counts = {
+  failure: number;
+  success: number;
+  target: number;
+};
+
+type PhysicalDeletionLogEntry =
+  | {
+      entity: "definitions";
+      errorType: string;
+      event: "physical_deletion_batch_failed";
+      stage: "database_delete";
+      target: number;
+    }
+  | {
+      entity: "user";
+      errorType: string;
+      event: "physical_deletion_item_failed";
+      stage: "avatar_delete" | "database_delete";
+    }
+  | {
+      definitions: Counts;
+      event: "physical_deletion_completed";
+      users: Counts;
+    };
+
+type RunPhysicalDeletionOptions = {
+  log?: (entry: PhysicalDeletionLogEntry) => void;
+};
+
+function errorType(error: unknown): string {
+  return error instanceof Error ? error.name : "UnknownError";
+}
+
+/**
+ * @doc doc/specs/workers-api-server.md#物理削除
+ */
+export async function runPhysicalDeletion(
+  env: Pick<Env, "AVATARS" | "DB">,
+  now: number,
+  { log = (entry) => console.log(JSON.stringify(entry)) }: RunPhysicalDeletionOptions = {},
+) {
+  const cutoff = now - retentionMs;
+  const definitionTarget =
+    (
+      await env.DB.prepare(
+        "select count(*) as count from definitions where deleted_at is not null and deleted_at <= ?",
+      )
+        .bind(cutoff)
+        .first<{ count: number }>()
+    )?.count ?? 0;
+
+  let definitionSuccess = 0;
+  let definitionFailure = 0;
+  try {
+    await env.DB.prepare("delete from definitions where deleted_at is not null and deleted_at <= ?")
+      .bind(cutoff)
+      .run();
+    definitionSuccess = definitionTarget;
+  } catch (error) {
+    definitionFailure = definitionTarget;
+    log({
+      entity: "definitions",
+      errorType: errorType(error),
+      event: "physical_deletion_batch_failed",
+      stage: "database_delete",
+      target: definitionTarget,
+    });
+  }
+
+  const expiredUsers = await env.DB.prepare(
+    `select id, avatar_key
+     from users
+     where deleted_at is not null and deleted_at <= ?`,
+  )
+    .bind(cutoff)
+    .all<ExpiredUser>();
+
+  let userSuccess = 0;
+  let userFailure = 0;
+  for (const user of expiredUsers.results) {
+    let stage: "avatar_delete" | "database_delete" = "avatar_delete";
+    try {
+      if (user.avatar_key !== null) await env.AVATARS.delete(user.avatar_key);
+      stage = "database_delete";
+      await env.DB.prepare("delete from users where id = ? and deleted_at <= ?")
+        .bind(user.id, cutoff)
+        .run();
+      userSuccess++;
+    } catch (error) {
+      userFailure++;
+      log({
+        entity: "user",
+        errorType: errorType(error),
+        event: "physical_deletion_item_failed",
+        stage,
+      });
+    }
+  }
+
+  log({
+    definitions: {
+      failure: definitionFailure,
+      success: definitionSuccess,
+      target: definitionTarget,
+    },
+    event: "physical_deletion_completed",
+    users: {
+      failure: userFailure,
+      success: userSuccess,
+      target: expiredUsers.results.length,
+    },
+  });
+}

--- a/server/src/routes/app-config.ts
+++ b/server/src/routes/app-config.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import { AppConfigService } from "../config/app-config-service";
 import { appConfigResponseSchema } from "../schemas/app-config";
-import { appCheckOnlySecurity, errorContent, jsonContent, notImplemented } from "./helpers";
+import { appCheckOnlySecurity, errorContent, jsonContent } from "./helpers";
 
 const getAppConfigRoute = createRoute({
   method: "get",
@@ -12,7 +13,15 @@ const getAppConfigRoute = createRoute({
   responses: {
     200: jsonContent(appConfigResponseSchema, "アプリ設定"),
     401: errorContent("App Check トークンが欠落・無効"),
+    500: errorContent("アプリ設定が未初期化"),
   },
 });
 
-export const appConfigRoutes = new OpenAPIHono().openapi(getAppConfigRoute, notImplemented);
+type AppConfigRouteEnvironment = {
+  Bindings: { DB: D1Database };
+};
+
+export const appConfigRoutes = new OpenAPIHono<AppConfigRouteEnvironment>().openapi(
+  getAppConfigRoute,
+  async (context) => context.json(await new AppConfigService(context.env.DB).get(), 200),
+);

--- a/server/src/routes/helpers.ts
+++ b/server/src/routes/helpers.ts
@@ -1,6 +1,4 @@
 import type { z } from "@hono/zod-openapi";
-import type { Context } from "hono";
-import { HTTPException } from "hono/http-exception";
 import { errorResponseSchema } from "../schemas/common";
 
 /**
@@ -20,11 +18,3 @@ export const errorContent = (description: string) => jsonContent(errorResponseSc
 export const authErrorResponses = {
   401: errorContent("App Check または Firebase ID トークンが欠落・無効"),
 };
-
-/**
- * フェーズ 2 のスタブハンドラ。実装はフェーズ 3（#184）。
- * OpenAPI 定義を汚さないよう、レスポンススキーマには含めず実行時に 501 を投げる。
- */
-export function notImplemented(_c: Context): never {
-  throw new HTTPException(501, { message: "not implemented" });
-}

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -104,6 +104,27 @@ const deleteAvatarRoute = createRoute({
   },
 });
 
+const getAvatarRoute = createRoute({
+  method: "get",
+  path: "/avatars/{id}",
+  tags: ["users"],
+  summary: "認証付きアバター画像を取得",
+  description: "非公開 R2 bucket の画像を認証済み利用者へ配信する。",
+  security: authenticatedSecurity,
+  request: { params: userIdParams },
+  responses: {
+    200: {
+      content: {
+        "image/jpeg": { schema: z.string().openapi({ format: "binary" }) },
+        "image/png": { schema: z.string().openapi({ format: "binary" }) },
+      },
+      description: "アバター画像",
+    },
+    404: errorContent("ユーザーまたはアバターが存在しない（avatar_not_found）"),
+    ...authErrorResponses,
+  },
+});
+
 const deleteMeRoute = createRoute({
   method: "delete",
   path: "/users/me",
@@ -314,6 +335,18 @@ export function createUserRoutes(options: UserServiceOptions = {}) {
     .openapi(deleteAvatarRoute, async (context) => {
       await new AvatarService(context.env).delete(context.get("firebaseUid"));
       return context.body(null, 204);
+    })
+    .openapi(getAvatarRoute, async (context) => {
+      const object = await new AvatarService(context.env).get(
+        context.get("firebaseUid"),
+        context.req.valid("param").id,
+      );
+      const headers = new Headers();
+      object.writeHttpMetadata(headers);
+      headers.set("Cache-Control", "private, max-age=300");
+      headers.set("ETag", object.httpEtag);
+      headers.set("X-Content-Type-Options", "nosniff");
+      return new Response(object.body, { headers });
     })
     .openapi(deleteMeRoute, async (context) => {
       await users(context.env).delete(context.get("firebaseUid"));

--- a/server/src/schemas/user.ts
+++ b/server/src/schemas/user.ts
@@ -11,7 +11,7 @@ export const userSummarySchema = z
     id: z.string(),
     publicId: z.string(),
     name: z.string(),
-    // avatar_key を R2 の配信 URL に解決した値。未設定は null。
+    // avatar_key を認証必須の Workers API URL に解決した値。未設定は null。
     avatarUrl: z.string().nullable(),
   })
   .openapi("UserSummary");

--- a/server/src/users/user-service.ts
+++ b/server/src/users/user-service.ts
@@ -454,12 +454,25 @@ async function readBodyWithLimit(
 }
 
 /**
- * R2 アバターの形式・容量検証、固定キー保存、削除、公開 URL 解決を扱う。
+ * R2 アバターの形式・容量検証、固定キー保存、削除、認証付き Worker URL 解決を扱う。
  *
  * @doc doc/specs/workers-api-server.md#アバター
  */
 export class AvatarService {
   constructor(private readonly env: UserBindings) {}
+
+  async get(viewerUid: string, targetUid: string): Promise<R2ObjectBody> {
+    await requireActiveUser(this.env.DB, viewerUid);
+    const target = await findActiveUser(this.env.DB, targetUid);
+    if (target?.avatar_key == null) {
+      throw new ApiError(404, "avatar_not_found", "Avatar not found");
+    }
+    const object = await this.env.AVATARS.get(target.avatar_key);
+    if (object === null) {
+      throw new ApiError(404, "avatar_not_found", "Avatar not found");
+    }
+    return object;
+  }
 
   async upload(uid: string, request: Request): Promise<string> {
     await requireActiveUser(this.env.DB, uid);

--- a/server/test/app-auth.test.ts
+++ b/server/test/app-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createApp } from "../src/app";
+import { createApp, type Env } from "../src/app";
 import type { RequestLogEntry } from "../src/middleware/request-context";
 
 function testApp() {
@@ -31,11 +31,20 @@ describe("createApp", () => {
   });
 
   test("app-config は App Check 検証後にルートへ到達する", async () => {
-    const response = await testApp().request("/v1/app-config", {
-      headers: { "X-Firebase-AppCheck": "valid-app-check" },
-    });
+    const response = await testApp().request(
+      "/v1/app-config",
+      { headers: { "X-Firebase-AppCheck": "valid-app-check" } },
+      {
+        DB: {
+          prepare: () => ({ first: async () => null }) as unknown as D1PreparedStatement,
+        } as unknown as D1Database,
+      } as Env,
+    );
 
-    expect(response.status).toBe(501);
+    expect(response.status).toBe(500);
+    expect(await response.json<unknown>()).toEqual({
+      error: { code: "app_config_unavailable", message: "App config unavailable" },
+    });
   });
 
   test("認証必須ルートは Firebase ID トークンも要求する", async () => {

--- a/server/test/openapi.test.ts
+++ b/server/test/openapi.test.ts
@@ -14,6 +14,7 @@ const expectedOperations = [
   "DELETE /v1/users/me",
   "PUT /v1/users/me/avatar",
   "DELETE /v1/users/me/avatar",
+  "GET /v1/avatars/{id}",
   "GET /v1/users/{id}",
   "GET /v1/users/{id}/dictionary",
   "GET /v1/users/{id}/definitions",

--- a/server/worker-test/app-config.workers.ts
+++ b/server/worker-test/app-config.workers.ts
@@ -1,0 +1,42 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createApp } from "../src/app";
+
+const app = createApp({
+  logRequest: () => {},
+  verifyAppCheck: async () => ({ appId: "test-app-id" }),
+});
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  await env.DB.prepare("delete from app_config").run();
+});
+
+describe("app config route", () => {
+  test("D1の単一行をISO 8601日時へ変換して返す", async () => {
+    await env.DB.prepare(
+      `insert into app_config
+         (id, min_app_version_ios, min_app_version_android, in_maintenance,
+          maintenance_scheduled_end_time, updated_at)
+       values (1, '2.0.0', '2.1.0', 1, ?, ?)`,
+    )
+      .bind(Date.parse("2026-07-16T12:00:00.000Z"), Date.parse("2026-07-16T00:00:00.000Z"))
+      .run();
+
+    const response = await app.request(
+      "/v1/app-config",
+      { headers: { "X-Firebase-AppCheck": "valid-app-check" } },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      inMaintenance: true,
+      maintenanceScheduledEndTime: "2026-07-16T12:00:00.000Z",
+      minAppVersionAndroid: "2.1.0",
+      minAppVersionIos: "2.0.0",
+      updatedAt: "2026-07-16T00:00:00.000Z",
+    });
+  });
+});

--- a/server/worker-test/physical-deletion.workers.ts
+++ b/server/worker-test/physical-deletion.workers.ts
@@ -1,0 +1,202 @@
+import {
+  applyD1Migrations,
+  createExecutionContext,
+  createScheduledController,
+  env,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import worker from "../src/index";
+import { runPhysicalDeletion } from "../src/maintenance/physical-deletion";
+
+const dayMs = 24 * 60 * 60 * 1000;
+const scheduledTime = new Date("2026-07-16T00:00:00.000Z");
+const cutoff = scheduledTime.getTime() - 30 * dayMs;
+
+async function insertUser(id: string, deletedAt: number | null, avatarKey: string | null = null) {
+  await env.DB.prepare(
+    `insert into users
+       (id, public_id, name, bio, avatar_key, last_os_version, last_app_version,
+        deleted_at, created_at, updated_at)
+     values (?, ?, ?, '', ?, 'iOS 19', '2.0.0', ?, ?, ?)`,
+  )
+    .bind(id, `public-${id}`, id, avatarKey, deletedAt, cutoff - dayMs, cutoff - dayMs)
+    .run();
+}
+
+async function insertDefinition(id: string, authorId: string, deletedAt: number | null) {
+  await env.DB.prepare(
+    `insert into definitions
+       (id, word_id, author_id, body, status, finalized_at, deleted_at, created_at, updated_at)
+     values (?, 'word-1', ?, 'body', 'public', ?, ?, ?, ?)`,
+  )
+    .bind(id, authorId, cutoff - dayMs, deletedAt, cutoff - dayMs, cutoff - dayMs)
+    .run();
+}
+
+async function runScheduledHandler() {
+  const context = createExecutionContext();
+  const scheduled = worker.scheduled as ExportedHandlerScheduledHandler<Cloudflare.Env>;
+  await scheduled(createScheduledController({ scheduledTime }), env, context);
+  await waitOnExecutionContext(context);
+}
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  await env.DB.batch([
+    env.DB.prepare("delete from users"),
+    env.DB.prepare("delete from words"),
+    env.DB.prepare("delete from app_config"),
+  ]);
+  const objects = await env.AVATARS.list();
+  if (objects.objects.length > 0) {
+    await env.AVATARS.delete(objects.objects.map((object) => object.key));
+  }
+});
+
+describe("physical deletion scheduled handler", () => {
+  test("Scheduled Handler を公開する", () => {
+    expect(worker.scheduled).toBeTypeOf("function");
+  });
+
+  test("30日以前に論理削除された定義・ユーザー・R2アバターだけを物理削除する", async () => {
+    await insertUser("expired", cutoff, "avatars/expired");
+    await insertUser("recent", cutoff + 1, "avatars/recent");
+    await insertUser("active", null);
+    await env.DB.prepare(
+      `insert into words
+         (id, word, reading, reading_sub_group, created_by, created_at, updated_at)
+       values ('word-1', '自由', 'じゆう', 'さ', 'expired', ?, ?)`,
+    )
+      .bind(cutoff - dayMs, cutoff - dayMs)
+      .run();
+    await insertDefinition("expired-user-definition", "expired", cutoff);
+    await insertDefinition("expired-definition", "active", cutoff);
+    await insertDefinition("recent-definition", "active", cutoff + 1);
+    await env.AVATARS.put("avatars/expired", "expired avatar");
+    await env.AVATARS.put("avatars/recent", "recent avatar");
+
+    await runScheduledHandler();
+
+    const users = await env.DB.prepare("select id from users order by id").all<{ id: string }>();
+    expect(users.results.map(({ id }) => id)).toEqual(["active", "recent"]);
+    const definitions = await env.DB.prepare("select id from definitions order by id").all<{
+      id: string;
+    }>();
+    expect(definitions.results.map(({ id }) => id)).toEqual(["recent-definition"]);
+    await expect(env.AVATARS.get("avatars/expired")).resolves.toBeNull();
+    await expect(env.AVATARS.get("avatars/recent")).resolves.not.toBeNull();
+    await expect(
+      env.DB.prepare("select created_by from words where id = 'word-1'").first(),
+    ).resolves.toEqual({ created_by: null });
+  });
+
+  test("R2削除に失敗したユーザーを保持し、他の対象を継続して集計を記録する", async () => {
+    await insertUser("failing", cutoff, "avatars/failing");
+    await insertUser("succeeding", cutoff, "avatars/succeeding");
+    await env.AVATARS.put("avatars/failing", "failing avatar");
+    await env.AVATARS.put("avatars/succeeding", "succeeding avatar");
+    const logs: unknown[] = [];
+    const avatars = {
+      delete: async (keys: string | string[]) => {
+        if (keys === "avatars/failing") throw new Error("simulated R2 failure");
+        return env.AVATARS.delete(keys);
+      },
+    } as unknown as R2Bucket;
+
+    await runPhysicalDeletion({ AVATARS: avatars, DB: env.DB }, scheduledTime.getTime(), {
+      log: (entry: unknown) => logs.push(entry),
+    });
+
+    const users = await env.DB.prepare("select id from users order by id").all<{ id: string }>();
+    expect(users.results.map(({ id }) => id)).toEqual(["failing"]);
+    await expect(env.AVATARS.get("avatars/failing")).resolves.not.toBeNull();
+    await expect(env.AVATARS.get("avatars/succeeding")).resolves.toBeNull();
+    expect(logs).toEqual([
+      {
+        entity: "user",
+        errorType: "Error",
+        event: "physical_deletion_item_failed",
+        stage: "avatar_delete",
+      },
+      {
+        definitions: { failure: 0, success: 0, target: 0 },
+        event: "physical_deletion_completed",
+        users: { failure: 1, success: 1, target: 2 },
+      },
+    ]);
+  });
+
+  test("定義の一括削除に失敗してもユーザー削除を継続して失敗件数を記録する", async () => {
+    await insertUser("active", null);
+    await insertUser("expired", cutoff);
+    await env.DB.prepare(
+      `insert into words
+         (id, word, reading, reading_sub_group, created_at, updated_at)
+       values ('word-1', '自由', 'じゆう', 'さ', ?, ?)`,
+    )
+      .bind(cutoff - dayMs, cutoff - dayMs)
+      .run();
+    await insertDefinition("expired-definition", "active", cutoff);
+    const logs: unknown[] = [];
+    const database = {
+      prepare(query: string) {
+        if (!query.startsWith("delete from definitions")) return env.DB.prepare(query);
+        return {
+          bind: () => ({
+            run: async () => {
+              throw new Error("simulated D1 failure");
+            },
+          }),
+        } as unknown as D1PreparedStatement;
+      },
+    } as unknown as D1Database;
+
+    await runPhysicalDeletion({ AVATARS: env.AVATARS, DB: database }, scheduledTime.getTime(), {
+      log: (entry) => logs.push(entry),
+    });
+
+    await expect(
+      env.DB.prepare("select id from users order by id").all<{ id: string }>(),
+    ).resolves.toMatchObject({ results: [{ id: "active" }] });
+    await expect(
+      env.DB.prepare("select id from definitions").all<{ id: string }>(),
+    ).resolves.toMatchObject({ results: [{ id: "expired-definition" }] });
+    expect(logs).toEqual([
+      {
+        entity: "definitions",
+        errorType: "Error",
+        event: "physical_deletion_batch_failed",
+        stage: "database_delete",
+        target: 1,
+      },
+      {
+        definitions: { failure: 1, success: 0, target: 1 },
+        event: "physical_deletion_completed",
+        users: { failure: 0, success: 1, target: 1 },
+      },
+    ]);
+  });
+
+  test("削除完了後に再実行しても成功し、対象件数を0として記録する", async () => {
+    await insertUser("expired", cutoff, "avatars/expired");
+    await env.AVATARS.put("avatars/expired", "expired avatar");
+    const logs: unknown[] = [];
+
+    await runPhysicalDeletion({ AVATARS: env.AVATARS, DB: env.DB }, scheduledTime.getTime(), {
+      log: () => {},
+    });
+    await runPhysicalDeletion({ AVATARS: env.AVATARS, DB: env.DB }, scheduledTime.getTime(), {
+      log: (entry) => logs.push(entry),
+    });
+
+    expect(logs).toEqual([
+      {
+        definitions: { failure: 0, success: 0, target: 0 },
+        event: "physical_deletion_completed",
+        users: { failure: 0, success: 0, target: 0 },
+      },
+    ]);
+  });
+});

--- a/server/worker-test/users.workers.ts
+++ b/server/worker-test/users.workers.ts
@@ -330,7 +330,7 @@ describe("avatar routes", () => {
     await createUser("alice", "Alice");
   });
 
-  test("JPEG を検証して固定キーへ保存し、公開 URL を返す", async () => {
+  test("JPEG を検証して固定キーへ保存し、認証付き Worker URL を返す", async () => {
     const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
 
     const response = await request("alice", "/v1/users/me/avatar", {
@@ -341,7 +341,7 @@ describe("avatar routes", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      avatarUrl: "https://avatars.local.invalid/avatars/alice",
+      avatarUrl: "http://localhost:8787/v1/avatars/alice",
     });
     const object = await env.AVATARS.get("avatars/alice");
     expect(object).not.toBeNull();
@@ -350,7 +350,40 @@ describe("avatar routes", () => {
 
     const me = await request("alice", "/v1/users/me");
     await expect(me.json()).resolves.toMatchObject({
-      avatarUrl: "https://avatars.local.invalid/avatars/alice",
+      avatarUrl: "http://localhost:8787/v1/avatars/alice",
+    });
+  });
+
+  test("認証済みユーザーへ非公開 R2 のアバターを配信する", async () => {
+    const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    await request("alice", "/v1/users/me/avatar", {
+      body: jpeg,
+      headers: { "Content-Type": "image/jpeg" },
+      method: "PUT",
+    });
+
+    const response = await request("alice", "/v1/avatars/alice");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/jpeg");
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=300");
+    expect(Array.from(new Uint8Array(await response.arrayBuffer()))).toEqual(Array.from(jpeg));
+
+    const urlOnlyResponse = await testApp("alice").request("/v1/avatars/alice", {}, env);
+    expect(urlOnlyResponse.status).toBe(401);
+  });
+
+  test("対象ユーザーまたはアバターがなければ一律 avatar_not_found を返す", async () => {
+    const missingUser = await request("alice", "/v1/avatars/missing");
+    expect(missingUser.status).toBe(404);
+    await expect(missingUser.json()).resolves.toEqual({
+      error: { code: "avatar_not_found", message: "Avatar not found" },
+    });
+
+    const missingAvatar = await request("alice", "/v1/avatars/alice");
+    expect(missingAvatar.status).toBe(404);
+    await expect(missingAvatar.json()).resolves.toEqual({
+      error: { code: "avatar_not_found", message: "Avatar not found" },
     });
   });
 

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -1,4 +1,3 @@
-# ローカル開発用の最小構成。dev/prod 環境分離・デプロイ設定はフェーズ 3（#184）で行う。
 name = "teigiii-api"
 main = "src/index.ts"
 compatibility_date = "2026-07-01"
@@ -6,7 +5,7 @@ compatibility_date = "2026-07-01"
 [vars]
 FIREBASE_PROJECT_ID = "everyone-teigi-dev"
 FIREBASE_PROJECT_NUMBER = "225028441501"
-AVATAR_BASE_URL = "https://avatars.local.invalid"
+AVATAR_BASE_URL = "http://localhost:8787/v1"
 
 [[d1_databases]]
 binding = "DB"
@@ -17,3 +16,40 @@ migrations_dir = "drizzle"
 [[r2_buckets]]
 binding = "AVATARS"
 bucket_name = "teigiii-local-avatars"
+
+[env.dev]
+name = "teigiii-api-dev"
+
+[env.dev.vars]
+FIREBASE_PROJECT_ID = "everyone-teigi-dev"
+FIREBASE_PROJECT_NUMBER = "225028441501"
+AVATAR_BASE_URL = "https://teigiii-api-dev.tetsuo21ad.workers.dev/v1"
+
+[[env.dev.d1_databases]]
+binding = "DB"
+database_name = "teigiii-dev"
+database_id = "3a8c086b-4704-4277-9c89-14e45fc00e92"
+migrations_dir = "drizzle"
+
+[[env.dev.r2_buckets]]
+binding = "AVATARS"
+bucket_name = "teigiii-dev-avatars"
+
+[env.prod]
+name = "teigiii-api-prod"
+
+[env.prod.vars]
+FIREBASE_PROJECT_ID = "everyone-teigi-prod"
+FIREBASE_PROJECT_NUMBER = "713374936833"
+# #186 で prod Worker の実 URL へ置換してから deploy する。
+AVATAR_BASE_URL = "https://api.prod.invalid/v1"
+
+[[env.prod.d1_databases]]
+binding = "DB"
+database_name = "teigiii-prod"
+database_id = "cf269ff5-12bd-49d6-96f4-b3bbf37371aa"
+migrations_dir = "drizzle"
+
+[[env.prod.r2_buckets]]
+binding = "AVATARS"
+bucket_name = "teigiii-prod-avatars"


### PR DESCRIPTION
## 概要
- 30日保持後の論理削除データを物理削除する Scheduled Handler を追加
- dev/prod の D1・R2 bindings と dev 手動デプロイ手順を整備
- app-config の実装を完了し、残っていた 501 を解消
- R2 public access を有効化せず、App Check と Firebase ID Token が必須の Worker API 経由でアバターを配信

## 実環境確認
- dev Worker へデプロイ済み
- dev D1 migration・初期データ投入済み
- 認証付き app-config、D1 read/write、R2 upload/read/delete を smoke test 済み
- URL 単独のアバターアクセスが 401 になることを確認
- remote dev bindings で物理削除 Cron と D1/R2 削除を確認
- dev R2 の r2.dev public access が無効であることを確認
- prod Worker bindings の dry-run 成功（prod deploy/Cron 有効化は #186）

## テスト
- server lint / typecheck / format check
- server unit tests: 73 passed
- Workers integration tests: 87 passed
- Flutter analyze: errors/warnings なし（既存 info 49件）
- Flutter tests: 104 passed
- DocBridge: 0 errors / 0 warnings

Closes #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated avatar delivery through the Workers API, including private image responses and standard security/cache headers.
  * Implemented app configuration retrieval with maintenance status and minimum app version information.
  * Added scheduled cleanup for expired users, avatars, and definitions with resilient, repeatable processing.

* **Bug Fixes**
  * App configuration failures now return clear HTTP 500 error responses instead of an unimplemented response.

* **Documentation**
  * Updated API, deployment, environment, monitoring, and avatar access documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->