### PR TITLE
feat: 起動時のユーザー自己修復を実装

### DIFF
--- a/doc/plans/2026-07-20-data-migration-bigbang-switchover.md
+++ b/doc/plans/2026-07-20-data-migration-bigbang-switchover.md
@@ -12,7 +12,7 @@ Firestore → D1、Firebase Storage → R2 の移行スクリプトを作成し�
 
 旧アプリ（Firestore 版バイナリ）のメンテナンスモードは `main.dart` の `builder` で UI に overlay を被せるだけで、`AuthGuard` の匿名サインアップ（Firebase Auth 登録 + Firestore プロフィール作成）はメンテ中でも実行される。さらに切替後も、ストア更新前の旧バイナリの初回起動で D1 に存在しない Auth ユーザーが恒久的に発生し得る。
 
-- **採用**: メンテフリーズ（切替手順の前提）+ クライアント自己修復（新アプリで起動時 `GET /v1/users/me` が 404 `user_not_found` の場合、`POST /v1/users` で再登録する）
+- **採用**: メンテフリーズ（切替手順の前提）+ クライアント自己修復（新アプリで既存の起動時バージョン情報更新（`PATCH /v1/users/me`）が 404 `user_not_found` の場合、`POST /v1/users` で再登録する。検知用の `GET` は追加しない）
 - **不採用**: 差分移行。メンテ開始後に発生する新規ユーザーはデフォルト名の空プロフィールのみ（UI 遮断により投稿等は不可能）で、自己修復による再生成で実害がない。一方、差分移行は一回きりの対処であり孤児 Auth ユーザーの恒久的な発生を構造的に塞げず、増分抽出の実装コストに価値が見合わない
 - issue #186 コメントの「1（差分移行）を軸に」は本決定で上書きする
 
@@ -79,7 +79,7 @@ Firestore → D1、Firebase Storage → R2 の移行スクリプトを作成し�
 
 ### PR 1: クライアント自己修復（Flutter）
 
-起動時 `GET /v1/users/me` が 404 `user_not_found` の場合、`POST /v1/users` で再登録する（既存の初回登録フローを再利用。Firebase Auth ユーザーは存在するためサーバー登録のみ）。
+既存の起動時バージョン情報更新（`PATCH /v1/users/me`）が 404 `user_not_found` の場合、`POST /v1/users` で再登録する（既存の初回登録フローを再利用。Firebase Auth ユーザーは存在するためサーバー登録のみ。検知用の `GET` は追加しない）。
 
 ### PR 2: 移行スクリプト一式（`server/scripts/migration/`）
 

--- a/lib/feature/auth/application/auth_service.dart
+++ b/lib/feature/auth/application/auth_service.dart
@@ -78,6 +78,11 @@ class AuthService {
   }
 
   /// ユーザーの設定に関する情報を更新する。
+  ///
+  /// 404 `user_not_found`（Firebase Auth にはユーザーが存在するがサーバー側に
+  /// 存在しない状態）の場合、自己修復として `_initUser()` による再登録を行う。
+  /// 移行スナップショット取得後に旧アプリで新規登録したユーザー等で発生しうる。
+  /// 再登録自体が失敗した場合はそのまま rethrow し、握りつぶさない。
   Future<void> updateUserConfig() async {
     final osVersion =
         await ref.read(deviceInfoRepositoryProvider).fetchOsVersion() ??
@@ -89,9 +94,17 @@ class AuthService {
     // ここで userId を出力しておく。
     logger.i('[$userId]としてログイン中です。ユーザー情報を更新します。');
 
-    await ref
-        .read(registerUserRepositoryProvider)
-        .updateVersionInfo(osVersion: osVersion, appVersion: appVersion);
+    try {
+      await ref
+          .read(registerUserRepositoryProvider)
+          .updateVersionInfo(osVersion: osVersion, appVersion: appVersion);
+    } on ApiException catch (e) {
+      if (e.statusCode != 404 || e.code != 'user_not_found') {
+        rethrow;
+      }
+      logger.w('[$userId]はサーバー未登録のため、自己修復として再登録します。');
+      await _initUser();
+    }
   }
 
   /// アカウントを削除する。

--- a/test/feature/auth/application/auth_service_test.dart
+++ b/test/feature/auth/application/auth_service_test.dart
@@ -165,6 +165,114 @@ void main() {
     });
   });
 
+  group('updateUserConfig() の自己修復', () {
+    test(
+      '404 user_not_found: initUser による再登録が呼ばれることを検証',
+      () async {
+        // * Arrange
+        final authService = container.read(authServiceProvider);
+        setupMock('iOS 14.4');
+        updateContainersOverride(isSignedIn: true);
+        when(
+          mockRegisterUserRepository.updateVersionInfo(
+            osVersion: anyNamed('osVersion'),
+            appVersion: anyNamed('appVersion'),
+          ),
+        ).thenThrow(ApiException(statusCode: 404, code: 'user_not_found'));
+
+        // * Act
+        await authService.updateUserConfig();
+
+        // * Assert
+        verify(
+          mockRegisterUserRepository.initUser(
+            name: UserProfile.defaultName,
+            osVersion: 'iOS 14.4',
+            appVersion: mockAppVersion,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('404 だが code が user_not_found でない場合は再登録せず rethrow する', () async {
+      // * Arrange
+      final authService = container.read(authServiceProvider);
+      setupMock('iOS 14.4');
+      updateContainersOverride(isSignedIn: true);
+      when(
+        mockRegisterUserRepository.updateVersionInfo(
+          osVersion: anyNamed('osVersion'),
+          appVersion: anyNamed('appVersion'),
+        ),
+      ).thenThrow(ApiException(statusCode: 404, code: 'other_not_found'));
+
+      // * Act & Assert
+      await expectLater(
+        authService.updateUserConfig(),
+        throwsA(isA<ApiException>()),
+      );
+      verifyNever(
+        mockRegisterUserRepository.initUser(
+          name: anyNamed('name'),
+          osVersion: anyNamed('osVersion'),
+          appVersion: anyNamed('appVersion'),
+        ),
+      );
+    });
+
+    test('500 の場合は再登録せず rethrow する', () async {
+      // * Arrange
+      final authService = container.read(authServiceProvider);
+      setupMock('iOS 14.4');
+      updateContainersOverride(isSignedIn: true);
+      when(
+        mockRegisterUserRepository.updateVersionInfo(
+          osVersion: anyNamed('osVersion'),
+          appVersion: anyNamed('appVersion'),
+        ),
+      ).thenThrow(ApiException(statusCode: 500));
+
+      // * Act & Assert
+      await expectLater(
+        authService.updateUserConfig(),
+        throwsA(isA<ApiException>()),
+      );
+      verifyNever(
+        mockRegisterUserRepository.initUser(
+          name: anyNamed('name'),
+          osVersion: anyNamed('osVersion'),
+          appVersion: anyNamed('appVersion'),
+        ),
+      );
+    });
+
+    test('再登録（自己修復）自体が失敗した場合はそのエラーを rethrow する', () async {
+      // * Arrange
+      final authService = container.read(authServiceProvider);
+      setupMock('iOS 14.4');
+      updateContainersOverride(isSignedIn: true);
+      when(
+        mockRegisterUserRepository.updateVersionInfo(
+          osVersion: anyNamed('osVersion'),
+          appVersion: anyNamed('appVersion'),
+        ),
+      ).thenThrow(ApiException(statusCode: 404, code: 'user_not_found'));
+      when(
+        mockRegisterUserRepository.initUser(
+          name: anyNamed('name'),
+          osVersion: anyNamed('osVersion'),
+          appVersion: anyNamed('appVersion'),
+        ),
+      ).thenThrow(ApiException(statusCode: 409, code: 'user_already_exists'));
+
+      // * Act & Assert
+      await expectLater(
+        authService.updateUserConfig(),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+
   group('signIn() 失敗時のクリーンアップ', () {
     test(
       'initUser 失敗時: サーバーユーザー削除 → Firebase Auth 削除の順で呼ばれ rethrow する',


### PR DESCRIPTION
## 概要

起動時のバージョン情報更新（`PATCH /v1/users/me`）が 404 `user_not_found` の場合、`POST /v1/users`（既存の `_initUser()`）で再登録する自己修復を実装する。

Part of #186（plan「実行手順 > PR 1」。base は #215 のスタック PR）。

## 背景

移行スナップショット取得後に旧アプリで新規登録したユーザーは Firebase Auth には存在するが D1 には存在せず、新アプリで実質使用不能になる。メンテ overlay は UI 遮断のみで匿名登録を止められず、切替後もストア未更新の旧バイナリ初回起動で同状態が恒久的に発生し得るため、クライアント側の自己修復で恒久対処する（差分移行は不採用。判断根拠は plan の決定事項 1）。

## 実装

- `AuthService.updateUserConfig()` で `statusCode == 404 && code == 'user_not_found'` の場合のみ catch し、既存の `_initUser()` を再利用して再登録。他の 404・他のエラーコードは rethrow
- 再登録自体の失敗（例: アカウント削除フロー部分失敗による論理削除済みユーザーの `409 user_already_exists`）は握りつぶさず伝播させる
- テスト 4 件追加（再登録成功 / code 不一致 rethrow / 500 rethrow / 再登録失敗の伝播）

## 検証

- `flutter test test/feature/auth/application/auth_service_test.dart`: 13 件パス（既存 9 + 新規 4）
- `just analyze`: 変更による新規指摘なし（既存の 84 件の info/warning のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFuDvszWhagt98Jgakqhhy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic account recovery when startup version updates return a `user_not_found` error.
  * The app now re-registers user information to recover from account migration or switching issues.
  * Other server errors continue to be reported normally.
* **Documentation**
  * Updated migration guidance to reflect the client self-repair flow and corresponding error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->