### PR TITLE
style: Dart tall style でリポジトリ全体を再整形

### DIFF
--- a/lib/core/common_provider/common_provider.g.dart
+++ b/lib/core/common_provider/common_provider.g.dart
@@ -15,14 +15,14 @@ String _$isLoadingOverlayNotifierHash() =>
 @ProviderFor(IsLoadingOverlayNotifier)
 final isLoadingOverlayNotifierProvider =
     NotifierProvider<IsLoadingOverlayNotifier, bool>.internal(
-  IsLoadingOverlayNotifier.new,
-  name: r'isLoadingOverlayNotifierProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$isLoadingOverlayNotifierHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      IsLoadingOverlayNotifier.new,
+      name: r'isLoadingOverlayNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$isLoadingOverlayNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef _$IsLoadingOverlayNotifier = Notifier<bool>;
 // ignore_for_file: type=lint

--- a/lib/core/common_provider/firebase_provider.g.dart
+++ b/lib/core/common_provider/firebase_provider.g.dart
@@ -13,8 +13,9 @@ String _$firestoreHash() => r'4963ca786eb54685cef6453544040c7567e77c0f';
 final firestoreProvider = Provider<FirebaseFirestore>.internal(
   firestore,
   name: r'firestoreProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$firestoreHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$firestoreHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/core/common_provider/flavor_state.dart
+++ b/lib/core/common_provider/flavor_state.dart
@@ -31,20 +31,20 @@ enum Flavor {
       case 'dev':
         return Flavor.dev;
       default:
-        throw UnsupportedError(
-          'this flavor is not expected',
-        );
+        throw UnsupportedError('this flavor is not expected');
     }
   }
 
   String generateRandomIconImageUrl() {
     switch (this) {
       case Flavor.prod:
-        return defaultIconImageUrlListForProd[
-            Random().nextInt(defaultIconImageUrlListForProd.length)];
+        return defaultIconImageUrlListForProd[Random().nextInt(
+          defaultIconImageUrlListForProd.length,
+        )];
       case Flavor.dev:
-        return defaultIconImageUrlListForDev[
-            Random().nextInt(defaultIconImageUrlListForDev.length)];
+        return defaultIconImageUrlListForDev[Random().nextInt(
+          defaultIconImageUrlListForDev.length,
+        )];
     }
   }
 }

--- a/lib/core/common_provider/flavor_state.g.dart
+++ b/lib/core/common_provider/flavor_state.g.dart
@@ -13,8 +13,9 @@ String _$flavorHash() => r'25ba4a0d5bc764f5d1eefe0d64f557e200ff4c3a';
 final flavorProvider = AutoDisposeProvider<Flavor>.internal(
   flavor,
   name: r'flavorProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$flavorHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$flavorHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/core/common_provider/in_app_review_provider.g.dart
+++ b/lib/core/common_provider/in_app_review_provider.g.dart
@@ -13,8 +13,9 @@ String _$inAppReviewHash() => r'e4a81de941378fc21b9690e55d12aad3923b492c';
 final inAppReviewProvider = AutoDisposeProvider<InAppReview>.internal(
   inAppReview,
   name: r'inAppReviewProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$inAppReviewHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$inAppReviewHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/core/common_provider/is_loading_overlay_state.g.dart
+++ b/lib/core/common_provider/is_loading_overlay_state.g.dart
@@ -15,14 +15,14 @@ String _$isLoadingOverlayNotifierHash() =>
 @ProviderFor(IsLoadingOverlayNotifier)
 final isLoadingOverlayNotifierProvider =
     NotifierProvider<IsLoadingOverlayNotifier, bool>.internal(
-  IsLoadingOverlayNotifier.new,
-  name: r'isLoadingOverlayNotifierProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$isLoadingOverlayNotifierHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      IsLoadingOverlayNotifier.new,
+      name: r'isLoadingOverlayNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$isLoadingOverlayNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef _$IsLoadingOverlayNotifier = Notifier<bool>;
 // ignore_for_file: type=lint

--- a/lib/core/common_provider/key_provider.dart
+++ b/lib/core/common_provider/key_provider.dart
@@ -13,8 +13,7 @@ GlobalKey globalKey(GlobalKeyRef ref) => GlobalKey();
 GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey(
   ScaffoldMessengerKeyRef ref,
   ScaffoldMessengerType type,
-) =>
-    GlobalKey<ScaffoldMessengerState>();
+) => GlobalKey<ScaffoldMessengerState>();
 
 enum ScaffoldMessengerType {
   /// MyApp の builder メソッド内の ScaffoldMessenger に設定する Key.
@@ -27,5 +26,5 @@ enum ScaffoldMessengerType {
   ///
   /// BottomNavigationBar を表示している Page 上で
   /// Snackbar を表示する場合に使用する。
-  baseRoute;
+  baseRoute,
 }

--- a/lib/core/common_provider/key_provider.g.dart
+++ b/lib/core/common_provider/key_provider.g.dart
@@ -13,8 +13,9 @@ String _$globalKeyHash() => r'c9b683949cb6cc7d2b9ae4df52a749fb1646b81e';
 final globalKeyProvider = AutoDisposeProvider<GlobalKey>.internal(
   globalKey,
   name: r'globalKeyProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$globalKeyHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$globalKeyHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
@@ -55,21 +56,15 @@ class ScaffoldMessengerKeyFamily
   const ScaffoldMessengerKeyFamily();
 
   /// See also [scaffoldMessengerKey].
-  ScaffoldMessengerKeyProvider call(
-    ScaffoldMessengerType type,
-  ) {
-    return ScaffoldMessengerKeyProvider(
-      type,
-    );
+  ScaffoldMessengerKeyProvider call(ScaffoldMessengerType type) {
+    return ScaffoldMessengerKeyProvider(type);
   }
 
   @override
   ScaffoldMessengerKeyProvider getProviderOverride(
     covariant ScaffoldMessengerKeyProvider provider,
   ) {
-    return call(
-      provider.type,
-    );
+    return call(provider.type);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -91,24 +86,19 @@ class ScaffoldMessengerKeyFamily
 class ScaffoldMessengerKeyProvider
     extends AutoDisposeProvider<GlobalKey<ScaffoldMessengerState>> {
   /// See also [scaffoldMessengerKey].
-  ScaffoldMessengerKeyProvider(
-    ScaffoldMessengerType type,
-  ) : this._internal(
-          (ref) => scaffoldMessengerKey(
-            ref as ScaffoldMessengerKeyRef,
-            type,
-          ),
-          from: scaffoldMessengerKeyProvider,
-          name: r'scaffoldMessengerKeyProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$scaffoldMessengerKeyHash,
-          dependencies: ScaffoldMessengerKeyFamily._dependencies,
-          allTransitiveDependencies:
-              ScaffoldMessengerKeyFamily._allTransitiveDependencies,
-          type: type,
-        );
+  ScaffoldMessengerKeyProvider(ScaffoldMessengerType type)
+    : this._internal(
+        (ref) => scaffoldMessengerKey(ref as ScaffoldMessengerKeyRef, type),
+        from: scaffoldMessengerKeyProvider,
+        name: r'scaffoldMessengerKeyProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$scaffoldMessengerKeyHash,
+        dependencies: ScaffoldMessengerKeyFamily._dependencies,
+        allTransitiveDependencies:
+            ScaffoldMessengerKeyFamily._allTransitiveDependencies,
+        type: type,
+      );
 
   ScaffoldMessengerKeyProvider._internal(
     super._createNotifier, {
@@ -125,7 +115,7 @@ class ScaffoldMessengerKeyProvider
   @override
   Override overrideWith(
     GlobalKey<ScaffoldMessengerState> Function(ScaffoldMessengerKeyRef provider)
-        create,
+    create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -143,7 +133,7 @@ class ScaffoldMessengerKeyProvider
 
   @override
   AutoDisposeProviderElement<GlobalKey<ScaffoldMessengerState>>
-      createElement() {
+  createElement() {
     return _ScaffoldMessengerKeyProviderElement(this);
   }
 
@@ -176,5 +166,6 @@ class _ScaffoldMessengerKeyProviderElement
   ScaffoldMessengerType get type =>
       (origin as ScaffoldMessengerKeyProvider).type;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/core/common_provider/launch_url_controller.dart
+++ b/lib/core/common_provider/launch_url_controller.dart
@@ -31,7 +31,9 @@ class LaunchUrlController {
           ? ScaffoldMessengerType.baseRoute
           : ScaffoldMessengerType.topRoute;
 
-      ref.read(snackBarControllerProvider).showErrorSnackBar(
+      ref
+          .read(snackBarControllerProvider)
+          .showErrorSnackBar(
             'ページを開けませんでした。もう一度お試しください。',
             scaffoldMessengerType,
           );

--- a/lib/core/common_provider/launch_url_controller.g.dart
+++ b/lib/core/common_provider/launch_url_controller.g.dart
@@ -13,14 +13,14 @@ String _$launchUrlControllerHash() =>
 @ProviderFor(launchUrlController)
 final launchUrlControllerProvider =
     AutoDisposeProvider<LaunchUrlController>.internal(
-  launchUrlController,
-  name: r'launchUrlControllerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$launchUrlControllerHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      launchUrlController,
+      name: r'launchUrlControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$launchUrlControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef LaunchUrlControllerRef = AutoDisposeProviderRef<LaunchUrlController>;
 // ignore_for_file: type=lint

--- a/lib/core/common_provider/snack_bar_controller.dart
+++ b/lib/core/common_provider/snack_bar_controller.dart
@@ -22,7 +22,10 @@ class SnackBarController {
         .read(scaffoldMessengerKeyProvider(type))
         .currentState
         ?.hideCurrentSnackBar();
-    ref.read(scaffoldMessengerKeyProvider(type)).currentState?.showSnackBar(
+    ref
+        .read(scaffoldMessengerKeyProvider(type))
+        .currentState
+        ?.showSnackBar(
           _BaseSnackBar(
             text: text,
             duration: const Duration(milliseconds: 2000),
@@ -37,7 +40,10 @@ class SnackBarController {
         .read(scaffoldMessengerKeyProvider(type))
         .currentState
         ?.hideCurrentSnackBar();
-    ref.read(scaffoldMessengerKeyProvider(type)).currentState?.showSnackBar(
+    ref
+        .read(scaffoldMessengerKeyProvider(type))
+        .currentState
+        ?.showSnackBar(
           _BaseSnackBar(
             text: text,
             duration: const Duration(milliseconds: 4000),
@@ -47,16 +53,14 @@ class SnackBarController {
 }
 
 class _BaseSnackBar extends SnackBar {
-  _BaseSnackBar({
-    required String text,
-    required super.duration,
-  }) : super(
-          content: Text(text),
-          margin: const EdgeInsets.all(16),
-          elevation: 0,
-          behavior: SnackBarBehavior.floating,
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(4)),
-          ),
-        );
+  _BaseSnackBar({required String text, required super.duration})
+    : super(
+        content: Text(text),
+        margin: const EdgeInsets.all(16),
+        elevation: 0,
+        behavior: SnackBarBehavior.floating,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(4)),
+        ),
+      );
 }

--- a/lib/core/common_provider/snack_bar_controller.g.dart
+++ b/lib/core/common_provider/snack_bar_controller.g.dart
@@ -13,14 +13,14 @@ String _$snackBarControllerHash() =>
 @ProviderFor(snackBarController)
 final snackBarControllerProvider =
     AutoDisposeProvider<SnackBarController>.internal(
-  snackBarController,
-  name: r'snackBarControllerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$snackBarControllerHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      snackBarController,
+      name: r'snackBarControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$snackBarControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef SnackBarControllerRef = AutoDisposeProviderRef<SnackBarController>;
 // ignore_for_file: type=lint

--- a/lib/core/common_widget/adaptive_overflow_text.dart
+++ b/lib/core/common_widget/adaptive_overflow_text.dart
@@ -27,19 +27,13 @@ class AdaptiveOverflowText extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text(
-          text,
-          maxLines: maxLines,
-          overflow: TextOverflow.ellipsis,
-        ),
+        Text(text, maxLines: maxLines, overflow: TextOverflow.ellipsis),
         if (isTextOverflown())
           Align(
             alignment: Alignment.topRight,
             child: Text(
               '続き →',
-              style: TextStyle(
-                color: Theme.of(context).colorScheme.tertiary,
-              ),
+              style: TextStyle(color: Theme.of(context).colorScheme.tertiary),
             ),
           ),
       ],

--- a/lib/core/common_widget/button/filled_button.dart
+++ b/lib/core/common_widget/button/filled_button.dart
@@ -25,21 +25,17 @@ class _BaseFilledButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextButton(
       style: TextButton.styleFrom(
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(48),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(48)),
         backgroundColor: backgroundColor,
       ),
       onPressed: onPressed,
       child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: 24,
-        ),
+        padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Text(
           text,
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: textColor,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.titleMedium?.copyWith(color: textColor),
         ),
       ),
     );

--- a/lib/core/common_widget/button/outlined_button.dart
+++ b/lib/core/common_widget/button/outlined_button.dart
@@ -25,23 +25,17 @@ class _BaseOutlinedButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextButton(
       style: TextButton.styleFrom(
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(48),
-        ),
-        side: BorderSide(
-          color: borderColor,
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(48)),
+        side: BorderSide(color: borderColor),
       ),
       onPressed: onPressed,
       child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: 24,
-        ),
+        padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Text(
           text,
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: textColor,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.titleMedium?.copyWith(color: textColor),
         ),
       ),
     );

--- a/lib/core/common_widget/button/to_search_user_button.dart
+++ b/lib/core/common_widget/button/to_search_user_button.dart
@@ -5,9 +5,7 @@ import 'package:flutter/material.dart';
 import '../../router/app_router.dart';
 
 class ToSearchUserButton extends StatelessWidget {
-  const ToSearchUserButton({
-    super.key,
-  });
+  const ToSearchUserButton({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/core/common_widget/cupertino_refresh_indicator.dart
+++ b/lib/core/common_widget/cupertino_refresh_indicator.dart
@@ -12,8 +12,11 @@ Widget buildCustomRefreshIndicator(
   double refreshTriggerPullDistance,
   double refreshIndicatorExtent,
 ) {
-  final percentageComplete =
-      clampDouble(pulledExtent / refreshTriggerPullDistance, 0, 1);
+  final percentageComplete = clampDouble(
+    pulledExtent / refreshTriggerPullDistance,
+    0,
+    1,
+  );
   const margin = 16.0;
   const radius = 10.0;
 

--- a/lib/core/common_widget/dialog/base_dialog.dart
+++ b/lib/core/common_widget/dialog/base_dialog.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
 
 class BaseDialog extends StatelessWidget {
-  const BaseDialog({
-    super.key,
-    required this.content,
-    required this.actions,
-  });
+  const BaseDialog({super.key, required this.content, required this.actions});
 
   final Widget content;
   final List<Widget> actions;
@@ -14,19 +10,9 @@ class BaseDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       elevation: 0,
-      contentPadding: const EdgeInsets.only(
-        top: 40,
-        bottom: 16,
-      ),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          content,
-        ],
-      ),
+      contentPadding: const EdgeInsets.only(top: 40, bottom: 16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      content: Column(mainAxisSize: MainAxisSize.min, children: [content]),
       actionsAlignment: MainAxisAlignment.spaceEvenly,
       actionsPadding: const EdgeInsets.only(bottom: 16),
       actions: actions,

--- a/lib/core/common_widget/dialog/confirm_dialog.dart
+++ b/lib/core/common_widget/dialog/confirm_dialog.dart
@@ -47,8 +47,8 @@ class ConfirmDialog extends StatelessWidget {
             child: Text(
               confirmButtonText,
               style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
+                color: Theme.of(context).colorScheme.error,
+              ),
             ),
           ),
         ),

--- a/lib/core/common_widget/dialog/loading_dialog.dart
+++ b/lib/core/common_widget/dialog/loading_dialog.dart
@@ -28,8 +28,9 @@ class OverlayLoadingWidget extends StatelessWidget {
                 children: [
                   CupertinoActivityIndicator(
                     radius: 16,
-                    color:
-                        Theme.of(context).colorScheme.surface.withOpacity(0.3),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surface.withOpacity(0.3),
                   ),
                 ],
               ),

--- a/lib/core/common_widget/error_and_retry_widget.dart
+++ b/lib/core/common_widget/error_and_retry_widget.dart
@@ -12,11 +12,9 @@ import 'button/outlined_button.dart';
 
 class ErrorAndRetryWidget extends ConsumerWidget {
   /// お問い合わせボタンを表示しない [ErrorAndRetryWidget].
-  const ErrorAndRetryWidget.cannotInquire({
-    super.key,
-    required this.onRetry,
-  })  : showInquireButton = false,
-        inBaseRoute = null;
+  const ErrorAndRetryWidget.cannotInquire({super.key, required this.onRetry})
+    : showInquireButton = false,
+      inBaseRoute = null;
 
   /// お問い合わせボタンを表示する [ErrorAndRetryWidget].
   const ErrorAndRetryWidget.canInquire({
@@ -44,15 +42,9 @@ class ErrorAndRetryWidget extends ConsumerWidget {
           size: 24,
         ),
         const Gap(8),
-        Text(
-          'エラーが発生しました。',
-          style: Theme.of(context).textTheme.titleLarge,
-        ),
+        Text('エラーが発生しました。', style: Theme.of(context).textTheme.titleLarge),
         const Gap(8),
-        Text(
-          '再読み込みをお試しください。',
-          style: Theme.of(context).textTheme.bodyMedium,
-        ),
+        Text('再読み込みをお試しください。', style: Theme.of(context).textTheme.bodyMedium),
         Text(
           '繰り返し発生する場合は、運営へお問い合わせください。',
           style: Theme.of(context).textTheme.bodyMedium,
@@ -94,10 +86,7 @@ class ErrorAndRetryWidget extends ConsumerWidget {
 
 /// [ErrorAndRetryWidget] の簡易版。
 class SimpleErrorAndRetryWidget extends StatelessWidget {
-  const SimpleErrorAndRetryWidget({
-    super.key,
-    required this.onRetry,
-  });
+  const SimpleErrorAndRetryWidget({super.key, required this.onRetry});
 
   final VoidCallback onRetry;
 
@@ -119,16 +108,13 @@ class SimpleErrorAndRetryWidget extends StatelessWidget {
               Text(
                 'エラー',
                 style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.error,
-                    ),
+                  color: Theme.of(context).colorScheme.error,
+                ),
               ),
             ],
           ),
           const Gap(8),
-          Text(
-            'タップで再読み込み',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
+          Text('タップで再読み込み', style: Theme.of(context).textTheme.titleMedium),
         ],
       ),
     );

--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -78,7 +78,9 @@ class InfinityScrollWidget extends ConsumerWidget {
           // ログ表示する。
           logger.e('error: $e, stackTrace: $s');
 
-          ref.read(snackBarControllerProvider).showErrorSnackBar(
+          ref
+              .read(snackBarControllerProvider)
+              .showErrorSnackBar(
                 '読み込めませんでした。もう一度お試しください。',
                 ScaffoldMessengerType.baseRoute,
               );
@@ -107,10 +109,7 @@ class InfinityScrollWidget extends ConsumerWidget {
             contentPadding: contentPadding,
             bottomWidget: listState.hasMore
                 ? const Column(
-                    children: [
-                      CupertinoActivityIndicator(),
-                      Gap(40),
-                    ],
+                    children: [CupertinoActivityIndicator(), Gap(40)],
                   )
                 : const SizedBox.shrink(),
             emptyWidget: emptyWidget,
@@ -249,9 +248,7 @@ class _StateScrollBar extends StatelessWidget {
           ),
           SliverPadding(
             padding: const EdgeInsets.only(top: 8, bottom: 40),
-            sliver: SliverToBoxAdapter(
-              child: bottomWidget,
-            ),
+            sliver: SliverToBoxAdapter(child: bottomWidget),
           ),
         ],
       ),
@@ -291,17 +288,13 @@ class _BottomWidgetWhenError extends StatelessWidget {
                   asyncListState.isRefreshing
                       ? Text(
                           '読み込み中...',
-                          style:
-                              Theme.of(context).textTheme.bodyMedium!.copyWith(
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                          style: Theme.of(context).textTheme.bodyMedium!
+                              .copyWith(fontWeight: FontWeight.bold),
                         )
                       : Text(
                           'タップで再読み込み',
-                          style:
-                              Theme.of(context).textTheme.bodyMedium!.copyWith(
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                          style: Theme.of(context).textTheme.bodyMedium!
+                              .copyWith(fontWeight: FontWeight.bold),
                         ),
                   const Gap(40),
                 ],

--- a/lib/core/common_widget/shimmer_widget.dart
+++ b/lib/core/common_widget/shimmer_widget.dart
@@ -7,10 +7,8 @@ class ShimmerWidget extends StatelessWidget {
     this.width = double.infinity,
     required this.height,
   }) : shapeBorder = const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(
-            Radius.circular(2),
-          ),
-        );
+         borderRadius: BorderRadius.all(Radius.circular(2)),
+       );
 
   const ShimmerWidget.circular({
     super.key,
@@ -25,15 +23,15 @@ class ShimmerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Shimmer.fromColors(
-        baseColor: Theme.of(context).colorScheme.surfaceVariant,
-        highlightColor: Theme.of(context).colorScheme.surface,
-        child: Container(
-          height: height,
-          width: width,
-          decoration: ShapeDecoration(
-            color: Theme.of(context).colorScheme.surfaceVariant,
-            shape: shapeBorder,
-          ),
-        ),
-      );
+    baseColor: Theme.of(context).colorScheme.surfaceVariant,
+    highlightColor: Theme.of(context).colorScheme.surface,
+    child: Container(
+      height: height,
+      width: width,
+      decoration: ShapeDecoration(
+        color: Theme.of(context).colorScheme.surfaceVariant,
+        shape: shapeBorder,
+      ),
+    ),
+  );
 }

--- a/lib/core/common_widget/simple_empty_widget.dart
+++ b/lib/core/common_widget/simple_empty_widget.dart
@@ -3,10 +3,7 @@ import 'package:gap/gap.dart';
 
 /// emptyステートとして使用する [message] を表示させるだけのシンプルな Widget.
 class SimpleEmptyWidget extends StatelessWidget {
-  const SimpleEmptyWidget({
-    super.key,
-    required this.message,
-  });
+  const SimpleEmptyWidget({super.key, required this.message});
 
   final String message;
 

--- a/lib/core/page/base_page.dart
+++ b/lib/core/page/base_page.dart
@@ -23,11 +23,7 @@ class BasePage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final currentUserId = ref.watch(userIdProvider);
     return currentUserId == null
-        ? const Scaffold(
-            body: Center(
-              child: CupertinoActivityIndicator(),
-            ),
-          )
+        ? const Scaffold(body: Center(child: CupertinoActivityIndicator()))
         : AutoTabsRouter(
             routes: [
               const HomeRouterRoute(),
@@ -78,9 +74,7 @@ class BasePage extends ConsumerWidget {
                       if (tabsRouter.activeIndex == index) {
                         // ネストされたルーターのスタック情報を破棄
                         tabsRouter
-                            .innerRouterOf<StackRouter>(
-                              tabsRouter.current.name,
-                            )
+                            .innerRouterOf<StackRouter>(tabsRouter.current.name)
                             ?.popUntilRoot();
 
                         PrimaryScrollController.of(

--- a/lib/core/page/definition_edit_page.dart
+++ b/lib/core/page/definition_edit_page.dart
@@ -13,10 +13,7 @@ import '../router/app_router.dart';
 
 @RoutePage()
 class DefinitionEditPage extends ConsumerWidget with PresentationMixin {
-  const DefinitionEditPage({
-    super.key,
-    required this.initialDefinition,
-  });
+  const DefinitionEditPage({super.key, required this.initialDefinition});
 
   final Definition initialDefinition;
 
@@ -24,8 +21,9 @@ class DefinitionEditPage extends ConsumerWidget with PresentationMixin {
   Widget build(BuildContext context, WidgetRef ref) {
     final initialDefinitionForWrite = initialDefinition.toDefinitionForWrite();
 
-    final definitionForWriteProvider =
-        definitionForWriteNotifierProvider(initialDefinitionForWrite);
+    final definitionForWriteProvider = definitionForWriteNotifierProvider(
+      initialDefinitionForWrite,
+    );
 
     final asyncDefinitionForWrite = ref.watch(definitionForWriteProvider);
     final notifier = ref.watch(definitionForWriteProvider.notifier);
@@ -57,29 +55,33 @@ class DefinitionEditPage extends ConsumerWidget with PresentationMixin {
                     }
 
                     // 投稿から1時間以上経過している場合、新規投稿するかどうかを確認する。
-                    ref.read(dialogControllerProvider).show(
-                      _AlertCannotEditDialog(
-                        onPost: () async {
-                          late final String definitionId;
-                          await executeWithOverlayLoading(
-                            ref,
-                            action: () async {
-                              definitionId = await notifier.post();
-                            },
-                            errorToastMessage: '投稿できませんでした。もう一度お試しください。',
-                            successToastMessage: '投稿しました！',
-                            inBaseRouteBeforeAction: false,
-                          );
-
-                          // 新規投稿した定義の詳細画面に遷移する。
-                          await ref.read(appRouterProvider).popAndPush(
-                                DefinitionDetailRoute(
-                                  definitionId: definitionId,
-                                ),
+                    ref
+                        .read(dialogControllerProvider)
+                        .show(
+                          _AlertCannotEditDialog(
+                            onPost: () async {
+                              late final String definitionId;
+                              await executeWithOverlayLoading(
+                                ref,
+                                action: () async {
+                                  definitionId = await notifier.post();
+                                },
+                                errorToastMessage: '投稿できませんでした。もう一度お試しください。',
+                                successToastMessage: '投稿しました！',
+                                inBaseRouteBeforeAction: false,
                               );
-                        },
-                      ),
-                    );
+
+                              // 新規投稿した定義の詳細画面に遷移する。
+                              await ref
+                                  .read(appRouterProvider)
+                                  .popAndPush(
+                                    DefinitionDetailRoute(
+                                      definitionId: definitionId,
+                                    ),
+                                  );
+                            },
+                          ),
+                        );
                   }
                 : null,
             child: Text(
@@ -87,30 +89,21 @@ class DefinitionEditPage extends ConsumerWidget with PresentationMixin {
               style: notifier.canEdit()
                   ? Theme.of(context).textTheme.titleLarge
                   : Theme.of(context).textTheme.titleLarge!.copyWith(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSurface
-                            .withOpacity(0.3),
-                      ),
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withOpacity(0.3),
+                    ),
             ),
           ),
         );
       },
       loading: () => Scaffold(
-        appBar: AppBar(
-          elevation: 0,
-        ),
-        body: const Center(
-          child: CircularProgressIndicator(),
-        ),
+        appBar: AppBar(elevation: 0),
+        body: const Center(child: CircularProgressIndicator()),
       ),
       error: (error, stackTrace) => Scaffold(
-        appBar: AppBar(
-          elevation: 0,
-        ),
-        body: Center(
-          child: Text(error.toString()),
-        ),
+        appBar: AppBar(elevation: 0),
+        body: Center(child: Text(error.toString())),
       ),
     );
   }
@@ -126,9 +119,7 @@ class _AlertCannotEditDialog extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return AlertDialog(
       elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       contentPadding: const EdgeInsets.only(
         top: 32,
         right: 24,
@@ -139,15 +130,9 @@ class _AlertCannotEditDialog extends ConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '投稿から1時間が経過したため保存できませんでした。',
-            overflow: TextOverflow.clip,
-          ),
+          Text('投稿から1時間が経過したため保存できませんでした。', overflow: TextOverflow.clip),
           Gap(8),
-          Text(
-            '代わりに、入力した内容で新規投稿しませんか？',
-            overflow: TextOverflow.clip,
-          ),
+          Text('代わりに、入力した内容で新規投稿しませんか？', overflow: TextOverflow.clip),
         ],
       ),
       actionsAlignment: MainAxisAlignment.spaceEvenly,
@@ -173,8 +158,8 @@ class _AlertCannotEditDialog extends ConsumerWidget {
             child: Text(
               '新規投稿する',
               style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
+                color: Theme.of(context).colorScheme.primary,
+              ),
             ),
           ),
         ),

--- a/lib/core/page/definition_post_page.dart
+++ b/lib/core/page/definition_post_page.dart
@@ -34,8 +34,9 @@ class DefinitionPostPage extends ConsumerWidget with PresentationMixin {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncDefinitionForWrite = ref
-        .watch(definitionForWriteNotifierProvider(initialDefinitionForWrite));
+    final asyncDefinitionForWrite = ref.watch(
+      definitionForWriteNotifierProvider(initialDefinitionForWrite),
+    );
     final notifier = ref.watch(
       definitionForWriteNotifierProvider(initialDefinitionForWrite).notifier,
     );
@@ -82,10 +83,10 @@ class DefinitionPostPage extends ConsumerWidget with PresentationMixin {
                       case AfterPostNavigationType.pop:
                         break;
                       case AfterPostNavigationType.toDetail:
-                        await ref.read(appRouterProvider).push(
-                              DefinitionDetailRoute(
-                                definitionId: definitionId,
-                              ),
+                        await ref
+                            .read(appRouterProvider)
+                            .push(
+                              DefinitionDetailRoute(definitionId: definitionId),
                             );
                         break;
                     }
@@ -96,30 +97,21 @@ class DefinitionPostPage extends ConsumerWidget with PresentationMixin {
               style: canPost
                   ? Theme.of(context).textTheme.titleLarge
                   : Theme.of(context).textTheme.titleLarge!.copyWith(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSurface
-                            .withOpacity(0.3),
-                      ),
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withOpacity(0.3),
+                    ),
             ),
           ),
         );
       },
       loading: () => Scaffold(
-        appBar: AppBar(
-          elevation: 0,
-        ),
-        body: const Center(
-          child: CircularProgressIndicator(),
-        ),
+        appBar: AppBar(elevation: 0),
+        body: const Center(child: CircularProgressIndicator()),
       ),
       error: (error, stackTrace) => Scaffold(
-        appBar: AppBar(
-          elevation: 0,
-        ),
-        body: Center(
-          child: Text(error.toString()),
-        ),
+        appBar: AppBar(elevation: 0),
+        body: Center(child: Text(error.toString())),
       ),
     );
   }

--- a/lib/core/page/dictionary_everyone_page.dart
+++ b/lib/core/page/dictionary_everyone_page.dart
@@ -26,10 +26,7 @@ class DictionaryEveryonePage extends StatelessWidget {
           leading: const ToSettingButton(),
         ),
         body: Padding(
-          padding: const EdgeInsets.only(
-            left: 16,
-            right: 16,
-          ),
+          padding: const EdgeInsets.only(left: 16, right: 16),
           child: ListView(
             children: const [
               Gap(24),

--- a/lib/core/page/dictionary_individual_page.dart
+++ b/lib/core/page/dictionary_individual_page.dart
@@ -57,18 +57,13 @@ class DictionaryIndividualPage extends ConsumerWidget {
           ),
         );
       },
-      loading: () => const Scaffold(
-        body: Center(
-          child: CupertinoActivityIndicator(),
-        ),
-      ),
+      loading: () =>
+          const Scaffold(body: Center(child: CupertinoActivityIndicator())),
       error: (error, stackTrace) {
         // エラー発生後の再読み込み中の場合、trueになる
         if (asyncTargetUserProfile.isRefreshing) {
           return Scaffold(
-            appBar: AppBar(
-              title: const Text('辞書'),
-            ),
+            appBar: AppBar(title: const Text('辞書')),
             body: const Padding(
               padding: EdgeInsets.symmetric(vertical: 24),
               child: Align(
@@ -79,12 +74,12 @@ class DictionaryIndividualPage extends ConsumerWidget {
           );
         }
 
-        logger.e('ユーザー[$targetUserId]のプロフィールの取得に失敗しました。'
-            'error: $error, stackTrace: $stackTrace');
+        logger.e(
+          'ユーザー[$targetUserId]のプロフィールの取得に失敗しました。'
+          'error: $error, stackTrace: $stackTrace',
+        );
         return Scaffold(
-          appBar: AppBar(
-            title: const Text('辞書'),
-          ),
+          appBar: AppBar(title: const Text('辞書')),
           body: Padding(
             padding: const EdgeInsets.symmetric(vertical: 24),
             child: Center(

--- a/lib/core/page/dictionary_sub_index_page.dart
+++ b/lib/core/page/dictionary_sub_index_page.dart
@@ -42,18 +42,16 @@ class DictionarySubIndexPage extends ConsumerWidget {
                     const Gap(16),
                     Padding(
                       padding: const EdgeInsets.only(bottom: 16),
-                      child:
-                          DictionaryAuthorWidget(targetUserId: targetUserId!),
+                      child: DictionaryAuthorWidget(
+                        targetUserId: targetUserId!,
+                      ),
                     ),
                   ],
                 )
               : const SizedBox.shrink(),
           const Gap(8),
           Padding(
-            padding: const EdgeInsets.only(
-              left: 16,
-              right: 16,
-            ),
+            padding: const EdgeInsets.only(left: 16, right: 16),
             child: ListView.builder(
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),

--- a/lib/core/page/home_page.dart
+++ b/lib/core/page/home_page.dart
@@ -63,9 +63,7 @@ class HomePage extends ConsumerWidget {
               children: <Widget>[
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.homeRecommend,
-                  emptyWidget: SimpleEmptyWidget(
-                    message: 'おすすめの投稿がありません...',
-                  ),
+                  emptyWidget: SimpleEmptyWidget(message: 'おすすめの投稿がありません...'),
                 ),
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.homeFollowing,

--- a/lib/core/page/profile_edit_page.dart
+++ b/lib/core/page/profile_edit_page.dart
@@ -16,17 +16,16 @@ import '../router/app_router.dart';
 
 @RoutePage()
 class ProfileEditPage extends ConsumerWidget with PresentationMixin {
-  ProfileEditPage({
-    super.key,
-  });
+  ProfileEditPage({super.key});
 
   final globalKey = GlobalKey();
   final avatarSize = AvatarSize.large;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncUserProfileForWrite =
-        ref.watch(userProfileForWriteNotifierProvider);
+    final asyncUserProfileForWrite = ref.watch(
+      userProfileForWriteNotifierProvider,
+    );
     final notifier = ref.watch(userProfileForWriteNotifierProvider.notifier);
 
     return asyncUserProfileForWrite.when(
@@ -48,11 +47,14 @@ class ProfileEditPage extends ConsumerWidget with PresentationMixin {
                 }
 
                 // 確認ダイアログを表示する。
-                ref.read(dialogControllerProvider).show(
+                ref
+                    .read(dialogControllerProvider)
+                    .show(
                       ConfirmDialog(
                         confirmMessage: '入力した内容は保存されません。\nよろしいですか？',
-                        onAccept: () async => Navigator.of(context)
-                            .popUntil((route) => route.isFirst),
+                        onAccept: () async => Navigator.of(
+                          context,
+                        ).popUntil((route) => route.isFirst),
                         confirmButtonText: 'OK',
                       ),
                     );
@@ -84,11 +86,10 @@ class ProfileEditPage extends ConsumerWidget with PresentationMixin {
                     style: canEdit
                         ? Theme.of(context).textTheme.titleLarge
                         : Theme.of(context).textTheme.titleLarge!.copyWith(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onSurface
-                                  .withOpacity(0.3),
-                            ),
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurface.withOpacity(0.3),
+                          ),
                   ),
                 ),
               ),
@@ -139,18 +140,13 @@ class ProfileEditPage extends ConsumerWidget with PresentationMixin {
           ),
         );
       },
-      loading: () => const Scaffold(
-        body: Center(
-          child: CupertinoActivityIndicator(),
-        ),
-      ),
+      loading: () =>
+          const Scaffold(body: Center(child: CupertinoActivityIndicator())),
       error: (error, stackTrace) {
         // エラー発生後の再読み込み中の場合、trueになる
         if (asyncUserProfileForWrite.isRefreshing) {
           return Scaffold(
-            appBar: AppBar(
-              title: const Text('プロフィール編集'),
-            ),
+            appBar: AppBar(title: const Text('プロフィール編集')),
             body: const Padding(
               padding: EdgeInsets.symmetric(vertical: 24),
               child: Align(
@@ -161,12 +157,12 @@ class ProfileEditPage extends ConsumerWidget with PresentationMixin {
           );
         }
 
-        logger.e('プロフィール編集画面でエラーが発生しました。'
-            'error: $error, stackTrace: $stackTrace');
+        logger.e(
+          'プロフィール編集画面でエラーが発生しました。'
+          'error: $error, stackTrace: $stackTrace',
+        );
         return Scaffold(
-          appBar: AppBar(
-            title: const Text('プロフィール編集'),
-          ),
+          appBar: AppBar(title: const Text('プロフィール編集')),
           body: Padding(
             padding: const EdgeInsets.symmetric(vertical: 24),
             child: Center(

--- a/lib/core/page/profile_top_page.dart
+++ b/lib/core/page/profile_top_page.dart
@@ -17,10 +17,7 @@ import '../common_widget/stickey_tab_bar_deligate.dart';
 
 @RoutePage()
 class ProfileTopPage extends ConsumerWidget {
-  const ProfileTopPage({
-    super.key,
-    required this.targetUserId,
-  });
+  const ProfileTopPage({super.key, required this.targetUserId});
 
   final String targetUserId;
 
@@ -61,9 +58,9 @@ class ProfileTopPage extends ConsumerWidget {
                   ],
                 ),
                 SliverList(
-                  delegate: SliverChildListDelegate(
-                    [ProfileWidget(targetUserId: targetUserId)],
-                  ),
+                  delegate: SliverChildListDelegate([
+                    ProfileWidget(targetUserId: targetUserId),
+                  ]),
                 ),
                 SliverPersistentHeader(
                   pinned: true,

--- a/lib/core/page/setting_page.dart
+++ b/lib/core/page/setting_page.dart
@@ -40,18 +40,12 @@ class SettingPage extends ConsumerWidget {
         ],
       ),
       body: Padding(
-        padding: const EdgeInsets.only(
-          left: 24,
-          right: 20,
-        ),
+        padding: const EdgeInsets.only(left: 24, right: 20),
         child: ListView(
           children: [
             const Gap(24),
             // 一般
-            Text(
-              '一般',
-              style: Theme.of(context).textTheme.titleSmall,
-            ),
+            Text('一般', style: Theme.of(context).textTheme.titleSmall),
             const Gap(8),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.speaker_slash),
@@ -63,16 +57,14 @@ class SettingPage extends ConsumerWidget {
             const Gap(32),
 
             // サポート
-            Text(
-              'サポート',
-              style: Theme.of(context).textTheme.titleSmall,
-            ),
+            Text('サポート', style: Theme.of(context).textTheme.titleSmall),
             const Gap(8),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.question_square),
               label: '使い方',
-              onTap: () =>
-                  ref.read(launchUrlControllerProvider).launchURL(howToPageUrl, inBaseRoute: false),
+              onTap: () => ref
+                  .read(launchUrlControllerProvider)
+                  .launchURL(howToPageUrl, inBaseRoute: false),
             ),
             const Gap(24),
             SettingTileButton(
@@ -80,11 +72,14 @@ class SettingPage extends ConsumerWidget {
               label: 'お問い合わせ',
               onTap: () {
                 final currentUserId = ref.read(userIdProvider)!;
-                final currentUserProfile =
-                    ref.read(userProfileProvider(currentUserId)).value;
+                final currentUserProfile = ref
+                    .read(userProfileProvider(currentUserId))
+                    .value;
                 final url = inquireFormUrl(currentUserProfile?.publicId ?? '');
 
-                ref.read(launchUrlControllerProvider).launchURL(url, inBaseRoute: false);
+                ref
+                    .read(launchUrlControllerProvider)
+                    .launchURL(url, inBaseRoute: false);
               },
             ),
             const Gap(24),
@@ -98,16 +93,14 @@ class SettingPage extends ConsumerWidget {
             const Gap(32),
 
             // アプリについて
-            Text(
-              'アプリについて',
-              style: Theme.of(context).textTheme.titleSmall,
-            ),
+            Text('アプリについて', style: Theme.of(context).textTheme.titleSmall),
             const Gap(8),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.doc_text),
               label: '利用規約',
-              onTap: () =>
-                  ref.read(launchUrlControllerProvider).launchURL(termPageUrl, inBaseRoute: false),
+              onTap: () => ref
+                  .read(launchUrlControllerProvider)
+                  .launchURL(termPageUrl, inBaseRoute: false),
             ),
             const Gap(24),
             SettingTileButton(
@@ -197,10 +190,7 @@ class SettingTileButton extends StatelessWidget {
           trailingIcon,
           const Gap(8),
           Expanded(
-            child: Text(
-              label,
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
+            child: Text(label, style: Theme.of(context).textTheme.titleLarge),
           ),
           Align(
             alignment: Alignment.centerRight,

--- a/lib/core/page/user_list_liked_page.dart
+++ b/lib/core/page/user_list_liked_page.dart
@@ -9,10 +9,7 @@ import '../../feature/user_list/util/user_list_type.dart';
 
 @RoutePage()
 class UserListLikedPage extends ConsumerWidget {
-  const UserListLikedPage({
-    super.key,
-    required this.definitionId,
-  });
+  const UserListLikedPage({super.key, required this.definitionId});
   final String definitionId;
 
   @override
@@ -42,9 +39,7 @@ class UserListLikedPage extends ConsumerWidget {
             targetUserId: null,
             targetDefinitionId: definitionId,
             // いいねが0件の場合、[LikeUserPage] には遷移しない想定だが念のため設定しておく
-            emptyWidget: const SimpleEmptyWidget(
-              message: 'まだいいね！されていません',
-            ),
+            emptyWidget: const SimpleEmptyWidget(message: 'まだいいね！されていません'),
           ),
         ),
       ),

--- a/lib/core/page/user_list_muted_page.dart
+++ b/lib/core/page/user_list_muted_page.dart
@@ -19,9 +19,7 @@ class UserListMutedPage extends ConsumerWidget {
     final asyncMutedUserIdList = ref.watch(mutedUserIdListProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('ミュート中のユーザー'),
-      ),
+      appBar: AppBar(title: const Text('ミュート中のユーザー')),
       body: asyncMutedUserIdList.when(
         data: (mutedUserIdList) {
           if (mutedUserIdList.isEmpty) {
@@ -58,8 +56,10 @@ class UserListMutedPage extends ConsumerWidget {
             );
           }
 
-          logger.e('ミュートユーザーの取得に失敗しました。'
-              'error: $error, stackTrace: $stackTrace');
+          logger.e(
+            'ミュートユーザーの取得に失敗しました。'
+            'error: $error, stackTrace: $stackTrace',
+          );
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Align(

--- a/lib/core/page/user_search_page.dart
+++ b/lib/core/page/user_search_page.dart
@@ -12,14 +12,9 @@ class UserSearchPage extends StatelessWidget {
     return GestureDetector(
       onTap: () => primaryFocus?.unfocus(),
       child: Scaffold(
-        appBar: AppBar(
-          title: const Text('ユーザーを探す'),
-        ),
+        appBar: AppBar(title: const Text('ユーザーを探す')),
         body: Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: 24,
-            horizontal: 40,
-          ),
+          padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
           child: SearchUserTextField(autoFocus: true),
         ),
       ),

--- a/lib/core/page/user_search_result_page.dart
+++ b/lib/core/page/user_search_result_page.dart
@@ -19,15 +19,14 @@ class UserSearchResultPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncUserProfileByPublicId =
-        ref.watch(userIdSearchByPublicIdProvider(searchWord));
+    final asyncUserProfileByPublicId = ref.watch(
+      userIdSearchByPublicIdProvider(searchWord),
+    );
 
     return GestureDetector(
       onTap: () => primaryFocus?.unfocus(),
       child: Scaffold(
-        appBar: AppBar(
-          title: const Text('ユーザーを探す'),
-        ),
+        appBar: AppBar(title: const Text('ユーザーを探す')),
         body: Padding(
           padding: const EdgeInsets.only(left: 16, right: 16),
           child: asyncUserProfileByPublicId.when(
@@ -60,8 +59,10 @@ class UserSearchResultPage extends ConsumerWidget {
             },
             loading: ProfileTileShimmer.new,
             error: (error, stackTrace) {
-              logger.e('[$searchWord]を検索時にエラーが発生しました。'
-                  'error: $error, stackTrace: $stackTrace');
+              logger.e(
+                '[$searchWord]を検索時にエラーが発生しました。'
+                'error: $error, stackTrace: $stackTrace',
+              );
               return ErrorAndRetryWidget.cannotInquire(
                 onRetry: () =>
                     ref.invalidate(userIdSearchByPublicIdProvider(searchWord)),

--- a/lib/core/page/welcome_page.dart
+++ b/lib/core/page/welcome_page.dart
@@ -34,10 +34,7 @@ class WelcomePage extends ConsumerWidget {
                 ),
               ),
               const Gap(24),
-              Text(
-                'ようこそ！',
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
+              Text('ようこそ！', style: Theme.of(context).textTheme.titleLarge),
               const Gap(24),
               Text(
                 '思うがままに\n言葉を定義しちゃってください😆',
@@ -47,9 +44,9 @@ class WelcomePage extends ConsumerWidget {
               const Gap(24),
               PrimaryFilledButton(
                 onPressed: () {
-                  ref.read(dialogControllerProvider).show(
-                        const ConfirmAgreementDialog(),
-                      );
+                  ref
+                      .read(dialogControllerProvider)
+                      .show(const ConfirmAgreementDialog());
                 },
                 text: 'はじめる',
               ),
@@ -64,11 +61,10 @@ class WelcomePage extends ConsumerWidget {
                     child: Text(
                       '利用規約',
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                            decoration: TextDecoration.underline,
-                          ),
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        decoration: TextDecoration.underline,
+                      ),
                     ),
                   ),
                   const Text(' と '),
@@ -79,11 +75,10 @@ class WelcomePage extends ConsumerWidget {
                     child: Text(
                       'プライバシーポリシー',
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                            decoration: TextDecoration.underline,
-                          ),
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        decoration: TextDecoration.underline,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/core/page/word_list_page.dart
+++ b/lib/core/page/word_list_page.dart
@@ -16,17 +16,15 @@ import '../common_widget/simple_empty_widget.dart';
 
 @RoutePage()
 class WordListPage extends ConsumerWidget {
-  const WordListPage({
-    super.key,
-    required this.selectedInitialSubGroup,
-  });
+  const WordListPage({super.key, required this.selectedInitialSubGroup});
 
   final InitialSubGroup selectedInitialSubGroup;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final wordListProvider =
-        wordListStateByInitialNotifierProvider(selectedInitialSubGroup.label);
+    final wordListProvider = wordListStateByInitialNotifierProvider(
+      selectedInitialSubGroup.label,
+    );
 
     String generateEmptyMessage(String initialLabel) {
       final messageList = [

--- a/lib/core/page/word_search_result_page.dart
+++ b/lib/core/page/word_search_result_page.dart
@@ -17,17 +17,15 @@ import '../common_widget/simple_empty_widget.dart';
 
 @RoutePage()
 class WordSearchResultPage extends ConsumerWidget {
-  const WordSearchResultPage({
-    super.key,
-    required this.searchWord,
-  });
+  const WordSearchResultPage({super.key, required this.searchWord});
 
   final String searchWord;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final wordListProvider =
-        wordListStateBySearchWordNotifierProvider(searchWord);
+    final wordListProvider = wordListStateBySearchWordNotifierProvider(
+      searchWord,
+    );
 
     String generateEmptyMessage(String label) {
       final messageList = [

--- a/lib/core/page/word_top_page.dart
+++ b/lib/core/page/word_top_page.dart
@@ -17,10 +17,7 @@ import '../common_widget/stickey_tab_bar_deligate.dart';
 
 @RoutePage()
 class WordTopPage extends ConsumerWidget {
-  const WordTopPage({
-    super.key,
-    required this.wordId,
-  });
+  const WordTopPage({super.key, required this.wordId});
 
   final String wordId;
 
@@ -72,14 +69,12 @@ class WordTopPage extends ConsumerWidget {
                     SliverAppBar(
                       forceElevated: true,
                       floating: true,
-                      title: Text(
-                        word.word,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                      title: Text(word.word, overflow: TextOverflow.ellipsis),
                     ),
                     SliverList(
-                      delegate:
-                          SliverChildListDelegate([WordWidget(word: word)]),
+                      delegate: SliverChildListDelegate([
+                        WordWidget(word: word),
+                      ]),
                     ),
                     SliverPersistentHeader(
                       pinned: true,
@@ -92,8 +87,9 @@ class WordTopPage extends ConsumerWidget {
                             Tab(text: 'いいね数順'),
                           ],
                           onTap: (_) {
-                            if (DefaultTabController.of(context)
-                                .indexIsChanging) {
+                            if (DefaultTabController.of(
+                              context,
+                            ).indexIsChanging) {
                               // * タブを切り替えた場合
                               return;
                             }
@@ -137,15 +133,13 @@ class WordTopPage extends ConsumerWidget {
         },
         loading: () => Scaffold(
           appBar: AppBar(),
-          body: const Column(
-            children: [
-              WordPageShimmer(),
-            ],
-          ),
+          body: const Column(children: [WordPageShimmer()]),
         ),
         error: (error, stackTrace) {
-          logger.e('語句[$wordId]の取得に失敗しました。'
-              'error: $error, stackTrace: $stackTrace');
+          logger.e(
+            '語句[$wordId]の取得に失敗しました。'
+            'error: $error, stackTrace: $stackTrace',
+          );
 
           return Scaffold(
             appBar: AppBar(),
@@ -155,7 +149,7 @@ class WordTopPage extends ConsumerWidget {
                 alignment: Alignment.topCenter,
                 child: asyncWord.isRefreshing
                     ? // エラー発生後の再読み込み中の場合
-                    const CupertinoActivityIndicator()
+                      const CupertinoActivityIndicator()
                     : ErrorAndRetryWidget.cannotInquire(
                         onRetry: () => ref.invalidate(wordProvider(wordId)),
                       ),

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -49,22 +49,10 @@ class AppRouter extends _$AppRouter {
   final Ref ref;
 
   final List<AdaptiveRoute> commonRouteList = [
-    AdaptiveRoute(
-      path: 'definition_detail',
-      page: DefinitionDetailRoute.page,
-    ),
-    AdaptiveRoute(
-      path: 'user_list_liked',
-      page: UserListLikedRoute.page,
-    ),
-    AdaptiveRoute(
-      path: 'word_top',
-      page: WordTopRoute.page,
-    ),
-    AdaptiveRoute(
-      path: 'profile_top',
-      page: ProfileTopRoute.page,
-    ),
+    AdaptiveRoute(path: 'definition_detail', page: DefinitionDetailRoute.page),
+    AdaptiveRoute(path: 'user_list_liked', page: UserListLikedRoute.page),
+    AdaptiveRoute(path: 'word_top', page: WordTopRoute.page),
+    AdaptiveRoute(path: 'profile_top', page: ProfileTopRoute.page),
     AdaptiveRoute(
       path: 'user_list_following_or_follower',
       page: UserListFollowingOrFollowerRoute.page,
@@ -77,119 +65,86 @@ class AppRouter extends _$AppRouter {
       path: 'individual_dictionary_definition_list',
       page: IndividualDictionaryDefinitionListRoute.page,
     ),
-    AdaptiveRoute(
-      path: 'user_search',
-      page: UserSearchRoute.page,
-    ),
-    AdaptiveRoute(
-      path: 'user_search_result',
-      page: UserSearchResultRoute.page,
-    ),
+    AdaptiveRoute(path: 'user_search', page: UserSearchRoute.page),
+    AdaptiveRoute(path: 'user_search_result', page: UserSearchResultRoute.page),
   ];
 
   @override
   List<AdaptiveRoute> get routes => [
+    AdaptiveRoute(path: '/welcome', page: WelcomeRoute.page),
+    AdaptiveRoute(
+      path: '/',
+      page: BaseRoute.page,
+      guards: [ref.read(firstLaunchGuardProvider), ref.read(authGuardProvider)],
+      children: [
         AdaptiveRoute(
-          path: '/welcome',
-          page: WelcomeRoute.page,
+          path: 'home',
+          page: HomeRouterRoute.page,
+          children: [
+            AdaptiveRoute(initial: true, page: HomeRoute.page),
+            AdaptiveRoute(
+              path: 'dictionary_individual',
+              page: DictionaryIndividualRoute.page,
+            ),
+            ...commonRouteList,
+          ],
         ),
         AdaptiveRoute(
-          path: '/',
-          page: BaseRoute.page,
-          guards: [
-            ref.read(firstLaunchGuardProvider),
-            ref.read(authGuardProvider),
-          ],
+          path: 'dictionary_individual',
+          page: DictionaryIndividualRouterRoute.page,
           children: [
+            AdaptiveRoute(initial: true, page: DictionaryIndividualRoute.page),
+            ...commonRouteList,
+          ],
+        ),
+        AdaptiveRoute(
+          path: 'dictionary_everyone',
+          page: DictionaryEveryoneRouterRoute.page,
+          children: [
+            AdaptiveRoute(initial: true, page: DictionaryEveryoneRoute.page),
+            AdaptiveRoute(path: 'word_list', page: WordListRoute.page),
             AdaptiveRoute(
-              path: 'home',
-              page: HomeRouterRoute.page,
-              children: [
-                AdaptiveRoute(
-                  initial: true,
-                  page: HomeRoute.page,
-                ),
-                AdaptiveRoute(
-                  path: 'dictionary_individual',
-                  page: DictionaryIndividualRoute.page,
-                ),
-                ...commonRouteList,
-              ],
+              path: 'word_search_result',
+              page: WordSearchResultRoute.page,
             ),
             AdaptiveRoute(
               path: 'dictionary_individual',
-              page: DictionaryIndividualRouterRoute.page,
-              children: [
-                AdaptiveRoute(
-                  initial: true,
-                  page: DictionaryIndividualRoute.page,
-                ),
-                ...commonRouteList,
-              ],
+              page: DictionaryIndividualRoute.page,
             ),
-            AdaptiveRoute(
-              path: 'dictionary_everyone',
-              page: DictionaryEveryoneRouterRoute.page,
-              children: [
-                AdaptiveRoute(
-                  initial: true,
-                  page: DictionaryEveryoneRoute.page,
-                ),
-                AdaptiveRoute(
-                  path: 'word_list',
-                  page: WordListRoute.page,
-                ),
-                AdaptiveRoute(
-                  path: 'word_search_result',
-                  page: WordSearchResultRoute.page,
-                ),
-                AdaptiveRoute(
-                  path: 'dictionary_individual',
-                  page: DictionaryIndividualRoute.page,
-                ),
-                ...commonRouteList,
-              ],
-            ),
+            ...commonRouteList,
           ],
         ),
-        AdaptiveRoute(
-          path: '/setting',
-          page: SettingRouterRoute.page,
-          fullscreenDialog: true,
-          children: [
-            AdaptiveRoute(
-              initial: true,
-              page: SettingRoute.page,
-            ),
-            AdaptiveRoute(
-              path: 'license',
-              page: MyLicenseRoute.page,
-            ),
-            AdaptiveRoute(
-              path: 'user_list_muted',
-              page: UserListMutedRoute.page,
-            ),
-          ],
-        ),
-        AdaptiveRoute(
-          path: '/definition_post',
-          page: DefinitionPostRoute.page,
-          fullscreenDialog: true,
-        ),
-        AdaptiveRoute(
-          path: '/definition_edit',
-          page: DefinitionEditRoute.page,
-          fullscreenDialog: true,
-        ),
-        AdaptiveRoute(
-          path: '/profile_edit',
-          page: ProfileEditRoute.page,
-          fullscreenDialog: true,
-        ),
-        AdaptiveRoute(
-          path: '/sign_in_failure',
-          page: SignInFailureRoute.page,
-          fullscreenDialog: true,
-        ),
-      ];
+      ],
+    ),
+    AdaptiveRoute(
+      path: '/setting',
+      page: SettingRouterRoute.page,
+      fullscreenDialog: true,
+      children: [
+        AdaptiveRoute(initial: true, page: SettingRoute.page),
+        AdaptiveRoute(path: 'license', page: MyLicenseRoute.page),
+        AdaptiveRoute(path: 'user_list_muted', page: UserListMutedRoute.page),
+      ],
+    ),
+    AdaptiveRoute(
+      path: '/definition_post',
+      page: DefinitionPostRoute.page,
+      fullscreenDialog: true,
+    ),
+    AdaptiveRoute(
+      path: '/definition_edit',
+      page: DefinitionEditRoute.page,
+      fullscreenDialog: true,
+    ),
+    AdaptiveRoute(
+      path: '/profile_edit',
+      page: ProfileEditRoute.page,
+      fullscreenDialog: true,
+    ),
+    AdaptiveRoute(
+      path: '/sign_in_failure',
+      page: SignInFailureRoute.page,
+      fullscreenDialog: true,
+    ),
+  ];
 }

--- a/lib/core/router/app_router.g.dart
+++ b/lib/core/router/app_router.g.dart
@@ -13,8 +13,9 @@ String _$appRouterHash() => r'feb7a4e507f23e7f2b0c6b4ac54db31d22d36356';
 final appRouterProvider = AutoDisposeProvider<Raw<AppRouter>>.internal(
   appRouter,
   name: r'appRouterProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$appRouterHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appRouterHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/core/router/app_router.gr.dart
+++ b/lib/core/router/app_router.gr.dart
@@ -113,8 +113,8 @@ abstract class _$AppRouter extends RootStackRouter {
       );
     },
     IndividualDictionaryDefinitionListRoute.name: (routeData) {
-      final args =
-          routeData.argsAs<IndividualDictionaryDefinitionListRouteArgs>();
+      final args = routeData
+          .argsAs<IndividualDictionaryDefinitionListRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
         child: IndividualDictionaryDefinitionListPage(
@@ -132,7 +132,8 @@ abstract class _$AppRouter extends RootStackRouter {
     },
     ProfileEditRoute.name: (routeData) {
       final args = routeData.argsAs<ProfileEditRouteArgs>(
-          orElse: () => const ProfileEditRouteArgs());
+        orElse: () => const ProfileEditRouteArgs(),
+      );
       return AutoRoutePage<dynamic>(
         routeData: routeData,
         child: ProfileEditPage(key: args.key),
@@ -142,10 +143,7 @@ abstract class _$AppRouter extends RootStackRouter {
       final args = routeData.argsAs<ProfileTopRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ProfileTopPage(
-          key: args.key,
-          targetUserId: args.targetUserId,
-        ),
+        child: ProfileTopPage(key: args.key, targetUserId: args.targetUserId),
       );
     },
     SettingRoute.name: (routeData) {
@@ -203,10 +201,7 @@ abstract class _$AppRouter extends RootStackRouter {
       final args = routeData.argsAs<UserSearchResultRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserSearchResultPage(
-          key: args.key,
-          searchWord: args.searchWord,
-        ),
+        child: UserSearchResultPage(key: args.key, searchWord: args.searchWord),
       );
     },
     WelcomeRoute.name: (routeData) {
@@ -229,20 +224,14 @@ abstract class _$AppRouter extends RootStackRouter {
       final args = routeData.argsAs<WordSearchResultRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: WordSearchResultPage(
-          key: args.key,
-          searchWord: args.searchWord,
-        ),
+        child: WordSearchResultPage(key: args.key, searchWord: args.searchWord),
       );
     },
     WordTopRoute.name: (routeData) {
       final args = routeData.argsAs<WordTopRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: WordTopPage(
-          key: args.key,
-          wordId: args.wordId,
-        ),
+        child: WordTopPage(key: args.key, wordId: args.wordId),
       );
     },
   };
@@ -252,10 +241,7 @@ abstract class _$AppRouter extends RootStackRouter {
 /// [BasePage]
 class BaseRoute extends PageRouteInfo<void> {
   const BaseRoute({List<PageRouteInfo>? children})
-      : super(
-          BaseRoute.name,
-          initialChildren: children,
-        );
+    : super(BaseRoute.name, initialChildren: children);
 
   static const String name = 'BaseRoute';
 
@@ -266,10 +252,7 @@ class BaseRoute extends PageRouteInfo<void> {
 /// [BaseRouterPage]
 class BaseRouterRoute extends PageRouteInfo<void> {
   const BaseRouterRoute({List<PageRouteInfo>? children})
-      : super(
-          BaseRouterRoute.name,
-          initialChildren: children,
-        );
+    : super(BaseRouterRoute.name, initialChildren: children);
 
   static const String name = 'BaseRouterRoute';
 
@@ -284,13 +267,10 @@ class DefinitionDetailRoute extends PageRouteInfo<DefinitionDetailRouteArgs> {
     required String definitionId,
     List<PageRouteInfo>? children,
   }) : super(
-          DefinitionDetailRoute.name,
-          args: DefinitionDetailRouteArgs(
-            key: key,
-            definitionId: definitionId,
-          ),
-          initialChildren: children,
-        );
+         DefinitionDetailRoute.name,
+         args: DefinitionDetailRouteArgs(key: key, definitionId: definitionId),
+         initialChildren: children,
+       );
 
   static const String name = 'DefinitionDetailRoute';
 
@@ -299,10 +279,7 @@ class DefinitionDetailRoute extends PageRouteInfo<DefinitionDetailRouteArgs> {
 }
 
 class DefinitionDetailRouteArgs {
-  const DefinitionDetailRouteArgs({
-    this.key,
-    required this.definitionId,
-  });
+  const DefinitionDetailRouteArgs({this.key, required this.definitionId});
 
   final Key? key;
 
@@ -322,13 +299,13 @@ class DefinitionEditRoute extends PageRouteInfo<DefinitionEditRouteArgs> {
     required Definition initialDefinition,
     List<PageRouteInfo>? children,
   }) : super(
-          DefinitionEditRoute.name,
-          args: DefinitionEditRouteArgs(
-            key: key,
-            initialDefinition: initialDefinition,
-          ),
-          initialChildren: children,
-        );
+         DefinitionEditRoute.name,
+         args: DefinitionEditRouteArgs(
+           key: key,
+           initialDefinition: initialDefinition,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'DefinitionEditRoute';
 
@@ -337,10 +314,7 @@ class DefinitionEditRoute extends PageRouteInfo<DefinitionEditRouteArgs> {
 }
 
 class DefinitionEditRouteArgs {
-  const DefinitionEditRouteArgs({
-    this.key,
-    required this.initialDefinition,
-  });
+  const DefinitionEditRouteArgs({this.key, required this.initialDefinition});
 
   final Key? key;
 
@@ -362,15 +336,15 @@ class DefinitionPostRoute extends PageRouteInfo<DefinitionPostRouteArgs> {
     AfterPostNavigationType afterPostNavigation = AfterPostNavigationType.pop,
     List<PageRouteInfo>? children,
   }) : super(
-          DefinitionPostRoute.name,
-          args: DefinitionPostRouteArgs(
-            key: key,
-            initialDefinitionForWrite: initialDefinitionForWrite,
-            autoFocusForm: autoFocusForm,
-            afterPostNavigation: afterPostNavigation,
-          ),
-          initialChildren: children,
-        );
+         DefinitionPostRoute.name,
+         args: DefinitionPostRouteArgs(
+           key: key,
+           initialDefinitionForWrite: initialDefinitionForWrite,
+           autoFocusForm: autoFocusForm,
+           afterPostNavigation: afterPostNavigation,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'DefinitionPostRoute';
 
@@ -404,10 +378,7 @@ class DefinitionPostRouteArgs {
 /// [DictionaryEveryonePage]
 class DictionaryEveryoneRoute extends PageRouteInfo<void> {
   const DictionaryEveryoneRoute({List<PageRouteInfo>? children})
-      : super(
-          DictionaryEveryoneRoute.name,
-          initialChildren: children,
-        );
+    : super(DictionaryEveryoneRoute.name, initialChildren: children);
 
   static const String name = 'DictionaryEveryoneRoute';
 
@@ -418,10 +389,7 @@ class DictionaryEveryoneRoute extends PageRouteInfo<void> {
 /// [DictionaryEveryoneRouterPage]
 class DictionaryEveryoneRouterRoute extends PageRouteInfo<void> {
   const DictionaryEveryoneRouterRoute({List<PageRouteInfo>? children})
-      : super(
-          DictionaryEveryoneRouterRoute.name,
-          initialChildren: children,
-        );
+    : super(DictionaryEveryoneRouterRoute.name, initialChildren: children);
 
   static const String name = 'DictionaryEveryoneRouterRoute';
 
@@ -438,14 +406,14 @@ class DictionaryIndividualRoute
     bool isTopRoute = false,
     List<PageRouteInfo>? children,
   }) : super(
-          DictionaryIndividualRoute.name,
-          args: DictionaryIndividualRouteArgs(
-            key: key,
-            targetUserId: targetUserId,
-            isTopRoute: isTopRoute,
-          ),
-          initialChildren: children,
-        );
+         DictionaryIndividualRoute.name,
+         args: DictionaryIndividualRouteArgs(
+           key: key,
+           targetUserId: targetUserId,
+           isTopRoute: isTopRoute,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'DictionaryIndividualRoute';
 
@@ -476,10 +444,7 @@ class DictionaryIndividualRouteArgs {
 /// [DictionaryIndividualRouterPage]
 class DictionaryIndividualRouterRoute extends PageRouteInfo<void> {
   const DictionaryIndividualRouterRoute({List<PageRouteInfo>? children})
-      : super(
-          DictionaryIndividualRouterRoute.name,
-          initialChildren: children,
-        );
+    : super(DictionaryIndividualRouterRoute.name, initialChildren: children);
 
   static const String name = 'DictionaryIndividualRouterRoute';
 
@@ -497,15 +462,15 @@ class DictionarySubIndexRoute
     required String? targetUserId,
     List<PageRouteInfo>? children,
   }) : super(
-          DictionarySubIndexRoute.name,
-          args: DictionarySubIndexRouteArgs(
-            key: key,
-            selectedInitialMainGroup: selectedInitialMainGroup,
-            dictionaryPageType: dictionaryPageType,
-            targetUserId: targetUserId,
-          ),
-          initialChildren: children,
-        );
+         DictionarySubIndexRoute.name,
+         args: DictionarySubIndexRouteArgs(
+           key: key,
+           selectedInitialMainGroup: selectedInitialMainGroup,
+           dictionaryPageType: dictionaryPageType,
+           targetUserId: targetUserId,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'DictionarySubIndexRoute';
 
@@ -539,10 +504,7 @@ class DictionarySubIndexRouteArgs {
 /// [HomePage]
 class HomeRoute extends PageRouteInfo<void> {
   const HomeRoute({List<PageRouteInfo>? children})
-      : super(
-          HomeRoute.name,
-          initialChildren: children,
-        );
+    : super(HomeRoute.name, initialChildren: children);
 
   static const String name = 'HomeRoute';
 
@@ -553,10 +515,7 @@ class HomeRoute extends PageRouteInfo<void> {
 /// [HomeRouterPage]
 class HomeRouterRoute extends PageRouteInfo<void> {
   const HomeRouterRoute({List<PageRouteInfo>? children})
-      : super(
-          HomeRouterRoute.name,
-          initialChildren: children,
-        );
+    : super(HomeRouterRoute.name, initialChildren: children);
 
   static const String name = 'HomeRouterRoute';
 
@@ -573,14 +532,14 @@ class IndividualDictionaryDefinitionListRoute
     required InitialSubGroup initialSubGroup,
     List<PageRouteInfo>? children,
   }) : super(
-          IndividualDictionaryDefinitionListRoute.name,
-          args: IndividualDictionaryDefinitionListRouteArgs(
-            key: key,
-            targetUserId: targetUserId,
-            initialSubGroup: initialSubGroup,
-          ),
-          initialChildren: children,
-        );
+         IndividualDictionaryDefinitionListRoute.name,
+         args: IndividualDictionaryDefinitionListRouteArgs(
+           key: key,
+           targetUserId: targetUserId,
+           initialSubGroup: initialSubGroup,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'IndividualDictionaryDefinitionListRoute';
 
@@ -611,10 +570,7 @@ class IndividualDictionaryDefinitionListRouteArgs {
 /// [MyLicensePage]
 class MyLicenseRoute extends PageRouteInfo<void> {
   const MyLicenseRoute({List<PageRouteInfo>? children})
-      : super(
-          MyLicenseRoute.name,
-          initialChildren: children,
-        );
+    : super(MyLicenseRoute.name, initialChildren: children);
 
   static const String name = 'MyLicenseRoute';
 
@@ -624,14 +580,12 @@ class MyLicenseRoute extends PageRouteInfo<void> {
 /// generated route for
 /// [ProfileEditPage]
 class ProfileEditRoute extends PageRouteInfo<ProfileEditRouteArgs> {
-  ProfileEditRoute({
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ProfileEditRoute.name,
-          args: ProfileEditRouteArgs(key: key),
-          initialChildren: children,
-        );
+  ProfileEditRoute({Key? key, List<PageRouteInfo>? children})
+    : super(
+        ProfileEditRoute.name,
+        args: ProfileEditRouteArgs(key: key),
+        initialChildren: children,
+      );
 
   static const String name = 'ProfileEditRoute';
 
@@ -658,13 +612,10 @@ class ProfileTopRoute extends PageRouteInfo<ProfileTopRouteArgs> {
     required String targetUserId,
     List<PageRouteInfo>? children,
   }) : super(
-          ProfileTopRoute.name,
-          args: ProfileTopRouteArgs(
-            key: key,
-            targetUserId: targetUserId,
-          ),
-          initialChildren: children,
-        );
+         ProfileTopRoute.name,
+         args: ProfileTopRouteArgs(key: key, targetUserId: targetUserId),
+         initialChildren: children,
+       );
 
   static const String name = 'ProfileTopRoute';
 
@@ -673,10 +624,7 @@ class ProfileTopRoute extends PageRouteInfo<ProfileTopRouteArgs> {
 }
 
 class ProfileTopRouteArgs {
-  const ProfileTopRouteArgs({
-    this.key,
-    required this.targetUserId,
-  });
+  const ProfileTopRouteArgs({this.key, required this.targetUserId});
 
   final Key? key;
 
@@ -692,10 +640,7 @@ class ProfileTopRouteArgs {
 /// [SettingPage]
 class SettingRoute extends PageRouteInfo<void> {
   const SettingRoute({List<PageRouteInfo>? children})
-      : super(
-          SettingRoute.name,
-          initialChildren: children,
-        );
+    : super(SettingRoute.name, initialChildren: children);
 
   static const String name = 'SettingRoute';
 
@@ -706,10 +651,7 @@ class SettingRoute extends PageRouteInfo<void> {
 /// [SettingRouterPage]
 class SettingRouterRoute extends PageRouteInfo<void> {
   const SettingRouterRoute({List<PageRouteInfo>? children})
-      : super(
-          SettingRouterRoute.name,
-          initialChildren: children,
-        );
+    : super(SettingRouterRoute.name, initialChildren: children);
 
   static const String name = 'SettingRouterRoute';
 
@@ -720,10 +662,7 @@ class SettingRouterRoute extends PageRouteInfo<void> {
 /// [SignInFailurePage]
 class SignInFailureRoute extends PageRouteInfo<void> {
   const SignInFailureRoute({List<PageRouteInfo>? children})
-      : super(
-          SignInFailureRoute.name,
-          initialChildren: children,
-        );
+    : super(SignInFailureRoute.name, initialChildren: children);
 
   static const String name = 'SignInFailureRoute';
 
@@ -740,14 +679,14 @@ class UserListFollowingOrFollowerRoute
     required String targetUserId,
     List<PageRouteInfo>? children,
   }) : super(
-          UserListFollowingOrFollowerRoute.name,
-          args: UserListFollowingOrFollowerRouteArgs(
-            key: key,
-            initialTab: initialTab,
-            targetUserId: targetUserId,
-          ),
-          initialChildren: children,
-        );
+         UserListFollowingOrFollowerRoute.name,
+         args: UserListFollowingOrFollowerRouteArgs(
+           key: key,
+           initialTab: initialTab,
+           targetUserId: targetUserId,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'UserListFollowingOrFollowerRoute';
 
@@ -782,13 +721,10 @@ class UserListLikedRoute extends PageRouteInfo<UserListLikedRouteArgs> {
     required String definitionId,
     List<PageRouteInfo>? children,
   }) : super(
-          UserListLikedRoute.name,
-          args: UserListLikedRouteArgs(
-            key: key,
-            definitionId: definitionId,
-          ),
-          initialChildren: children,
-        );
+         UserListLikedRoute.name,
+         args: UserListLikedRouteArgs(key: key, definitionId: definitionId),
+         initialChildren: children,
+       );
 
   static const String name = 'UserListLikedRoute';
 
@@ -797,10 +733,7 @@ class UserListLikedRoute extends PageRouteInfo<UserListLikedRouteArgs> {
 }
 
 class UserListLikedRouteArgs {
-  const UserListLikedRouteArgs({
-    this.key,
-    required this.definitionId,
-  });
+  const UserListLikedRouteArgs({this.key, required this.definitionId});
 
   final Key? key;
 
@@ -816,10 +749,7 @@ class UserListLikedRouteArgs {
 /// [UserListMutedPage]
 class UserListMutedRoute extends PageRouteInfo<void> {
   const UserListMutedRoute({List<PageRouteInfo>? children})
-      : super(
-          UserListMutedRoute.name,
-          initialChildren: children,
-        );
+    : super(UserListMutedRoute.name, initialChildren: children);
 
   static const String name = 'UserListMutedRoute';
 
@@ -830,10 +760,7 @@ class UserListMutedRoute extends PageRouteInfo<void> {
 /// [UserSearchPage]
 class UserSearchRoute extends PageRouteInfo<void> {
   const UserSearchRoute({List<PageRouteInfo>? children})
-      : super(
-          UserSearchRoute.name,
-          initialChildren: children,
-        );
+    : super(UserSearchRoute.name, initialChildren: children);
 
   static const String name = 'UserSearchRoute';
 
@@ -848,13 +775,10 @@ class UserSearchResultRoute extends PageRouteInfo<UserSearchResultRouteArgs> {
     required String searchWord,
     List<PageRouteInfo>? children,
   }) : super(
-          UserSearchResultRoute.name,
-          args: UserSearchResultRouteArgs(
-            key: key,
-            searchWord: searchWord,
-          ),
-          initialChildren: children,
-        );
+         UserSearchResultRoute.name,
+         args: UserSearchResultRouteArgs(key: key, searchWord: searchWord),
+         initialChildren: children,
+       );
 
   static const String name = 'UserSearchResultRoute';
 
@@ -863,10 +787,7 @@ class UserSearchResultRoute extends PageRouteInfo<UserSearchResultRouteArgs> {
 }
 
 class UserSearchResultRouteArgs {
-  const UserSearchResultRouteArgs({
-    this.key,
-    required this.searchWord,
-  });
+  const UserSearchResultRouteArgs({this.key, required this.searchWord});
 
   final Key? key;
 
@@ -882,10 +803,7 @@ class UserSearchResultRouteArgs {
 /// [WelcomePage]
 class WelcomeRoute extends PageRouteInfo<void> {
   const WelcomeRoute({List<PageRouteInfo>? children})
-      : super(
-          WelcomeRoute.name,
-          initialChildren: children,
-        );
+    : super(WelcomeRoute.name, initialChildren: children);
 
   static const String name = 'WelcomeRoute';
 
@@ -900,25 +818,23 @@ class WordListRoute extends PageRouteInfo<WordListRouteArgs> {
     required InitialSubGroup selectedInitialSubGroup,
     List<PageRouteInfo>? children,
   }) : super(
-          WordListRoute.name,
-          args: WordListRouteArgs(
-            key: key,
-            selectedInitialSubGroup: selectedInitialSubGroup,
-          ),
-          initialChildren: children,
-        );
+         WordListRoute.name,
+         args: WordListRouteArgs(
+           key: key,
+           selectedInitialSubGroup: selectedInitialSubGroup,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'WordListRoute';
 
-  static const PageInfo<WordListRouteArgs> page =
-      PageInfo<WordListRouteArgs>(name);
+  static const PageInfo<WordListRouteArgs> page = PageInfo<WordListRouteArgs>(
+    name,
+  );
 }
 
 class WordListRouteArgs {
-  const WordListRouteArgs({
-    this.key,
-    required this.selectedInitialSubGroup,
-  });
+  const WordListRouteArgs({this.key, required this.selectedInitialSubGroup});
 
   final Key? key;
 
@@ -938,13 +854,10 @@ class WordSearchResultRoute extends PageRouteInfo<WordSearchResultRouteArgs> {
     required String searchWord,
     List<PageRouteInfo>? children,
   }) : super(
-          WordSearchResultRoute.name,
-          args: WordSearchResultRouteArgs(
-            key: key,
-            searchWord: searchWord,
-          ),
-          initialChildren: children,
-        );
+         WordSearchResultRoute.name,
+         args: WordSearchResultRouteArgs(key: key, searchWord: searchWord),
+         initialChildren: children,
+       );
 
   static const String name = 'WordSearchResultRoute';
 
@@ -953,10 +866,7 @@ class WordSearchResultRoute extends PageRouteInfo<WordSearchResultRouteArgs> {
 }
 
 class WordSearchResultRouteArgs {
-  const WordSearchResultRouteArgs({
-    this.key,
-    required this.searchWord,
-  });
+  const WordSearchResultRouteArgs({this.key, required this.searchWord});
 
   final Key? key;
 
@@ -976,25 +886,20 @@ class WordTopRoute extends PageRouteInfo<WordTopRouteArgs> {
     required String wordId,
     List<PageRouteInfo>? children,
   }) : super(
-          WordTopRoute.name,
-          args: WordTopRouteArgs(
-            key: key,
-            wordId: wordId,
-          ),
-          initialChildren: children,
-        );
+         WordTopRoute.name,
+         args: WordTopRouteArgs(key: key, wordId: wordId),
+         initialChildren: children,
+       );
 
   static const String name = 'WordTopRoute';
 
-  static const PageInfo<WordTopRouteArgs> page =
-      PageInfo<WordTopRouteArgs>(name);
+  static const PageInfo<WordTopRouteArgs> page = PageInfo<WordTopRouteArgs>(
+    name,
+  );
 }
 
 class WordTopRouteArgs {
-  const WordTopRouteArgs({
-    this.key,
-    required this.wordId,
-  });
+  const WordTopRouteArgs({this.key, required this.wordId});
 
   final Key? key;
 

--- a/lib/core/router/auth_guard.g.dart
+++ b/lib/core/router/auth_guard.g.dart
@@ -13,8 +13,9 @@ String _$authGuardHash() => r'ca0593bb139c88d8f1aaa3c45b038e438ee3facd';
 final authGuardProvider = AutoDisposeProvider<AuthGuard>.internal(
   authGuard,
   name: r'authGuardProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$authGuardHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$authGuardHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/core/router/first_launch_guard.dart
+++ b/lib/core/router/first_launch_guard.dart
@@ -9,7 +9,8 @@ import 'app_router.dart';
 part 'first_launch_guard.g.dart';
 
 @riverpod
-FirstLaunchGuard firstLaunchGuard(FirstLaunchGuardRef ref) => FirstLaunchGuard(ref);
+FirstLaunchGuard firstLaunchGuard(FirstLaunchGuardRef ref) =>
+    FirstLaunchGuard(ref);
 
 class FirstLaunchGuard extends AutoRouteGuard {
   FirstLaunchGuard(this.ref);
@@ -21,8 +22,9 @@ class FirstLaunchGuard extends AutoRouteGuard {
     NavigationResolver resolver,
     StackRouter router,
   ) async {
-    final isFirstLaunch =
-        await ref.read(isFirstLaunchRepositoryProvider).isFirstLaunch();
+    final isFirstLaunch = await ref
+        .read(isFirstLaunchRepositoryProvider)
+        .isFirstLaunch();
 
     if (isFirstLaunch) {
       logger.d('初回起動しました。');

--- a/lib/feature/auth/application/auth_state.g.dart
+++ b/lib/feature/auth/application/auth_state.g.dart
@@ -15,8 +15,9 @@ String _$userChangesHash() => r'4d38930d75575de157a299ad9b32c030d7490685';
 final userChangesProvider = StreamProvider<User?>.internal(
   userChanges,
   name: r'userChangesProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$userChangesHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$userChangesHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
@@ -35,8 +36,9 @@ String _$userIdHash() => r'ddb1ce88c396dbc1fc35794967e712feaf9aadac';
 final userIdProvider = Provider<String?>.internal(
   userId,
   name: r'userIdProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$userIdHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$userIdHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
@@ -53,8 +55,9 @@ String _$isSignedInHash() => r'7be28bf7800a870161b37258d04586b45882c83a';
 final isSignedInProvider = Provider<bool>.internal(
   isSignedIn,
   name: r'isSignedInProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$isSignedInHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$isSignedInHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/feature/auth/repository/auth_repository.dart
+++ b/lib/feature/auth/repository/auth_repository.dart
@@ -6,9 +6,8 @@ import '../../../core/common_provider/firebase_providers.dart';
 part 'auth_repository.g.dart';
 
 @Riverpod(keepAlive: true)
-AuthRepository authRepository(AuthRepositoryRef ref) => AuthRepository(
-      ref.watch(firebaseAuthProvider),
-    );
+AuthRepository authRepository(AuthRepositoryRef ref) =>
+    AuthRepository(ref.watch(firebaseAuthProvider));
 
 class AuthRepository {
   AuthRepository(this.firebaseAuth);

--- a/lib/feature/definition/application/definition_for_write_notifier.g.dart
+++ b/lib/feature/definition/application/definition_for_write_notifier.g.dart
@@ -34,9 +34,7 @@ abstract class _$DefinitionForWriteNotifier
     extends BuildlessAutoDisposeAsyncNotifier<DefinitionForWrite> {
   late final DefinitionForWrite? definitionForWrite;
 
-  FutureOr<DefinitionForWrite> build(
-    DefinitionForWrite? definitionForWrite,
-  );
+  FutureOr<DefinitionForWrite> build(DefinitionForWrite? definitionForWrite);
 }
 
 /// 更新時などTextField等に初期表示したい値がある場合、
@@ -65,18 +63,14 @@ class DefinitionForWriteNotifierFamily
   DefinitionForWriteNotifierProvider call(
     DefinitionForWrite? definitionForWrite,
   ) {
-    return DefinitionForWriteNotifierProvider(
-      definitionForWrite,
-    );
+    return DefinitionForWriteNotifierProvider(definitionForWrite);
   }
 
   @override
   DefinitionForWriteNotifierProvider getProviderOverride(
     covariant DefinitionForWriteNotifierProvider provider,
   ) {
-    return call(
-      provider.definitionForWrite,
-    );
+    return call(provider.definitionForWrite);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -99,28 +93,30 @@ class DefinitionForWriteNotifierFamily
 ///
 /// Copied from [DefinitionForWriteNotifier].
 class DefinitionForWriteNotifierProvider
-    extends AutoDisposeAsyncNotifierProviderImpl<DefinitionForWriteNotifier,
-        DefinitionForWrite> {
+    extends
+        AutoDisposeAsyncNotifierProviderImpl<
+          DefinitionForWriteNotifier,
+          DefinitionForWrite
+        > {
   /// 更新時などTextField等に初期表示したい値がある場合、
   /// [definitionForWrite] として渡す。
   ///
   /// Copied from [DefinitionForWriteNotifier].
-  DefinitionForWriteNotifierProvider(
-    DefinitionForWrite? definitionForWrite,
-  ) : this._internal(
-          () => DefinitionForWriteNotifier()
-            ..definitionForWrite = definitionForWrite,
-          from: definitionForWriteNotifierProvider,
-          name: r'definitionForWriteNotifierProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$definitionForWriteNotifierHash,
-          dependencies: DefinitionForWriteNotifierFamily._dependencies,
-          allTransitiveDependencies:
-              DefinitionForWriteNotifierFamily._allTransitiveDependencies,
-          definitionForWrite: definitionForWrite,
-        );
+  DefinitionForWriteNotifierProvider(DefinitionForWrite? definitionForWrite)
+    : this._internal(
+        () =>
+            DefinitionForWriteNotifier()
+              ..definitionForWrite = definitionForWrite,
+        from: definitionForWriteNotifierProvider,
+        name: r'definitionForWriteNotifierProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$definitionForWriteNotifierHash,
+        dependencies: DefinitionForWriteNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            DefinitionForWriteNotifierFamily._allTransitiveDependencies,
+        definitionForWrite: definitionForWrite,
+      );
 
   DefinitionForWriteNotifierProvider._internal(
     super._createNotifier, {
@@ -138,9 +134,7 @@ class DefinitionForWriteNotifierProvider
   FutureOr<DefinitionForWrite> runNotifierBuild(
     covariant DefinitionForWriteNotifier notifier,
   ) {
-    return notifier.build(
-      definitionForWrite,
-    );
+    return notifier.build(definitionForWrite);
   }
 
   @override
@@ -160,8 +154,11 @@ class DefinitionForWriteNotifierProvider
   }
 
   @override
-  AutoDisposeAsyncNotifierProviderElement<DefinitionForWriteNotifier,
-      DefinitionForWrite> createElement() {
+  AutoDisposeAsyncNotifierProviderElement<
+    DefinitionForWriteNotifier,
+    DefinitionForWrite
+  >
+  createElement() {
     return _DefinitionForWriteNotifierProviderElement(this);
   }
 
@@ -187,13 +184,18 @@ mixin DefinitionForWriteNotifierRef
 }
 
 class _DefinitionForWriteNotifierProviderElement
-    extends AutoDisposeAsyncNotifierProviderElement<DefinitionForWriteNotifier,
-        DefinitionForWrite> with DefinitionForWriteNotifierRef {
+    extends
+        AutoDisposeAsyncNotifierProviderElement<
+          DefinitionForWriteNotifier,
+          DefinitionForWrite
+        >
+    with DefinitionForWriteNotifierRef {
   _DefinitionForWriteNotifierProviderElement(super.provider);
 
   @override
   DefinitionForWrite? get definitionForWrite =>
       (origin as DefinitionForWriteNotifierProvider).definitionForWrite;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/definition/application/definition_service.g.dart
+++ b/lib/feature/definition/application/definition_service.g.dart
@@ -12,14 +12,14 @@ String _$definitionServiceHash() => r'ff6f7c3f812dca75bd2fd4e82d177c2f78465bb5';
 @ProviderFor(definitionService)
 final definitionServiceProvider =
     AutoDisposeProvider<DefinitionService>.internal(
-  definitionService,
-  name: r'definitionServiceProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$definitionServiceHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      definitionService,
+      name: r'definitionServiceProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$definitionServiceHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef DefinitionServiceRef = AutoDisposeProviderRef<DefinitionService>;
 // ignore_for_file: type=lint

--- a/lib/feature/definition/domain/definition_for_write.freezed.dart
+++ b/lib/feature/definition/domain/definition_for_write.freezed.dart
@@ -12,7 +12,8 @@ part of 'definition_for_write.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
 
 /// @nodoc
 mixin _$DefinitionForWrite {
@@ -32,16 +33,18 @@ mixin _$DefinitionForWrite {
 /// @nodoc
 abstract class $DefinitionForWriteCopyWith<$Res> {
   factory $DefinitionForWriteCopyWith(
-          DefinitionForWrite value, $Res Function(DefinitionForWrite) then) =
-      _$DefinitionForWriteCopyWithImpl<$Res, DefinitionForWrite>;
+    DefinitionForWrite value,
+    $Res Function(DefinitionForWrite) then,
+  ) = _$DefinitionForWriteCopyWithImpl<$Res, DefinitionForWrite>;
   @useResult
-  $Res call(
-      {String? id,
-      String authorId,
-      String word,
-      String wordReading,
-      bool isPublic,
-      String definition});
+  $Res call({
+    String? id,
+    String authorId,
+    String word,
+    String wordReading,
+    bool isPublic,
+    String definition,
+  });
 }
 
 /// @nodoc
@@ -64,59 +67,65 @@ class _$DefinitionForWriteCopyWithImpl<$Res, $Val extends DefinitionForWrite>
     Object? isPublic = null,
     Object? definition = null,
   }) {
-    return _then(_value.copyWith(
-      id: freezed == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String?,
-      authorId: null == authorId
-          ? _value.authorId
-          : authorId // ignore: cast_nullable_to_non_nullable
-              as String,
-      word: null == word
-          ? _value.word
-          : word // ignore: cast_nullable_to_non_nullable
-              as String,
-      wordReading: null == wordReading
-          ? _value.wordReading
-          : wordReading // ignore: cast_nullable_to_non_nullable
-              as String,
-      isPublic: null == isPublic
-          ? _value.isPublic
-          : isPublic // ignore: cast_nullable_to_non_nullable
-              as bool,
-      definition: null == definition
-          ? _value.definition
-          : definition // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+    return _then(
+      _value.copyWith(
+            id: freezed == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            authorId: null == authorId
+                ? _value.authorId
+                : authorId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            word: null == word
+                ? _value.word
+                : word // ignore: cast_nullable_to_non_nullable
+                      as String,
+            wordReading: null == wordReading
+                ? _value.wordReading
+                : wordReading // ignore: cast_nullable_to_non_nullable
+                      as String,
+            isPublic: null == isPublic
+                ? _value.isPublic
+                : isPublic // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            definition: null == definition
+                ? _value.definition
+                : definition // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$DefinitionForWriteImplCopyWith<$Res>
     implements $DefinitionForWriteCopyWith<$Res> {
-  factory _$$DefinitionForWriteImplCopyWith(_$DefinitionForWriteImpl value,
-          $Res Function(_$DefinitionForWriteImpl) then) =
-      __$$DefinitionForWriteImplCopyWithImpl<$Res>;
+  factory _$$DefinitionForWriteImplCopyWith(
+    _$DefinitionForWriteImpl value,
+    $Res Function(_$DefinitionForWriteImpl) then,
+  ) = __$$DefinitionForWriteImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call(
-      {String? id,
-      String authorId,
-      String word,
-      String wordReading,
-      bool isPublic,
-      String definition});
+  $Res call({
+    String? id,
+    String authorId,
+    String word,
+    String wordReading,
+    bool isPublic,
+    String definition,
+  });
 }
 
 /// @nodoc
 class __$$DefinitionForWriteImplCopyWithImpl<$Res>
     extends _$DefinitionForWriteCopyWithImpl<$Res, _$DefinitionForWriteImpl>
     implements _$$DefinitionForWriteImplCopyWith<$Res> {
-  __$$DefinitionForWriteImplCopyWithImpl(_$DefinitionForWriteImpl _value,
-      $Res Function(_$DefinitionForWriteImpl) _then)
-      : super(_value, _then);
+  __$$DefinitionForWriteImplCopyWithImpl(
+    _$DefinitionForWriteImpl _value,
+    $Res Function(_$DefinitionForWriteImpl) _then,
+  ) : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -128,46 +137,48 @@ class __$$DefinitionForWriteImplCopyWithImpl<$Res>
     Object? isPublic = null,
     Object? definition = null,
   }) {
-    return _then(_$DefinitionForWriteImpl(
-      id: freezed == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String?,
-      authorId: null == authorId
-          ? _value.authorId
-          : authorId // ignore: cast_nullable_to_non_nullable
-              as String,
-      word: null == word
-          ? _value.word
-          : word // ignore: cast_nullable_to_non_nullable
-              as String,
-      wordReading: null == wordReading
-          ? _value.wordReading
-          : wordReading // ignore: cast_nullable_to_non_nullable
-              as String,
-      isPublic: null == isPublic
-          ? _value.isPublic
-          : isPublic // ignore: cast_nullable_to_non_nullable
-              as bool,
-      definition: null == definition
-          ? _value.definition
-          : definition // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
+    return _then(
+      _$DefinitionForWriteImpl(
+        id: freezed == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        authorId: null == authorId
+            ? _value.authorId
+            : authorId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        word: null == word
+            ? _value.word
+            : word // ignore: cast_nullable_to_non_nullable
+                  as String,
+        wordReading: null == wordReading
+            ? _value.wordReading
+            : wordReading // ignore: cast_nullable_to_non_nullable
+                  as String,
+        isPublic: null == isPublic
+            ? _value.isPublic
+            : isPublic // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        definition: null == definition
+            ? _value.definition
+            : definition // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
   }
 }
 
 /// @nodoc
 
 class _$DefinitionForWriteImpl extends _DefinitionForWrite {
-  const _$DefinitionForWriteImpl(
-      {required this.id,
-      required this.authorId,
-      required this.word,
-      required this.wordReading,
-      required this.isPublic,
-      required this.definition})
-      : super._();
+  const _$DefinitionForWriteImpl({
+    required this.id,
+    required this.authorId,
+    required this.word,
+    required this.wordReading,
+    required this.isPublic,
+    required this.definition,
+  }) : super._();
 
   /// 更新時のみ使用する。新規投稿時はnull
   @override
@@ -207,28 +218,37 @@ class _$DefinitionForWriteImpl extends _DefinitionForWrite {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, id, authorId, word, wordReading, isPublic, definition);
+    runtimeType,
+    id,
+    authorId,
+    word,
+    wordReading,
+    isPublic,
+    definition,
+  );
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DefinitionForWriteImplCopyWith<_$DefinitionForWriteImpl> get copyWith =>
       __$$DefinitionForWriteImplCopyWithImpl<_$DefinitionForWriteImpl>(
-          this, _$identity);
+        this,
+        _$identity,
+      );
 }
 
 abstract class _DefinitionForWrite extends DefinitionForWrite {
-  const factory _DefinitionForWrite(
-      {required final String? id,
-      required final String authorId,
-      required final String word,
-      required final String wordReading,
-      required final bool isPublic,
-      required final String definition}) = _$DefinitionForWriteImpl;
+  const factory _DefinitionForWrite({
+    required final String? id,
+    required final String authorId,
+    required final String word,
+    required final String wordReading,
+    required final bool isPublic,
+    required final String definition,
+  }) = _$DefinitionForWriteImpl;
   const _DefinitionForWrite._() : super._();
 
   @override
-
   /// 更新時のみ使用する。新規投稿時はnull
   String? get id;
   @override

--- a/lib/feature/definition/presentation/definition_tile_shimmer.dart
+++ b/lib/feature/definition/presentation/definition_tile_shimmer.dart
@@ -24,21 +24,12 @@ class DefinitionTileShimmer extends StatelessWidget {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        ShimmerWidget.rectangular(
-                          height: 16,
-                          width: 160,
-                        ),
-                        ShimmerWidget.rectangular(
-                          height: 16,
-                          width: 40,
-                        ),
+                        ShimmerWidget.rectangular(height: 16, width: 160),
+                        ShimmerWidget.rectangular(height: 16, width: 40),
                       ],
                     ),
                     Gap(8),
-                    ShimmerWidget.rectangular(
-                      height: 24,
-                      width: 200,
-                    ),
+                    ShimmerWidget.rectangular(height: 24, width: 200),
                     Gap(8),
                     ShimmerWidget.rectangular(height: 72),
                     Gap(8),

--- a/lib/feature/definition/presentation/select_post_type_button.dart
+++ b/lib/feature/definition/presentation/select_post_type_button.dart
@@ -45,18 +45,14 @@ class SelectPostTypeButton extends ConsumerWidget {
             items: [
               PullDownMenuItem(
                 onTap: () {
-                  notifier.changePublicState(
-                    isPublic: true,
-                  );
+                  notifier.changePublicState(isPublic: true);
                 },
                 title: DefinitionPostType.public.labelForWrite,
                 icon: DefinitionPostType.public.icon,
               ),
               PullDownMenuItem(
                 onTap: () {
-                  notifier.changePublicState(
-                    isPublic: false,
-                  );
+                  notifier.changePublicState(isPublic: false);
                 },
                 title: DefinitionPostType.private.labelForWrite,
                 icon: DefinitionPostType.private.icon,

--- a/lib/feature/definition/presentation/self_definition_action_icon_button.dart
+++ b/lib/feature/definition/presentation/self_definition_action_icon_button.dart
@@ -62,7 +62,9 @@ class SelfDefinitionActionIconButton extends ConsumerWidget
           title: 'この定義を削除',
           icon: CupertinoIcons.trash,
           onTap: () {
-            ref.read(dialogControllerProvider).show(
+            ref
+                .read(dialogControllerProvider)
+                .show(
                   ConfirmDialog(
                     confirmMessage: '本当に削除してもよろしいですか？',
                     onAccept: () async {
@@ -125,9 +127,7 @@ class _CannotEditAlertDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       contentPadding: const EdgeInsets.only(
         top: 32,
         right: 24,
@@ -138,15 +138,9 @@ class _CannotEditAlertDialog extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '編集は投稿してから1時間以内にしかできません。',
-            overflow: TextOverflow.clip,
-          ),
+          Text('編集は投稿してから1時間以内にしかできません。', overflow: TextOverflow.clip),
           Gap(8),
-          Text(
-            '代わりに、この投稿の内容をもとに新規投稿を作成しませんか？',
-            overflow: TextOverflow.clip,
-          ),
+          Text('代わりに、この投稿の内容をもとに新規投稿を作成しませんか？', overflow: TextOverflow.clip),
         ],
       ),
       actionsAlignment: MainAxisAlignment.spaceEvenly,
@@ -179,8 +173,8 @@ class _CannotEditAlertDialog extends StatelessWidget {
             child: Text(
               '作成する',
               style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
+                color: Theme.of(context).colorScheme.primary,
+              ),
             ),
           ),
         ),
@@ -203,13 +197,8 @@ class _ChangePostTypeConfirmDialog extends ConsumerWidget
 
     return AlertDialog(
       elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
-      contentPadding: const EdgeInsets.only(
-        top: 16,
-        bottom: 8,
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      contentPadding: const EdgeInsets.only(top: 16, bottom: 8),
       title: const Center(child: Text('確認')),
       content: Column(
         mainAxisSize: MainAxisSize.min,
@@ -227,10 +216,7 @@ class _ChangePostTypeConfirmDialog extends ConsumerWidget
           onTap: context.popRoute,
           child: Padding(
             padding: const EdgeInsets.all(16),
-            child: Text(
-              'しない',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
+            child: Text('しない', style: Theme.of(context).textTheme.titleMedium),
           ),
         ),
         InkWell(
@@ -255,8 +241,8 @@ class _ChangePostTypeConfirmDialog extends ConsumerWidget
             child: Text(
               'する',
               style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
+                color: Theme.of(context).colorScheme.error,
+              ),
             ),
           ),
         ),

--- a/lib/feature/definition/repository/fetch_definition_repository.g.dart
+++ b/lib/feature/definition/repository/fetch_definition_repository.g.dart
@@ -13,14 +13,14 @@ String _$fetchDefinitionRepositoryHash() =>
 @ProviderFor(fetchDefinitionRepository)
 final fetchDefinitionRepositoryProvider =
     Provider<FetchDefinitionRepository>.internal(
-  fetchDefinitionRepository,
-  name: r'fetchDefinitionRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$fetchDefinitionRepositoryHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      fetchDefinitionRepository,
+      name: r'fetchDefinitionRepositoryProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$fetchDefinitionRepositoryHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef FetchDefinitionRepositoryRef = ProviderRef<FetchDefinitionRepository>;
 // ignore_for_file: type=lint

--- a/lib/feature/definition/repository/write_definition_repository.g.dart
+++ b/lib/feature/definition/repository/write_definition_repository.g.dart
@@ -13,16 +13,16 @@ String _$writeDefinitionRepositoryHash() =>
 @ProviderFor(writeDefinitionRepository)
 final writeDefinitionRepositoryProvider =
     AutoDisposeProvider<WriteDefinitionRepository>.internal(
-  writeDefinitionRepository,
-  name: r'writeDefinitionRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$writeDefinitionRepositoryHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      writeDefinitionRepository,
+      name: r'writeDefinitionRepositoryProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$writeDefinitionRepositoryHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
-typedef WriteDefinitionRepositoryRef
-    = AutoDisposeProviderRef<WriteDefinitionRepository>;
+typedef WriteDefinitionRepositoryRef =
+    AutoDisposeProviderRef<WriteDefinitionRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/definition/util/after_post_navigation_type.dart
+++ b/lib/feature/definition/util/after_post_navigation_type.dart
@@ -1,4 +1,1 @@
-enum AfterPostNavigationType {
-  pop,
-  toDetail;
-}
+enum AfterPostNavigationType { pop, toDetail }

--- a/lib/feature/definition_like/application/like_definition_service.g.dart
+++ b/lib/feature/definition_like/application/like_definition_service.g.dart
@@ -13,16 +13,16 @@ String _$likeDefinitionServiceHash() =>
 @ProviderFor(likeDefinitionService)
 final likeDefinitionServiceProvider =
     AutoDisposeProvider<LikeDefinitionService>.internal(
-  likeDefinitionService,
-  name: r'likeDefinitionServiceProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$likeDefinitionServiceHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      likeDefinitionService,
+      name: r'likeDefinitionServiceProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$likeDefinitionServiceHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
-typedef LikeDefinitionServiceRef
-    = AutoDisposeProviderRef<LikeDefinitionService>;
+typedef LikeDefinitionServiceRef =
+    AutoDisposeProviderRef<LikeDefinitionService>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/definition_like/presentation/like_widget.dart
+++ b/lib/feature/definition_like/presentation/like_widget.dart
@@ -31,19 +31,16 @@ class LikeWidget extends ConsumerWidget with PresentationMixin {
             top: 2,
             right: showCount ? 24 : 0,
           ),
-          padding: const EdgeInsets.only(
-            top: 4,
-            right: 4,
-            bottom: 4,
-          ),
+          padding: const EdgeInsets.only(top: 4, right: 4, bottom: 4),
           size: 20,
           likeBuilder: (bool isLiked) {
             return Align(
               alignment: Alignment.centerLeft,
               child: Icon(
                 isLiked ? CupertinoIcons.heart_fill : CupertinoIcons.heart,
-                color:
-                    isLiked ? likeColor : Theme.of(context).colorScheme.outline,
+                color: isLiked
+                    ? likeColor
+                    : Theme.of(context).colorScheme.outline,
                 size: 20,
               ),
             );
@@ -65,13 +62,13 @@ class LikeWidget extends ConsumerWidget with PresentationMixin {
             var isActionCompleted = false;
             await executeWithOverlayLoading(
               ref,
-                  action: () async {
-                    await ref
-                        .read(likeDefinitionServiceProvider)
-                        .tapLike(definition);
-                    isActionCompleted = true;
-                  },
-                );
+              action: () async {
+                await ref
+                    .read(likeDefinitionServiceProvider)
+                    .tapLike(definition);
+                isActionCompleted = true;
+              },
+            );
 
             if (isActionCompleted) {
               return !definition.isLikedByUser;

--- a/lib/feature/definition_like/repository/like_definition_repository.g.dart
+++ b/lib/feature/definition_like/repository/like_definition_repository.g.dart
@@ -13,16 +13,16 @@ String _$likeDefinitionRepositoryHash() =>
 @ProviderFor(likeDefinitionRepository)
 final likeDefinitionRepositoryProvider =
     AutoDisposeProvider<LikeDefinitionRepository>.internal(
-  likeDefinitionRepository,
-  name: r'likeDefinitionRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$likeDefinitionRepositoryHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      likeDefinitionRepository,
+      name: r'likeDefinitionRepositoryProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$likeDefinitionRepositoryHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
-typedef LikeDefinitionRepositoryRef
-    = AutoDisposeProviderRef<LikeDefinitionRepository>;
+typedef LikeDefinitionRepositoryRef =
+    AutoDisposeProviderRef<LikeDefinitionRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/definition_list/util/definition_feed_type.dart
+++ b/lib/feature/definition_list/util/definition_feed_type.dart
@@ -22,7 +22,4 @@ enum DefinitionFeedType {
 }
 
 // TODO(me): [DefinitionFeedType]の値に合わせて更新する必要があことをなんとかしたい
-enum WordTopOrderByType {
-  createdAt,
-  likesCount;
-}
+enum WordTopOrderByType { createdAt, likesCount }

--- a/lib/feature/force_event/application/app_config_state.g.dart
+++ b/lib/feature/force_event/application/app_config_state.g.dart
@@ -15,8 +15,9 @@ String _$appConfigHash() => r'28e72d143d5d1f2be2ef58a5851f391bb7066eba';
 final appConfigProvider = StreamProvider<AppConfigDocument>.internal(
   appConfig,
   name: r'appConfigProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$appConfigHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appConfigHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/lib/feature/force_event/domain/app_maintenance.freezed.dart
+++ b/lib/feature/force_event/domain/app_maintenance.freezed.dart
@@ -12,7 +12,8 @@ part of 'app_maintenance.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
 
 /// @nodoc
 mixin _$AppMaintenance {
@@ -27,8 +28,9 @@ mixin _$AppMaintenance {
 /// @nodoc
 abstract class $AppMaintenanceCopyWith<$Res> {
   factory $AppMaintenanceCopyWith(
-          AppMaintenance value, $Res Function(AppMaintenance) then) =
-      _$AppMaintenanceCopyWithImpl<$Res, AppMaintenance>;
+    AppMaintenance value,
+    $Res Function(AppMaintenance) then,
+  ) = _$AppMaintenanceCopyWithImpl<$Res, AppMaintenance>;
   @useResult
   $Res call({bool inMaintenance, String scheduledEndTime});
 }
@@ -45,29 +47,30 @@ class _$AppMaintenanceCopyWithImpl<$Res, $Val extends AppMaintenance>
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? inMaintenance = null,
-    Object? scheduledEndTime = null,
-  }) {
-    return _then(_value.copyWith(
-      inMaintenance: null == inMaintenance
-          ? _value.inMaintenance
-          : inMaintenance // ignore: cast_nullable_to_non_nullable
-              as bool,
-      scheduledEndTime: null == scheduledEndTime
-          ? _value.scheduledEndTime
-          : scheduledEndTime // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  $Res call({Object? inMaintenance = null, Object? scheduledEndTime = null}) {
+    return _then(
+      _value.copyWith(
+            inMaintenance: null == inMaintenance
+                ? _value.inMaintenance
+                : inMaintenance // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            scheduledEndTime: null == scheduledEndTime
+                ? _value.scheduledEndTime
+                : scheduledEndTime // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$AppMaintenanceImplCopyWith<$Res>
     implements $AppMaintenanceCopyWith<$Res> {
-  factory _$$AppMaintenanceImplCopyWith(_$AppMaintenanceImpl value,
-          $Res Function(_$AppMaintenanceImpl) then) =
-      __$$AppMaintenanceImplCopyWithImpl<$Res>;
+  factory _$$AppMaintenanceImplCopyWith(
+    _$AppMaintenanceImpl value,
+    $Res Function(_$AppMaintenanceImpl) then,
+  ) = __$$AppMaintenanceImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool inMaintenance, String scheduledEndTime});
@@ -78,33 +81,35 @@ class __$$AppMaintenanceImplCopyWithImpl<$Res>
     extends _$AppMaintenanceCopyWithImpl<$Res, _$AppMaintenanceImpl>
     implements _$$AppMaintenanceImplCopyWith<$Res> {
   __$$AppMaintenanceImplCopyWithImpl(
-      _$AppMaintenanceImpl _value, $Res Function(_$AppMaintenanceImpl) _then)
-      : super(_value, _then);
+    _$AppMaintenanceImpl _value,
+    $Res Function(_$AppMaintenanceImpl) _then,
+  ) : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? inMaintenance = null,
-    Object? scheduledEndTime = null,
-  }) {
-    return _then(_$AppMaintenanceImpl(
-      inMaintenance: null == inMaintenance
-          ? _value.inMaintenance
-          : inMaintenance // ignore: cast_nullable_to_non_nullable
-              as bool,
-      scheduledEndTime: null == scheduledEndTime
-          ? _value.scheduledEndTime
-          : scheduledEndTime // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
+  $Res call({Object? inMaintenance = null, Object? scheduledEndTime = null}) {
+    return _then(
+      _$AppMaintenanceImpl(
+        inMaintenance: null == inMaintenance
+            ? _value.inMaintenance
+            : inMaintenance // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        scheduledEndTime: null == scheduledEndTime
+            ? _value.scheduledEndTime
+            : scheduledEndTime // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
   }
 }
 
 /// @nodoc
 
 class _$AppMaintenanceImpl implements _AppMaintenance {
-  const _$AppMaintenanceImpl(
-      {required this.inMaintenance, required this.scheduledEndTime});
+  const _$AppMaintenanceImpl({
+    required this.inMaintenance,
+    required this.scheduledEndTime,
+  });
 
   @override
   final bool inMaintenance;
@@ -135,13 +140,16 @@ class _$AppMaintenanceImpl implements _AppMaintenance {
   @pragma('vm:prefer-inline')
   _$$AppMaintenanceImplCopyWith<_$AppMaintenanceImpl> get copyWith =>
       __$$AppMaintenanceImplCopyWithImpl<_$AppMaintenanceImpl>(
-          this, _$identity);
+        this,
+        _$identity,
+      );
 }
 
 abstract class _AppMaintenance implements AppMaintenance {
-  const factory _AppMaintenance(
-      {required final bool inMaintenance,
-      required final String scheduledEndTime}) = _$AppMaintenanceImpl;
+  const factory _AppMaintenance({
+    required final bool inMaintenance,
+    required final String scheduledEndTime,
+  }) = _$AppMaintenanceImpl;
 
   @override
   bool get inMaintenance;

--- a/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
@@ -50,11 +50,12 @@ class OverlayInMaintenanceDialog extends ConsumerWidget {
                   ),
                   const Gap(16),
                   PrimaryFilledButton(
-                    onPressed: () =>
-                        ref.read(launchUrlControllerProvider).launchURL(
-                              latestInformationPageUrl,
-                              inBaseRoute: false,
-                            ),
+                    onPressed: () => ref
+                        .read(launchUrlControllerProvider)
+                        .launchURL(
+                          latestInformationPageUrl,
+                          inBaseRoute: false,
+                        ),
                     text: '最新情報を確認する',
                   ),
                 ],

--- a/lib/feature/force_event/repository/entity/app_config_document.freezed.dart
+++ b/lib/feature/force_event/repository/entity/app_config_document.freezed.dart
@@ -12,7 +12,8 @@ part of 'app_config_document.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
 
 /// @nodoc
 mixin _$AppConfigDocument {
@@ -29,13 +30,15 @@ mixin _$AppConfigDocument {
 /// @nodoc
 abstract class $AppConfigDocumentCopyWith<$Res> {
   factory $AppConfigDocumentCopyWith(
-          AppConfigDocument value, $Res Function(AppConfigDocument) then) =
-      _$AppConfigDocumentCopyWithImpl<$Res, AppConfigDocument>;
+    AppConfigDocument value,
+    $Res Function(AppConfigDocument) then,
+  ) = _$AppConfigDocumentCopyWithImpl<$Res, AppConfigDocument>;
   @useResult
-  $Res call(
-      {String minAppVersionForIos,
-      String minAppVersionForAndroid,
-      Map<String, Map<String, Object>> maintenanceMap});
+  $Res call({
+    String minAppVersionForIos,
+    String minAppVersionForAndroid,
+    Map<String, Map<String, Object>> maintenanceMap,
+  });
 }
 
 /// @nodoc
@@ -55,44 +58,50 @@ class _$AppConfigDocumentCopyWithImpl<$Res, $Val extends AppConfigDocument>
     Object? minAppVersionForAndroid = null,
     Object? maintenanceMap = null,
   }) {
-    return _then(_value.copyWith(
-      minAppVersionForIos: null == minAppVersionForIos
-          ? _value.minAppVersionForIos
-          : minAppVersionForIos // ignore: cast_nullable_to_non_nullable
-              as String,
-      minAppVersionForAndroid: null == minAppVersionForAndroid
-          ? _value.minAppVersionForAndroid
-          : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
-              as String,
-      maintenanceMap: null == maintenanceMap
-          ? _value.maintenanceMap
-          : maintenanceMap // ignore: cast_nullable_to_non_nullable
-              as Map<String, Map<String, Object>>,
-    ) as $Val);
+    return _then(
+      _value.copyWith(
+            minAppVersionForIos: null == minAppVersionForIos
+                ? _value.minAppVersionForIos
+                : minAppVersionForIos // ignore: cast_nullable_to_non_nullable
+                      as String,
+            minAppVersionForAndroid: null == minAppVersionForAndroid
+                ? _value.minAppVersionForAndroid
+                : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
+                      as String,
+            maintenanceMap: null == maintenanceMap
+                ? _value.maintenanceMap
+                : maintenanceMap // ignore: cast_nullable_to_non_nullable
+                      as Map<String, Map<String, Object>>,
+          )
+          as $Val,
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$AppConfigDocumentImplCopyWith<$Res>
     implements $AppConfigDocumentCopyWith<$Res> {
-  factory _$$AppConfigDocumentImplCopyWith(_$AppConfigDocumentImpl value,
-          $Res Function(_$AppConfigDocumentImpl) then) =
-      __$$AppConfigDocumentImplCopyWithImpl<$Res>;
+  factory _$$AppConfigDocumentImplCopyWith(
+    _$AppConfigDocumentImpl value,
+    $Res Function(_$AppConfigDocumentImpl) then,
+  ) = __$$AppConfigDocumentImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call(
-      {String minAppVersionForIos,
-      String minAppVersionForAndroid,
-      Map<String, Map<String, Object>> maintenanceMap});
+  $Res call({
+    String minAppVersionForIos,
+    String minAppVersionForAndroid,
+    Map<String, Map<String, Object>> maintenanceMap,
+  });
 }
 
 /// @nodoc
 class __$$AppConfigDocumentImplCopyWithImpl<$Res>
     extends _$AppConfigDocumentCopyWithImpl<$Res, _$AppConfigDocumentImpl>
     implements _$$AppConfigDocumentImplCopyWith<$Res> {
-  __$$AppConfigDocumentImplCopyWithImpl(_$AppConfigDocumentImpl _value,
-      $Res Function(_$AppConfigDocumentImpl) _then)
-      : super(_value, _then);
+  __$$AppConfigDocumentImplCopyWithImpl(
+    _$AppConfigDocumentImpl _value,
+    $Res Function(_$AppConfigDocumentImpl) _then,
+  ) : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -101,32 +110,34 @@ class __$$AppConfigDocumentImplCopyWithImpl<$Res>
     Object? minAppVersionForAndroid = null,
     Object? maintenanceMap = null,
   }) {
-    return _then(_$AppConfigDocumentImpl(
-      minAppVersionForIos: null == minAppVersionForIos
-          ? _value.minAppVersionForIos
-          : minAppVersionForIos // ignore: cast_nullable_to_non_nullable
-              as String,
-      minAppVersionForAndroid: null == minAppVersionForAndroid
-          ? _value.minAppVersionForAndroid
-          : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
-              as String,
-      maintenanceMap: null == maintenanceMap
-          ? _value._maintenanceMap
-          : maintenanceMap // ignore: cast_nullable_to_non_nullable
-              as Map<String, Map<String, Object>>,
-    ));
+    return _then(
+      _$AppConfigDocumentImpl(
+        minAppVersionForIos: null == minAppVersionForIos
+            ? _value.minAppVersionForIos
+            : minAppVersionForIos // ignore: cast_nullable_to_non_nullable
+                  as String,
+        minAppVersionForAndroid: null == minAppVersionForAndroid
+            ? _value.minAppVersionForAndroid
+            : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
+                  as String,
+        maintenanceMap: null == maintenanceMap
+            ? _value._maintenanceMap
+            : maintenanceMap // ignore: cast_nullable_to_non_nullable
+                  as Map<String, Map<String, Object>>,
+      ),
+    );
   }
 }
 
 /// @nodoc
 
 class _$AppConfigDocumentImpl extends _AppConfigDocument {
-  const _$AppConfigDocumentImpl(
-      {required this.minAppVersionForIos,
-      required this.minAppVersionForAndroid,
-      required final Map<String, Map<String, Object>> maintenanceMap})
-      : _maintenanceMap = maintenanceMap,
-        super._();
+  const _$AppConfigDocumentImpl({
+    required this.minAppVersionForIos,
+    required this.minAppVersionForAndroid,
+    required final Map<String, Map<String, Object>> maintenanceMap,
+  }) : _maintenanceMap = maintenanceMap,
+       super._();
 
   @override
   final String minAppVersionForIos;
@@ -153,33 +164,40 @@ class _$AppConfigDocumentImpl extends _AppConfigDocument {
             (identical(other.minAppVersionForIos, minAppVersionForIos) ||
                 other.minAppVersionForIos == minAppVersionForIos) &&
             (identical(
-                    other.minAppVersionForAndroid, minAppVersionForAndroid) ||
+                  other.minAppVersionForAndroid,
+                  minAppVersionForAndroid,
+                ) ||
                 other.minAppVersionForAndroid == minAppVersionForAndroid) &&
-            const DeepCollectionEquality()
-                .equals(other._maintenanceMap, _maintenanceMap));
+            const DeepCollectionEquality().equals(
+              other._maintenanceMap,
+              _maintenanceMap,
+            ));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      minAppVersionForIos,
-      minAppVersionForAndroid,
-      const DeepCollectionEquality().hash(_maintenanceMap));
+    runtimeType,
+    minAppVersionForIos,
+    minAppVersionForAndroid,
+    const DeepCollectionEquality().hash(_maintenanceMap),
+  );
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$AppConfigDocumentImplCopyWith<_$AppConfigDocumentImpl> get copyWith =>
       __$$AppConfigDocumentImplCopyWithImpl<_$AppConfigDocumentImpl>(
-          this, _$identity);
+        this,
+        _$identity,
+      );
 }
 
 abstract class _AppConfigDocument extends AppConfigDocument {
-  const factory _AppConfigDocument(
-          {required final String minAppVersionForIos,
-          required final String minAppVersionForAndroid,
-          required final Map<String, Map<String, Object>> maintenanceMap}) =
-      _$AppConfigDocumentImpl;
+  const factory _AppConfigDocument({
+    required final String minAppVersionForIos,
+    required final String minAppVersionForAndroid,
+    required final Map<String, Map<String, Object>> maintenanceMap,
+  }) = _$AppConfigDocumentImpl;
   const _AppConfigDocument._() : super._();
 
   @override

--- a/lib/feature/introduction/application/introduction_service.g.dart
+++ b/lib/feature/introduction/application/introduction_service.g.dart
@@ -13,14 +13,14 @@ String _$introductionServiceHash() =>
 @ProviderFor(introductionService)
 final introductionServiceProvider =
     AutoDisposeProvider<IntroductionService>.internal(
-  introductionService,
-  name: r'introductionServiceProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$introductionServiceHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      introductionService,
+      name: r'introductionServiceProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$introductionServiceHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef IntroductionServiceRef = AutoDisposeProviderRef<IntroductionService>;
 // ignore_for_file: type=lint

--- a/lib/feature/introduction/presentation/confirm_agreement_dialog.dart
+++ b/lib/feature/introduction/presentation/confirm_agreement_dialog.dart
@@ -7,19 +7,14 @@ import '../../../core/router/app_router.dart';
 import '../application/introduction_service.dart';
 
 class ConfirmAgreementDialog extends ConsumerWidget {
-  const ConfirmAgreementDialog({
-    super.key,
-  });
+  const ConfirmAgreementDialog({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return BaseDialog(
       content: const Padding(
         padding: EdgeInsets.symmetric(horizontal: 16),
-        child: Text(
-          '利用規約とプライバシーポリシーに\n同意しますか？',
-          textAlign: TextAlign.center,
-        ),
+        child: Text('利用規約とプライバシーポリシーに\n同意しますか？', textAlign: TextAlign.center),
       ),
       actions: [
         InkWell(
@@ -46,8 +41,8 @@ class ConfirmAgreementDialog extends ConsumerWidget {
             child: Text(
               '同意する',
               style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
+                color: Theme.of(context).colorScheme.primary,
+              ),
             ),
           ),
         ),

--- a/lib/feature/introduction/repository/is_first_launch_repository.dart
+++ b/lib/feature/introduction/repository/is_first_launch_repository.dart
@@ -6,8 +6,7 @@ part 'is_first_launch_repository.g.dart';
 @riverpod
 IsFirstLaunchRepository isFirstLaunchRepository(
   IsFirstLaunchRepositoryRef ref,
-) =>
-    IsFirstLaunchRepository();
+) => IsFirstLaunchRepository();
 
 class IsFirstLaunchRepository {
   IsFirstLaunchRepository();

--- a/lib/feature/introduction/repository/is_first_launch_repository.g.dart
+++ b/lib/feature/introduction/repository/is_first_launch_repository.g.dart
@@ -13,16 +13,16 @@ String _$isFirstLaunchRepositoryHash() =>
 @ProviderFor(isFirstLaunchRepository)
 final isFirstLaunchRepositoryProvider =
     AutoDisposeProvider<IsFirstLaunchRepository>.internal(
-  isFirstLaunchRepository,
-  name: r'isFirstLaunchRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$isFirstLaunchRepositoryHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      isFirstLaunchRepository,
+      name: r'isFirstLaunchRepositoryProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$isFirstLaunchRepositoryHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
-typedef IsFirstLaunchRepositoryRef
-    = AutoDisposeProviderRef<IsFirstLaunchRepository>;
+typedef IsFirstLaunchRepositoryRef =
+    AutoDisposeProviderRef<IsFirstLaunchRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/setting/presentation/delete_account_button.dart
+++ b/lib/feature/setting/presentation/delete_account_button.dart
@@ -11,14 +11,14 @@ import '../../../util/mixin/presentation_mixin.dart';
 import '../../auth/application/auth_service.dart';
 
 class DeleteAccountButton extends ConsumerWidget with PresentationMixin {
-  const DeleteAccountButton({
-    super.key,
-  });
+  const DeleteAccountButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     Future<void> showCompleteDeleteAccountDialog() async {
-      ref.read(dialogControllerProvider).show(
+      ref
+          .read(dialogControllerProvider)
+          .show(
             WillPopScope(
               onWillPop: () async => false,
               child: AlertDialog(
@@ -26,10 +26,7 @@ class DeleteAccountButton extends ConsumerWidget with PresentationMixin {
                 content: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Text(
-                      'ご利用ありがとうございました。',
-                      textAlign: TextAlign.center,
-                    ),
+                    const Text('ご利用ありがとうございました。', textAlign: TextAlign.center),
                     const Gap(16),
                     Text(
                       '新たにアカウントを作成する場合は、\n「新規作成」ボタンをタップしてください',
@@ -51,7 +48,9 @@ class DeleteAccountButton extends ConsumerWidget with PresentationMixin {
     }
 
     Future<void> showFinalConfirmDialog() async {
-      ref.read(dialogControllerProvider).show(
+      ref
+          .read(dialogControllerProvider)
+          .show(
             ConfirmDialog(
               confirmMessage: '最終確認です。\n本当にアカウントを削除しても\nよろしいですか？',
               onAccept: () async {
@@ -71,7 +70,9 @@ class DeleteAccountButton extends ConsumerWidget with PresentationMixin {
     }
 
     Future<void> showInitialConfirmDialog() async {
-      ref.read(dialogControllerProvider).show(
+      ref
+          .read(dialogControllerProvider)
+          .show(
             ConfirmDialog(
               confirmMessage: '全ての投稿が削除されます。\n本当にアカウントを削除しても\nよろしいですか？',
               onAccept: showFinalConfirmDialog,
@@ -85,8 +86,8 @@ class DeleteAccountButton extends ConsumerWidget with PresentationMixin {
       child: Text(
         'アカウント削除',
         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: Theme.of(context).colorScheme.error,
-            ),
+          color: Theme.of(context).colorScheme.error,
+        ),
       ),
     );
   }

--- a/lib/feature/user_config/presentation/other_user_action_icon_button.dart
+++ b/lib/feature/user_config/presentation/other_user_action_icon_button.dart
@@ -72,17 +72,17 @@ class OtherUserActionIconButton extends ConsumerWidget with PresentationMixin {
         PullDownMenuItem(
           onTap: () async {
             final currentUserId = ref.read(userIdProvider)!;
-            final currentUserProfile =
-                await ref.read(userProfileProvider(currentUserId).future);
+            final currentUserProfile = await ref.read(
+              userProfileProvider(currentUserId).future,
+            );
 
             final url = userReportFormUrl(
               currentUserPublicId: currentUserProfile.publicId,
               targetUserPublicId: ownerProfile.publicId,
             );
-            await ref.read(launchUrlControllerProvider).launchURL(
-                  url,
-                  inBaseRoute: inBaseRoute,
-                );
+            await ref
+                .read(launchUrlControllerProvider)
+                .launchURL(url, inBaseRoute: inBaseRoute);
           },
           title: 'このユーザーを報告',
           icon: CupertinoIcons.flag,
@@ -103,8 +103,9 @@ class OtherUserActionIconButton extends ConsumerWidget with PresentationMixin {
             final position =
                 box!.localToGlobal(Offset.zero) & const Size(40, 48);
 
-            final ownerProfile =
-                await ref.read(userProfileProvider(ownerId).future);
+            final ownerProfile = await ref.read(
+              userProfileProvider(ownerId).future,
+            );
 
             if (!context.mounted) {
               return;

--- a/lib/feature/user_config/repository/device_info_repository.g.dart
+++ b/lib/feature/user_config/repository/device_info_repository.g.dart
@@ -13,14 +13,14 @@ String _$deviceInfoRepositoryHash() =>
 @ProviderFor(deviceInfoRepository)
 final deviceInfoRepositoryProvider =
     AutoDisposeProvider<DeviceInfoRepository>.internal(
-  deviceInfoRepository,
-  name: r'deviceInfoRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$deviceInfoRepositoryHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      deviceInfoRepository,
+      name: r'deviceInfoRepositoryProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$deviceInfoRepositoryHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
 typedef DeviceInfoRepositoryRef = AutoDisposeProviderRef<DeviceInfoRepository>;
 // ignore_for_file: type=lint

--- a/lib/feature/user_config/repository/package_info_repository.g.dart
+++ b/lib/feature/user_config/repository/package_info_repository.g.dart
@@ -13,16 +13,16 @@ String _$packageInfoRepositoryHash() =>
 @ProviderFor(packageInfoRepository)
 final packageInfoRepositoryProvider =
     AutoDisposeProvider<PackageInfoRepository>.internal(
-  packageInfoRepository,
-  name: r'packageInfoRepositoryProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$packageInfoRepositoryHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+      packageInfoRepository,
+      name: r'packageInfoRepositoryProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$packageInfoRepositoryHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
-typedef PackageInfoRepositoryRef
-    = AutoDisposeProviderRef<PackageInfoRepository>;
+typedef PackageInfoRepositoryRef =
+    AutoDisposeProviderRef<PackageInfoRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/user_follow/presentation/follow_or_unfollow_button.dart
+++ b/lib/feature/user_follow/presentation/follow_or_unfollow_button.dart
@@ -9,10 +9,7 @@ import '../application/user_follow_service.dart';
 import '../application/user_follow_state.dart';
 
 class FollowOrUnfollowButton extends ConsumerWidget {
-  const FollowOrUnfollowButton({
-    super.key,
-    required this.targetUserId,
-  });
+  const FollowOrUnfollowButton({super.key, required this.targetUserId});
 
   final String targetUserId;
 
@@ -38,9 +35,7 @@ class FollowOrUnfollowButton extends ConsumerWidget {
 }
 
 class _FollowButton extends ConsumerWidget with PresentationMixin {
-  const _FollowButton({
-    required this.targetUserId,
-  });
+  const _FollowButton({required this.targetUserId});
 
   final String targetUserId;
 
@@ -61,9 +56,7 @@ class _FollowButton extends ConsumerWidget with PresentationMixin {
 }
 
 class _UnfollowButton extends ConsumerWidget with PresentationMixin {
-  const _UnfollowButton({
-    required this.targetUserId,
-  });
+  const _UnfollowButton({required this.targetUserId});
 
   final String targetUserId;
 

--- a/lib/feature/user_follow/presentation/following_and_follower_count_widget.dart
+++ b/lib/feature/user_follow/presentation/following_and_follower_count_widget.dart
@@ -38,10 +38,9 @@ class FollowingAndFollowerCountWidget extends ConsumerWidget {
                 children: [
                   Text(
                     followCount.followingCount.toString(),
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyMedium!
-                        .copyWith(fontWeight: FontWeight.bold),
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const Gap(4),
                   const Text('フォロー中'),
@@ -62,10 +61,9 @@ class FollowingAndFollowerCountWidget extends ConsumerWidget {
                 children: [
                   Text(
                     followCount.followerCount.toString(),
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyMedium!
-                        .copyWith(fontWeight: FontWeight.bold),
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const Gap(4),
                   const Text('フォロワー'),

--- a/lib/feature/user_profile/presentation/profile_tile_shimmer.dart
+++ b/lib/feature/user_profile/presentation/profile_tile_shimmer.dart
@@ -23,10 +23,7 @@ class ProfileTileShimmer extends StatelessWidget {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const ShimmerWidget.rectangular(
-                          width: 120,
-                          height: 24,
-                        ),
+                        const ShimmerWidget.rectangular(width: 120, height: 24),
                         ShimmerWidget.circular(
                           width: 144,
                           height: 40,

--- a/lib/feature/user_profile/presentation/profile_widget_shimmer.dart
+++ b/lib/feature/user_profile/presentation/profile_widget_shimmer.dart
@@ -15,11 +15,7 @@ class ProfileWidgetShimmer extends StatelessWidget {
         children: [
           const Gap(24),
           const Row(
-            children: [
-              ShimmerWidget.circular(width: 72, height: 72),
-              Spacer(),
-              
-            ],
+            children: [ShimmerWidget.circular(width: 72, height: 72), Spacer()],
           ),
           const Gap(16),
           const ShimmerWidget.rectangular(width: 240, height: 24),

--- a/lib/feature/user_search/presentation/search_user_text_field.dart
+++ b/lib/feature/user_search/presentation/search_user_text_field.dart
@@ -11,11 +11,7 @@ import '../../../core/router/app_router.dart';
 import '../../user_profile/domain/user_profile.dart';
 
 class SearchUserTextField extends ConsumerStatefulWidget {
-  SearchUserTextField({
-    super.key,
-    this.autoFocus = false,
-    this.defaultText,
-  });
+  SearchUserTextField({super.key, this.autoFocus = false, this.defaultText});
 
   final bool autoFocus;
   final String? defaultText;
@@ -83,20 +79,21 @@ class _SearchUserTextFieldState extends ConsumerState<SearchUserTextField> {
                       },
                       child: Text(
                         '検索',
-                        style:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(
-                                  color: controller.text.length ==
-                                          UserProfile.publicIdLength
-                                      ? Theme.of(context).colorScheme.onSurface
-                                      : Theme.of(context)
-                                          .colorScheme
-                                          .onSurfaceVariant
-                                          .withOpacity(0.4),
-                                ),
+                        style: Theme.of(context).textTheme.titleMedium!
+                            .copyWith(
+                              color:
+                                  controller.text.length ==
+                                      UserProfile.publicIdLength
+                                  ? Theme.of(context).colorScheme.onSurface
+                                  : Theme.of(context)
+                                        .colorScheme
+                                        .onSurfaceVariant
+                                        .withOpacity(0.4),
+                            ),
                       ),
                     ),
                   );
-                }
+                },
               ],
             ),
           ],
@@ -112,7 +109,9 @@ class _SearchUserTextFieldState extends ConsumerState<SearchUserTextField> {
           autofocus: widget.autoFocus,
           onSubmitted: (value) {
             if (value.length != UserProfile.publicIdLength) {
-              ref.read(snackBarControllerProvider).showErrorSnackBar(
+              ref
+                  .read(snackBarControllerProvider)
+                  .showErrorSnackBar(
                     '9文字入力してください',
                     ScaffoldMessengerType.baseRoute,
                   );
@@ -122,10 +121,7 @@ class _SearchUserTextFieldState extends ConsumerState<SearchUserTextField> {
             context.pushRoute(UserSearchResultRoute(searchWord: value));
           },
           decoration: InputDecoration(
-            prefixIcon: const Icon(
-              CupertinoIcons.search,
-              size: 20,
-            ),
+            prefixIcon: const Icon(CupertinoIcons.search, size: 20),
             prefixIconColor: Theme.of(context).colorScheme.onSurfaceVariant,
             suffixIcon: Consumer(
               builder: (context, ref, child) {

--- a/lib/feature/word/application/word_state.g.dart
+++ b/lib/feature/word/application/word_state.g.dart
@@ -55,21 +55,13 @@ class WordFamily extends Family<AsyncValue<Word?>> {
   /// 該当する [Word] が見つからない場合、nullを返す。
   ///
   /// Copied from [word].
-  WordProvider call(
-    String wordId,
-  ) {
-    return WordProvider(
-      wordId,
-    );
+  WordProvider call(String wordId) {
+    return WordProvider(wordId);
   }
 
   @override
-  WordProvider getProviderOverride(
-    covariant WordProvider provider,
-  ) {
-    return call(
-      provider.wordId,
-    );
+  WordProvider getProviderOverride(covariant WordProvider provider) {
+    return call(provider.wordId);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -98,21 +90,18 @@ class WordProvider extends AutoDisposeFutureProvider<Word?> {
   /// 該当する [Word] が見つからない場合、nullを返す。
   ///
   /// Copied from [word].
-  WordProvider(
-    String wordId,
-  ) : this._internal(
-          (ref) => word(
-            ref as WordRef,
-            wordId,
-          ),
-          from: wordProvider,
-          name: r'wordProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product') ? null : _$wordHash,
-          dependencies: WordFamily._dependencies,
-          allTransitiveDependencies: WordFamily._allTransitiveDependencies,
-          wordId: wordId,
-        );
+  WordProvider(String wordId)
+    : this._internal(
+        (ref) => word(ref as WordRef, wordId),
+        from: wordProvider,
+        name: r'wordProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$wordHash,
+        dependencies: WordFamily._dependencies,
+        allTransitiveDependencies: WordFamily._allTransitiveDependencies,
+        wordId: wordId,
+      );
 
   WordProvider._internal(
     super._createNotifier, {
@@ -127,9 +116,7 @@ class WordProvider extends AutoDisposeFutureProvider<Word?> {
   final String wordId;
 
   @override
-  Override overrideWith(
-    FutureOr<Word?> Function(WordRef provider) create,
-  ) {
+  Override overrideWith(FutureOr<Word?> Function(WordRef provider) create) {
     return ProviderOverride(
       origin: this,
       override: WordProvider._internal(
@@ -175,5 +162,6 @@ class _WordProviderElement extends AutoDisposeFutureProviderElement<Word?>
   @override
   String get wordId => (origin as WordProvider).wordId;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/word/domain/word.freezed.dart
+++ b/lib/feature/word/domain/word.freezed.dart
@@ -12,7 +12,8 @@ part of 'word.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
 
 /// @nodoc
 mixin _$Word {
@@ -31,12 +32,13 @@ abstract class $WordCopyWith<$Res> {
   factory $WordCopyWith(Word value, $Res Function(Word) then) =
       _$WordCopyWithImpl<$Res, Word>;
   @useResult
-  $Res call(
-      {String id,
-      String word,
-      String reading,
-      String initialSubGroupLabel,
-      int postedDefinitionCount});
+  $Res call({
+    String id,
+    String word,
+    String reading,
+    String initialSubGroupLabel,
+    int postedDefinitionCount,
+  });
 }
 
 /// @nodoc
@@ -58,44 +60,49 @@ class _$WordCopyWithImpl<$Res, $Val extends Word>
     Object? initialSubGroupLabel = null,
     Object? postedDefinitionCount = null,
   }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      word: null == word
-          ? _value.word
-          : word // ignore: cast_nullable_to_non_nullable
-              as String,
-      reading: null == reading
-          ? _value.reading
-          : reading // ignore: cast_nullable_to_non_nullable
-              as String,
-      initialSubGroupLabel: null == initialSubGroupLabel
-          ? _value.initialSubGroupLabel
-          : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
-              as String,
-      postedDefinitionCount: null == postedDefinitionCount
-          ? _value.postedDefinitionCount
-          : postedDefinitionCount // ignore: cast_nullable_to_non_nullable
-              as int,
-    ) as $Val);
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            word: null == word
+                ? _value.word
+                : word // ignore: cast_nullable_to_non_nullable
+                      as String,
+            reading: null == reading
+                ? _value.reading
+                : reading // ignore: cast_nullable_to_non_nullable
+                      as String,
+            initialSubGroupLabel: null == initialSubGroupLabel
+                ? _value.initialSubGroupLabel
+                : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
+                      as String,
+            postedDefinitionCount: null == postedDefinitionCount
+                ? _value.postedDefinitionCount
+                : postedDefinitionCount // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$WordImplCopyWith<$Res> implements $WordCopyWith<$Res> {
   factory _$$WordImplCopyWith(
-          _$WordImpl value, $Res Function(_$WordImpl) then) =
-      __$$WordImplCopyWithImpl<$Res>;
+    _$WordImpl value,
+    $Res Function(_$WordImpl) then,
+  ) = __$$WordImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call(
-      {String id,
-      String word,
-      String reading,
-      String initialSubGroupLabel,
-      int postedDefinitionCount});
+  $Res call({
+    String id,
+    String word,
+    String reading,
+    String initialSubGroupLabel,
+    int postedDefinitionCount,
+  });
 }
 
 /// @nodoc
@@ -103,7 +110,7 @@ class __$$WordImplCopyWithImpl<$Res>
     extends _$WordCopyWithImpl<$Res, _$WordImpl>
     implements _$$WordImplCopyWith<$Res> {
   __$$WordImplCopyWithImpl(_$WordImpl _value, $Res Function(_$WordImpl) _then)
-      : super(_value, _then);
+    : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -114,40 +121,43 @@ class __$$WordImplCopyWithImpl<$Res>
     Object? initialSubGroupLabel = null,
     Object? postedDefinitionCount = null,
   }) {
-    return _then(_$WordImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      word: null == word
-          ? _value.word
-          : word // ignore: cast_nullable_to_non_nullable
-              as String,
-      reading: null == reading
-          ? _value.reading
-          : reading // ignore: cast_nullable_to_non_nullable
-              as String,
-      initialSubGroupLabel: null == initialSubGroupLabel
-          ? _value.initialSubGroupLabel
-          : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
-              as String,
-      postedDefinitionCount: null == postedDefinitionCount
-          ? _value.postedDefinitionCount
-          : postedDefinitionCount // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
+    return _then(
+      _$WordImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        word: null == word
+            ? _value.word
+            : word // ignore: cast_nullable_to_non_nullable
+                  as String,
+        reading: null == reading
+            ? _value.reading
+            : reading // ignore: cast_nullable_to_non_nullable
+                  as String,
+        initialSubGroupLabel: null == initialSubGroupLabel
+            ? _value.initialSubGroupLabel
+            : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
+                  as String,
+        postedDefinitionCount: null == postedDefinitionCount
+            ? _value.postedDefinitionCount
+            : postedDefinitionCount // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
   }
 }
 
 /// @nodoc
 
 class _$WordImpl implements _Word {
-  const _$WordImpl(
-      {required this.id,
-      required this.word,
-      required this.reading,
-      required this.initialSubGroupLabel,
-      required this.postedDefinitionCount});
+  const _$WordImpl({
+    required this.id,
+    required this.word,
+    required this.reading,
+    required this.initialSubGroupLabel,
+    required this.postedDefinitionCount,
+  });
 
   @override
   final String id;
@@ -180,8 +190,14 @@ class _$WordImpl implements _Word {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, id, word, reading,
-      initialSubGroupLabel, postedDefinitionCount);
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    word,
+    reading,
+    initialSubGroupLabel,
+    postedDefinitionCount,
+  );
 
   @JsonKey(ignore: true)
   @override
@@ -191,12 +207,13 @@ class _$WordImpl implements _Word {
 }
 
 abstract class _Word implements Word {
-  const factory _Word(
-      {required final String id,
-      required final String word,
-      required final String reading,
-      required final String initialSubGroupLabel,
-      required final int postedDefinitionCount}) = _$WordImpl;
+  const factory _Word({
+    required final String id,
+    required final String word,
+    required final String reading,
+    required final String initialSubGroupLabel,
+    required final int postedDefinitionCount,
+  }) = _$WordImpl;
 
   @override
   String get id;

--- a/lib/feature/word/presentation/index_tile.dart
+++ b/lib/feature/word/presentation/index_tile.dart
@@ -2,10 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class IndexTile extends StatelessWidget {
-  const IndexTile({
-    super.key,
-    required this.label,
-  });
+  const IndexTile({super.key, required this.label});
 
   final String label;
 
@@ -16,10 +13,7 @@ class IndexTile extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            label,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
+          Text(label, style: Theme.of(context).textTheme.titleLarge),
           Icon(
             CupertinoIcons.chevron_forward,
             color: Theme.of(context).colorScheme.onSurfaceVariant,

--- a/lib/feature/word/presentation/word_tile.dart
+++ b/lib/feature/word/presentation/word_tile.dart
@@ -7,10 +7,7 @@ import '../../../../core/router/app_router.dart';
 import '../domain/word.dart';
 
 class WordTile extends StatelessWidget {
-  const WordTile({
-    super.key,
-    required this.word,
-  });
+  const WordTile({super.key, required this.word});
 
   final Word word;
 
@@ -39,10 +36,8 @@ class WordTile extends StatelessWidget {
                       Text(
                         word.reading,
                         style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onSurfaceVariant,
-                            ),
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
                       ),
                     ],
                   ),
@@ -53,9 +48,8 @@ class WordTile extends StatelessWidget {
                     Text(
                       '${word.postedDefinitionCount}投稿',
                       style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
                     ),
                     const Gap(4),
                     Icon(

--- a/lib/feature/word/presentation/word_widget.dart
+++ b/lib/feature/word/presentation/word_widget.dart
@@ -23,23 +23,20 @@ class WordWidget extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Gap(24),
-          Text(
-            word.word,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
+          Text(word.word, style: Theme.of(context).textTheme.titleLarge),
           Text(
             word.reading,
             style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.bold,
-                ),
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.bold,
+            ),
           ),
           const Gap(24),
           Text(
             '${word.postedDefinitionCount}投稿',
             style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
           const Gap(8),
           Center(

--- a/lib/feature/word/util/dictionary_page_type.dart
+++ b/lib/feature/word/util/dictionary_page_type.dart
@@ -1,4 +1,1 @@
-enum DictionaryPageType {
-  individual,
-  everyone,
-}
+enum DictionaryPageType { individual, everyone }

--- a/lib/feature/word_list/presentation/search_word_text_field.dart
+++ b/lib/feature/word_list/presentation/search_word_text_field.dart
@@ -6,10 +6,7 @@ import '../../../../core/router/app_router.dart';
 
 /// 語句を検索する用の [TextField]。
 class SearchWordTextField extends StatefulWidget {
-  const SearchWordTextField({
-    super.key,
-    this.defaultText,
-  });
+  const SearchWordTextField({super.key, this.defaultText});
 
   /// 初期値として表示するテキスト。
   final String? defaultText;
@@ -52,24 +49,16 @@ class _SearchWordTextFieldState extends State<SearchWordTextField> {
           return;
         }
         controller.text = widget.defaultText ?? '';
-        context.pushRoute(
-          WordSearchResultRoute(searchWord: value),
-        );
+        context.pushRoute(WordSearchResultRoute(searchWord: value));
       },
       decoration: InputDecoration(
-        prefixIcon: const Icon(
-          CupertinoIcons.search,
-          size: 20,
-        ),
+        prefixIcon: const Icon(CupertinoIcons.search, size: 20),
         prefixIconColor: Theme.of(context).colorScheme.onSurfaceVariant,
         suffixIcon: isEmpty
             ? const SizedBox.shrink()
             : GestureDetector(
                 onTap: controller.clear,
-                child: const Icon(
-                  CupertinoIcons.clear_thick_circled,
-                  size: 20,
-                ),
+                child: const Icon(CupertinoIcons.clear_thick_circled, size: 20),
               ),
         suffixIconColor: Theme.of(context).colorScheme.onSurfaceVariant,
         hintText: '語句を検索',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,15 +35,15 @@ Future<void> main() async {
   await Firebase.initializeApp(options: firebaseOptionsWithFlavor(flavor));
 
   await FirebaseAppCheck.instance.activate(
-    androidProvider:
-        kReleaseMode ? AndroidProvider.playIntegrity : AndroidProvider.debug,
-    appleProvider:
-        kReleaseMode ? AppleProvider.deviceCheck : AppleProvider.debug,
+    androidProvider: kReleaseMode
+        ? AndroidProvider.playIntegrity
+        : AndroidProvider.debug,
+    appleProvider: kReleaseMode
+        ? AppleProvider.deviceCheck
+        : AppleProvider.debug,
   );
 
-  await FirebaseAnalytics.instance.logEvent(
-    name: 'launch App',
-  );
+  await FirebaseAnalytics.instance.logEvent(name: 'launch App');
 
   // Flutterフレームワークがキャッチしたエラーを記録する
   FlutterError.onError = (errorDetails) {
@@ -71,9 +71,7 @@ Future<void> main() async {
   ]).then((_) {
     runApp(
       ProviderScope(
-        overrides: [
-          flavorProvider.overrideWithValue(flavor),
-        ],
+        overrides: [flavorProvider.overrideWithValue(flavor)],
         child: DevicePreview(
           enabled: false,
           builder: (context) {
@@ -128,8 +126,10 @@ class MyApp extends ConsumerWidget {
               return const Scaffold(body: OverlayLoadingWidget());
             }
 
-            logger.e('[asyncIsRequiredUpdate]の取得時にエラーが発生しました。'
-                ' error: $e, stackTrace: $s');
+            logger.e(
+              '[asyncIsRequiredUpdate]の取得時にエラーが発生しました。'
+              ' error: $e, stackTrace: $s',
+            );
             return Scaffold(
               body: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -149,10 +149,7 @@ class MyApp extends ConsumerWidget {
             if (isRequiredUpdate) {
               // * アップデートが必要な場合
               return Stack(
-                children: [
-                  child!,
-                  const OverlayForceUpdateDialog(),
-                ],
+                children: [child!, const OverlayForceUpdateDialog()],
               );
             }
 

--- a/lib/util/constant/initial_main_group.dart
+++ b/lib/util/constant/initial_main_group.dart
@@ -311,11 +311,9 @@ enum InitialSubGroup {
 
     // アルファベット
     if (alphabetRegex.hasMatch(initial)) {
-      return InitialSubGroup.values
-          .firstWhere(
-            (element) => element.label == initial.toUpperCase(),
-          )
-          ;
+      return InitialSubGroup.values.firstWhere(
+        (element) => element.label == initial.toUpperCase(),
+      );
     }
 
     // 数字

--- a/lib/util/constant/string_regex.dart
+++ b/lib/util/constant/string_regex.dart
@@ -4,8 +4,9 @@ final alphabetRegex = RegExp(r'^[a-zA-Z]+$');
 final numberRegex = RegExp(r'^[0-9]+$');
 
 /// アプリ内において、「基本的な記号」と定義する記号にマッチする正規表現
-final basicSymbolRegex =
-    RegExp(r'^[!#$%&()*+,\-./:;<=>?@\[\]^_`{|}~（）「」『』ー]+$');
+final basicSymbolRegex = RegExp(
+  r'^[!#$%&()*+,\-./:;<=>?@\[\]^_`{|}~（）「」『』ー]+$',
+);
 
 // TODO(me): ベタ書きではなく、既存の定数を使用して定義したい
 

--- a/lib/util/constant/text_theme.dart
+++ b/lib/util/constant/text_theme.dart
@@ -3,13 +3,7 @@ import 'package:flutter/material.dart';
 const lineFontFamily = 'LINESeedJP';
 
 const textTheme = TextTheme(
-  titleLarge: TextStyle(
-    fontWeight: FontWeight.bold,
-  ),
-  titleMedium: TextStyle(
-    fontWeight: FontWeight.bold,
-  ),
-  bodyLarge: TextStyle(
-    fontSize: 18,
-  ),
+  titleLarge: TextStyle(fontWeight: FontWeight.bold),
+  titleMedium: TextStyle(fontWeight: FontWeight.bold),
+  bodyLarge: TextStyle(fontSize: 18),
 );

--- a/lib/util/constant/theme_data.dart
+++ b/lib/util/constant/theme_data.dart
@@ -6,8 +6,9 @@ import 'text_theme.dart';
 // [BuildContext]を引数で渡すしたくないが、
 // [AppBarTheme]の[titleTextStyle]を設定するためにやむを得ず渡している
 ThemeData getThemeData(ThemeMode themeMode, BuildContext context) {
-  final colorScheme =
-      themeMode == ThemeMode.light ? lightColorScheme : darkColorScheme;
+  final colorScheme = themeMode == ThemeMode.light
+      ? lightColorScheme
+      : darkColorScheme;
 
   return ThemeData(
     fontFamily: lineFontFamily,
@@ -18,22 +19,16 @@ ThemeData getThemeData(ThemeMode themeMode, BuildContext context) {
       backgroundColor: colorScheme.surface,
       elevation: 0.1,
       titleTextStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
-            fontFamily: lineFontFamily,
-            color: colorScheme.onSurface,
-            fontWeight: FontWeight.bold,
-          ),
-      iconTheme: IconThemeData(
+        fontFamily: lineFontFamily,
         color: colorScheme.onSurface,
+        fontWeight: FontWeight.bold,
       ),
+      iconTheme: IconThemeData(color: colorScheme.onSurface),
     ),
     iconButtonTheme: IconButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all<Color>(
-          colorScheme.surface,
-        ),
-        iconColor: MaterialStateProperty.all<Color>(
-          colorScheme.primary,
-        ),
+        backgroundColor: MaterialStateProperty.all<Color>(colorScheme.surface),
+        iconColor: MaterialStateProperty.all<Color>(colorScheme.primary),
       ),
     ),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
@@ -44,9 +39,7 @@ ThemeData getThemeData(ThemeMode themeMode, BuildContext context) {
         fontWeight: FontWeight.bold,
         fontSize: 12,
       ),
-      unselectedLabelStyle: const TextStyle(
-        fontFamily: lineFontFamily,
-      ),
+      unselectedLabelStyle: const TextStyle(fontFamily: lineFontFamily),
       elevation: 0.1,
     ),
     tabBarTheme: TabBarThemeData(

--- a/lib/util/dummy_data/definitions_dummy.dart
+++ b/lib/util/dummy_data/definitions_dummy.dart
@@ -119,8 +119,9 @@ Future<void> addDefinitionDummy0to29(String flavorName) async {
       'wordId': wordIds[i],
       'word': words[i],
       'wordReading': readings[i],
-      'wordReadingInitialSubGroupLabel':
-          InitialSubGroup.fromString(readings[i]),
+      'wordReadingInitialSubGroupLabel': InitialSubGroup.fromString(
+        readings[i],
+      ),
       'authorId': 'user${Random().nextInt(20) + 1}',
       'definition': definitions[i],
       'likesCount': Random().nextInt(100),

--- a/lib/util/dummy_data/user_follow_counts_dummy.dart
+++ b/lib/util/dummy_data/user_follow_counts_dummy.dart
@@ -9,13 +9,11 @@ Future<void> addUserFollowCountsToFirestore(String flavorName) async {
 
   for (var i = 1; i <= 20; i++) {
     final userId = 'user$i';
-    await firestore.collection('UserFollowCounts').doc(userId).set(
-      {
-        'followerCount': 0,
-        'followingCount': 0,
-        'createdAt': FieldValue.serverTimestamp(),
-        'updatedAt': FieldValue.serverTimestamp(),
-      },
-    );
+    await firestore.collection('UserFollowCounts').doc(userId).set({
+      'followerCount': 0,
+      'followingCount': 0,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
   }
 }

--- a/lib/util/dummy_data/user_follows_dummy.dart
+++ b/lib/util/dummy_data/user_follows_dummy.dart
@@ -27,14 +27,12 @@ Future<void> addUserFollowsToFirestore2(String flavorName) async {
 
   for (var i = 2; i <= 20; i++) {
     final userId = 'user$i';
-    await FirebaseFirestore.instance.collection('UserFollows').add(
-      {
-        'followingId': 'user1',
-        'followerId': userId,
-        'createdAt': FieldValue.serverTimestamp(),
-        'updatedAt': FieldValue.serverTimestamp(),
-      },
-    );
+    await FirebaseFirestore.instance.collection('UserFollows').add({
+      'followingId': 'user1',
+      'followerId': userId,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
   }
 }
 
@@ -46,14 +44,12 @@ Future<void> addUserFollowsToFirestore3(String flavorName) async {
 
   for (var i = 2; i <= 20; i++) {
     final userId = 'user$i';
-    await FirebaseFirestore.instance.collection('UserFollows').add(
-      {
-        'followingId': userId,
-        'followerId': 'user1',
-        'createdAt': FieldValue.serverTimestamp(),
-        'updatedAt': FieldValue.serverTimestamp(),
-      },
-    );
+    await FirebaseFirestore.instance.collection('UserFollows').add({
+      'followingId': userId,
+      'followerId': 'user1',
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
   }
 }
 

--- a/lib/util/dummy_data/user_profiles_dummy.dart
+++ b/lib/util/dummy_data/user_profiles_dummy.dart
@@ -13,7 +13,10 @@ Future<void> addUserProfilesToFirestore(String flavorName) async {
 
   // 上で定義したusersマップを用いてデータをFirestoreに追加
   for (final userId in userProfiles.keys) {
-    await firestore.collection('UserProfiles').doc(userId).set(userProfiles[userId]!);
+    await firestore
+        .collection('UserProfiles')
+        .doc(userId)
+        .set(userProfiles[userId]!);
     await Future<void>.delayed(const Duration(milliseconds: 1000));
   }
 }

--- a/lib/util/dummy_data/words_dummy.dart
+++ b/lib/util/dummy_data/words_dummy.dart
@@ -71,13 +71,7 @@ Future<void> addWordsDummy0to29(String flavorName) async {
     'みらいえいごう',
   ];
 
-  await _addWordsDummyToFirestore(
-    flavorName,
-    words,
-    readings,
-    0,
-    29,
-  );
+  await _addWordsDummyToFirestore(flavorName, words, readings, 0, 29);
 }
 
 Future<void> addWordsDummy30to59(String flavorName) async {
@@ -149,13 +143,7 @@ Future<void> addWordsDummy30to59(String flavorName) async {
     'ざつおん',
   ];
 
-  await _addWordsDummyToFirestore(
-    flavorName,
-    words,
-    readings,
-    30,
-    59,
-  );
+  await _addWordsDummyToFirestore(flavorName, words, readings, 30, 59);
 }
 
 Future<void> _addWordsDummyToFirestore(

--- a/lib/util/exception/base_exception.dart
+++ b/lib/util/exception/base_exception.dart
@@ -1,10 +1,7 @@
 import 'exception_code.dart';
 
 class BaseException implements Exception {
-  const BaseException(
-    this.exceptionCode, {
-    this.info,
-  });
+  const BaseException(this.exceptionCode, {this.info});
 
   final ExceptionCode exceptionCode;
   final dynamic info;

--- a/lib/util/exception/database_exception.dart
+++ b/lib/util/exception/database_exception.dart
@@ -23,20 +23,11 @@ class DatabaseException extends BaseException {
 /// データベース関連のエラーコード
 enum DatabaseExceptionCode implements ExceptionCode {
   // データが見つからない
-  notFound(
-    'not found',
-    'エラーが発生しました。もう一度お試しください。',
-  ),
+  notFound('not found', 'エラーが発生しました。もう一度お試しください。'),
   // 不明
-  unknown(
-    'unknown',
-    'エラーが発生しました。もう一度お試しください。',
-  );
+  unknown('unknown', 'エラーが発生しました。もう一度お試しください。');
 
-  const DatabaseExceptionCode(
-    this._code,
-    this._message,
-  );
+  const DatabaseExceptionCode(this._code, this._message);
 
   final String _code;
   final String? _message;

--- a/lib/util/extension/target_platform_extension.dart
+++ b/lib/util/extension/target_platform_extension.dart
@@ -4,10 +4,7 @@ extension TargetPlatformExtension on TargetPlatform {
   /// [TargetPlatform]に対して、 iOS と Android の場合で処理を分ける。
   ///
   /// iOS でも Android でもない場合は、[UnsupportedError] を投げる。
-  T when<T>({
-    required T Function() onIOS,
-    required T Function() onAndroid,
-  }) {
+  T when<T>({required T Function() onIOS, required T Function() onAndroid}) {
     switch (this) {
       case TargetPlatform.iOS:
         return onIOS();

--- a/test/core/api/api_exception_test.dart
+++ b/test/core/api/api_exception_test.dart
@@ -57,11 +57,7 @@ void main() {
           statusCode: 409,
           data: {
             'error': {'code': 'conflict', 'message': '登録済みの言葉です'},
-            'existingWord': {
-              'id': 'word-1',
-              'word': '定義',
-              'reading': 'ていぎ',
-            },
+            'existingWord': {'id': 'word-1', 'word': '定義', 'reading': 'ていぎ'},
           },
         ),
       ),

--- a/test/core/api/discover_feed_item_test.dart
+++ b/test/core/api/discover_feed_item_test.dart
@@ -2,34 +2,34 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:teigiii_api/teigiii_api.dart';
 
 Map<String, dynamic> definitionActivityJson() => {
-      'type': 'definition',
-      'occurredAt': '2026-07-18T00:00:00.000Z',
-      'definition': {
-        'id': 'def-1',
-        'word': {'id': 'word-1', 'word': '定義', 'reading': 'ていぎ'},
-        'author': {
-          'id': 'user-1',
-          'publicId': '123456789',
-          'name': 'テストユーザー',
-          'avatarUrl': null,
-        },
-        'body': '本文',
-        'status': 'public',
-        'isEdited': false,
-        'likesCount': 0,
-        'isLikedByMe': false,
-        'finalizedAt': null,
-        'editableUntil': null,
-        'createdAt': '2026-07-18T00:00:00.000Z',
-        'updatedAt': '2026-07-18T00:00:00.000Z',
-      },
-    };
+  'type': 'definition',
+  'occurredAt': '2026-07-18T00:00:00.000Z',
+  'definition': {
+    'id': 'def-1',
+    'word': {'id': 'word-1', 'word': '定義', 'reading': 'ていぎ'},
+    'author': {
+      'id': 'user-1',
+      'publicId': '123456789',
+      'name': 'テストユーザー',
+      'avatarUrl': null,
+    },
+    'body': '本文',
+    'status': 'public',
+    'isEdited': false,
+    'likesCount': 0,
+    'isLikedByMe': false,
+    'finalizedAt': null,
+    'editableUntil': null,
+    'createdAt': '2026-07-18T00:00:00.000Z',
+    'updatedAt': '2026-07-18T00:00:00.000Z',
+  },
+};
 
 Map<String, dynamic> wordRegisteredActivityJson() => {
-      'type': 'wordRegistered',
-      'occurredAt': '2026-07-18T00:00:00.000Z',
-      'word': {'id': 'word-2', 'word': '言葉', 'reading': 'ことば'},
-    };
+  'type': 'wordRegistered',
+  'occurredAt': '2026-07-18T00:00:00.000Z',
+  'word': {'id': 'word-2', 'word': '言葉', 'reading': 'ことば'},
+};
 
 void main() {
   test('definition バリアントをデシリアライズできる', () {

--- a/test/core/common_provider/common_provider_test.mocks.dart
+++ b/test/core/common_provider/common_provider_test.mocks.dart
@@ -23,18 +23,8 @@ import 'is_loading_overlay_state_test.dart' as _i2;
 /// See the documentation for Mockito's code generation for more information.
 class MockListener extends _i1.Mock implements _i2.Listener<bool> {
   @override
-  void call(
-    bool? previous,
-    bool? next,
-  ) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #call,
-          [
-            previous,
-            next,
-          ],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void call(bool? previous, bool? next) => super.noSuchMethod(
+    Invocation.method(#call, [previous, next]),
+    returnValueForMissingStub: null,
+  );
 }

--- a/test/core/common_provider/is_loading_overlay_state_test.dart
+++ b/test/core/common_provider/is_loading_overlay_state_test.dart
@@ -7,10 +7,9 @@ import 'package:teigi_app/core/common_provider/is_loading_overlay_state.dart';
 import 'common_provider_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<Listener<bool>>()])
-
 // ignore: one_member_abstracts, unreachable_from_main
 abstract class Listener<T> {
-// ignore: unreachable_from_main
+  // ignore: unreachable_from_main
   void call(T? previous, T next);
 }
 
@@ -18,17 +17,15 @@ void main() {
   final listener = MockListener();
   late ProviderContainer container;
 
-  setUp(
-    () {
-      container = ProviderContainer()
-        ..listen(
-          isLoadingOverlayNotifierProvider,
-          listener,
-          fireImmediately: true,
-        );
-      addTearDown(container.dispose);
-    },
-  );
+  setUp(() {
+    container = ProviderContainer()
+      ..listen(
+        isLoadingOverlayNotifierProvider,
+        listener,
+        fireImmediately: true,
+      );
+    addTearDown(container.dispose);
+  });
 
   tearDown(() {
     reset(listener);
@@ -88,7 +85,6 @@ void main() {
       // * Arrange
       container.read(isLoadingOverlayNotifierProvider.notifier)
         ..startLoading()
-
         // * Act
         ..finishLoading();
 

--- a/test/core/common_provider/is_loading_overlay_state_test.mocks.dart
+++ b/test/core/common_provider/is_loading_overlay_state_test.mocks.dart
@@ -25,18 +25,8 @@ import 'is_loading_overlay_state_test.dart' as _i2;
 /// See the documentation for Mockito's code generation for more information.
 class MockListener extends _i1.Mock implements _i2.Listener<bool> {
   @override
-  void call(
-    bool? previous,
-    bool? next,
-  ) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #call,
-          [
-            previous,
-            next,
-          ],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void call(bool? previous, bool? next) => super.noSuchMethod(
+    Invocation.method(#call, [previous, next]),
+    returnValueForMissingStub: null,
+  );
 }

--- a/test/feature/auth/application/auth_service_test.dart
+++ b/test/feature/auth/application/auth_service_test.dart
@@ -166,27 +166,30 @@ void main() {
   });
 
   group('signIn() 失敗時のクリーンアップ', () {
-    test('initUser 失敗時: サーバーユーザー削除 → Firebase Auth 削除の順で呼ばれ rethrow する', () async {
-      // * Arrange
-      final authService = container.read(authServiceProvider);
-      setupMock('iOS 14.4');
-      when(
-        mockRegisterUserRepository.initUser(
-          name: anyNamed('name'),
-          osVersion: anyNamed('osVersion'),
-          appVersion: anyNamed('appVersion'),
-        ),
-      ).thenThrow(ApiException(statusCode: 500));
+    test(
+      'initUser 失敗時: サーバーユーザー削除 → Firebase Auth 削除の順で呼ばれ rethrow する',
+      () async {
+        // * Arrange
+        final authService = container.read(authServiceProvider);
+        setupMock('iOS 14.4');
+        when(
+          mockRegisterUserRepository.initUser(
+            name: anyNamed('name'),
+            osVersion: anyNamed('osVersion'),
+            appVersion: anyNamed('appVersion'),
+          ),
+        ).thenThrow(ApiException(statusCode: 500));
 
-      // * Act & Assert
-      await expectLater(authService.signIn(), throwsA(isA<ApiException>()));
+        // * Act & Assert
+        await expectLater(authService.signIn(), throwsA(isA<ApiException>()));
 
-      // Firebase Auth だけでなくサーバーユーザーもベストエフォート削除される
-      verifyInOrder([
-        mockRegisterUserRepository.deleteUser(),
-        mockAuthRepository.deleteUser(),
-      ]);
-    });
+        // Firebase Auth だけでなくサーバーユーザーもベストエフォート削除される
+        verifyInOrder([
+          mockRegisterUserRepository.deleteUser(),
+          mockAuthRepository.deleteUser(),
+        ]);
+      },
+    );
 
     test('サーバーユーザー削除も失敗した場合でも Firebase Auth 削除まで到達し rethrow する', () async {
       // * Arrange
@@ -254,10 +257,7 @@ void main() {
       ).thenThrow(ApiException(statusCode: 500));
 
       // * Act & Assert
-      await expectLater(
-        authService.deleteUser(),
-        throwsA(isA<ApiException>()),
-      );
+      await expectLater(authService.deleteUser(), throwsA(isA<ApiException>()));
       verifyNever(mockAuthRepository.deleteUser());
     });
   });

--- a/test/feature/definition/domain/definition_for_write_test.dart
+++ b/test/feature/definition/domain/definition_for_write_test.dart
@@ -56,10 +56,7 @@ void main() {
       final actual = definition.outputWordError();
 
       // * Assert
-      expect(
-        actual,
-        '${baseDefinitionForWrite.maxWordLength}文字以内で入力してください',
-      );
+      expect(actual, '${baseDefinitionForWrite.maxWordLength}文字以内で入力してください');
     });
 
     test('スペースのみ（先頭がスペース）', () {
@@ -99,8 +96,9 @@ void main() {
 
     test('ひらがな + カタカナ + アラビア数字 + 大文字アルファベット + 小文字アルファベット + ?', () {
       // * Arrange
-      final definition =
-          baseDefinitionForWrite.copyWith(wordReading: 'ひらがなカタカナ0Aa?');
+      final definition = baseDefinitionForWrite.copyWith(
+        wordReading: 'ひらがなカタカナ0Aa?',
+      );
 
       // * Act
       final actual = definition.outputWordReadingError();
@@ -111,8 +109,9 @@ void main() {
 
     test('途中にスペース', () {
       // * Arrange
-      final definition =
-          baseDefinitionForWrite.copyWith(wordReading: 'ふつかめの かれー');
+      final definition = baseDefinitionForWrite.copyWith(
+        wordReading: 'ふつかめの かれー',
+      );
 
       // * Act
       final actual = definition.outputWordReadingError();
@@ -123,8 +122,9 @@ void main() {
 
     test('漢字が含まれている', () {
       // * Arrange
-      final definition =
-          baseDefinitionForWrite.copyWith(wordReading: '二日目の かれー');
+      final definition = baseDefinitionForWrite.copyWith(
+        wordReading: '二日目の かれー',
+      );
 
       // * Act
       final actual = definition.outputWordReadingError();
@@ -137,8 +137,9 @@ void main() {
       // * Arrange
       final wordReading =
           'あ' * (baseDefinitionForWrite.maxWordReadingLength + 1);
-      final definition =
-          baseDefinitionForWrite.copyWith(wordReading: wordReading);
+      final definition = baseDefinitionForWrite.copyWith(
+        wordReading: wordReading,
+      );
 
       // * Act
       final actual = definition.outputWordReadingError();
@@ -152,8 +153,9 @@ void main() {
 
     test('無効な記号が含まれている', () {
       // * Arrange
-      final definition =
-          baseDefinitionForWrite.copyWith(wordReading: 'ふつかめの かれー💓');
+      final definition = baseDefinitionForWrite.copyWith(
+        wordReading: 'ふつかめの かれー💓',
+      );
 
       // * Act
       final actual = definition.outputWordReadingError();

--- a/test/feature/user_profile/repository/avatar_repository_test.dart
+++ b/test/feature/user_profile/repository/avatar_repository_test.dart
@@ -56,14 +56,13 @@ void main() {
       // アップロード後に（ディスク側の）古いキャッシュが破棄されること
       verify(mockCacheManager.removeFile(avatarUrl)).called(1);
       // 送信されたバイト列・Content-Type・Content-Length を検証する
-      final captured =
-          verify(
-            mockDio.put<Map<String, dynamic>>(
-              '/v1/users/me/avatar',
-              data: captureAnyNamed('data'),
-              options: captureAnyNamed('options'),
-            ),
-          ).captured;
+      final captured = verify(
+        mockDio.put<Map<String, dynamic>>(
+          '/v1/users/me/avatar',
+          data: captureAnyNamed('data'),
+          options: captureAnyNamed('options'),
+        ),
+      ).captured;
       final data = captured[0] as Stream<List<int>>;
       final options = captured[1] as Options;
 

--- a/test/feature/user_search/repository/user_search_repository_test.dart
+++ b/test/feature/user_search/repository/user_search_repository_test.dart
@@ -75,10 +75,9 @@ void main() {
       when(
         mockSearchApi.v1SearchUsersGet(q: '123456789', limit: 50),
       ).thenAnswer(
-        (_) async => buildResponse(
-          [buildItem('userB', '1234567890')],
-          nextCursor: 'cursor1',
-        ),
+        (_) async => buildResponse([
+          buildItem('userB', '1234567890'),
+        ], nextCursor: 'cursor1'),
       );
       // 2 ページ目に完全一致が含まれる
       when(

--- a/test/util/extension/date_time_extension_test.dart
+++ b/test/util/extension/date_time_extension_test.dart
@@ -154,8 +154,9 @@ void main() {
 
     test('59分経過している（59分前の時刻が実行）', () {
       // * Arrange
-      final thirtyMinutesAgo =
-          DateTime.now().subtract(const Duration(minutes: 59));
+      final thirtyMinutesAgo = DateTime.now().subtract(
+        const Duration(minutes: 59),
+      );
 
       // * Act
       final actual = thirtyMinutesAgo.hasOneHourPassed();

--- a/test/util/extension/string_extension_test.dart
+++ b/test/util/extension/string_extension_test.dart
@@ -36,10 +36,7 @@ void main() {
       const hiragana = 'サケ';
 
       // * Act & Assert
-      expect(
-        () => hiragana.katakanaToHiragana(),
-        throwsFormatException,
-      );
+      expect(() => hiragana.katakanaToHiragana(), throwsFormatException);
     });
 
     test('空文字', () {
@@ -47,10 +44,7 @@ void main() {
       const hiragana = '';
 
       // * Act & Assert
-      expect(
-        () => hiragana.katakanaToHiragana(),
-        throwsFormatException,
-      );
+      expect(() => hiragana.katakanaToHiragana(), throwsFormatException);
     });
 
     test('スペース', () {
@@ -58,10 +52,7 @@ void main() {
       const hiragana = ' ';
 
       // * Act & Assert
-      expect(
-        () => hiragana.katakanaToHiragana(),
-        throwsArgumentError,
-      );
+      expect(() => hiragana.katakanaToHiragana(), throwsArgumentError);
     });
 
     test('ひらがな', () {
@@ -69,10 +60,7 @@ void main() {
       const hiragana = 'あ';
 
       // * Act & Assert
-      expect(
-        () => hiragana.katakanaToHiragana(),
-        throwsArgumentError,
-      );
+      expect(() => hiragana.katakanaToHiragana(), throwsArgumentError);
     });
 
     test('数字', () {
@@ -80,10 +68,7 @@ void main() {
       const hiragana = '1';
 
       // * Act & Assert
-      expect(
-        () => hiragana.katakanaToHiragana(),
-        throwsArgumentError,
-      );
+      expect(() => hiragana.katakanaToHiragana(), throwsArgumentError);
     });
 
     test('半角カタカナ', () {
@@ -91,10 +76,7 @@ void main() {
       const hiragana = 'ｱ';
 
       // * Act & Assert
-      expect(
-        () => hiragana.katakanaToHiragana(),
-        throwsArgumentError,
-      );
+      expect(() => hiragana.katakanaToHiragana(), throwsArgumentError);
     });
   });
 

--- a/test/util/extension/string_list_extension_test.dart
+++ b/test/util/extension/string_list_extension_test.dart
@@ -3,7 +3,8 @@ import 'package:teigi_app/util/extension/string_list_extension.dart';
 
 void main() {
   group('orSingleEmptyStringList', () {
-    test('Listが空の場合、空のString（' '）が入ったListを返すことを検証', () {
+    test('Listが空の場合、空のString（'
+        '）が入ったListを返すことを検証', () {
       // * Arrange
       final emptyList = <String>[];
 


### PR DESCRIPTION
## 概要

Flutter 3.41.8 に含まれる Dart フォーマッタで、リポジトリ内の Dart コードを tall style に一括整形しました。意味的なコード変更とは分離しています。

## 変更内容

- just format を実行し、lib / test 配下の 111 ファイルを再整形
- 2 回目の just format で 0 changed を確認
- 実装・設定・依存関係の変更なし

## 検証

- just format: 423 files, 0 changed
- just analyze: pass（既存 info 83 件、exit 0）
- just test: 171 tests passed
- just docbridge-check: 0 errors, 0 warnings
- git diff --check: pass

Closes #209