### PR TITLE
chore: prod リリース準備設定を反映

### DIFF
--- a/dart_defines/prod.json
+++ b/dart_defines/prod.json
@@ -2,5 +2,5 @@
     "flavor": "prod",
     "appName": "Teigiii",
     "appIdSuffix": "",
-    "apiBaseUrl": "https://api.prod.invalid"
+    "apiBaseUrl": "https://teigiii-api-prod.tetsuo21ad.workers.dev"
 }

--- a/doc/plans/2026-07-20-data-migration-bigbang-switchover.md
+++ b/doc/plans/2026-07-20-data-migration-bigbang-switchover.md
@@ -110,7 +110,7 @@ Google Play は配信停止中のため、提出・リリース・強制アッ�
 **事前準備（切替日より前。順序厳守 — 審査員が prod API を実際に叩くため、インフラ整備が提出より先）**
 1. PR 1 / PR 2 マージ、リハーサル完了（一時 D1/R2 に対して export → import → verify、結果を issue #186 に記録、一時リソース削除）
 2. prod インフラ整備（この項内も順序厳守）
-   1. `server/wrangler.toml` の `env.prod.vars.AVATAR_BASE_URL` と `dart_defines/prod.json` の `apiBaseUrl` を実 URL（`https://teigiii-api-prod.tetsuo21ad.workers.dev`）に置換する。**必ずデプロイより前に行う**（デプロイ済み Worker の vars はローカル置換では更新されず、プレースホルダ URL のまま審査に進んでしまうため）。`dart_defines/prod.json` は TestFlight ビルドより前が必須条件だが、ここで同時に置換する
+   1. リリースバージョンを `1.1.0+8` に更新する。`server/wrangler.toml` の `env.prod.vars.AVATAR_BASE_URL`、`dart_defines/prod.json` の `apiBaseUrl`、`ios/Flutter/Prod.xcconfig` の `apiBaseUrl` を実 URL（`https://teigiii-api-prod.tetsuo21ad.workers.dev`）に置換する。**必ずデプロイより前に行う**（デプロイ済み Worker の vars はローカル置換では更新されず、プレースホルダ URL のまま審査に進んでしまうため）。Dart defines と Xcode build setting の双方が TestFlight ビルドより前の必須条件である
    2. prod Worker デプロイ
    3. prod D1 マイグレーション適用・R2 バケット作成
    4. `app_config` 行を冪等 upsert で投入する（D1 の列は snake_case、`updated_at` は NOT NULL の Unix ミリ秒。`CHECK(id = 1)` のため `id = 1` 固定）:
@@ -119,7 +119,7 @@ Google Play は配信停止中のため、提出・リリース・強制アッ�
       cd server
       bunx wrangler d1 execute teigiii-prod --remote --command \
         "insert into app_config (id, min_app_version_ios, min_app_version_android, in_maintenance, maintenance_scheduled_end_time, updated_at)
-         values (1, '<新バージョン>', '<新バージョン>', 0, null, unixepoch('now') * 1000)
+         values (1, '1.1.0', '1.1.0', 0, null, unixepoch('now') * 1000)
          on conflict(id) do update set
            min_app_version_ios = excluded.min_app_version_ios,
            min_app_version_android = excluded.min_app_version_android,
@@ -133,7 +133,7 @@ Google Play は配信停止中のため、提出・リリース・強制アッ�
       ```bash
       curl --fail-with-body -H "X-Firebase-AppCheck: <valid prod App Check token>" \
         https://teigiii-api-prod.tetsuo21ad.workers.dev/v1/app-config
-      # minAppVersionIos / minAppVersionAndroid = 新バージョン、inMaintenance = false を確認
+      # minAppVersionIos / minAppVersionAndroid = 1.1.0、inMaintenance = false を確認
       ```
 3. 本番と同一手順で prod D1/R2 へスナップショット投入（export → import → verify）
 4. TestFlight ビルドで prod バックエンド疎通を実機確認（App Check・匿名登録・既存データ表示まで）

--- a/ios/Flutter/Prod.xcconfig
+++ b/ios/Flutter/Prod.xcconfig
@@ -2,7 +2,7 @@
 flavor=prod
 appName=Teigiii
 appIdSuffix=
-apiBaseUrl=https:/$()/api.prod.invalid
+apiBaseUrl=https:/$()/teigiii-api-prod.tetsuo21ad.workers.dev
 
 CODE_SIGN_IDENTITY=Apple Development
 CODE_SIGN_IDENTITY[sdk=iphoneos*]=iPhone Distribution

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: teigi_app
 description: A new Flutter project.
 
-version: 1.0.0+7
+version: 1.1.0+8
 publish_to: none
 
 environment:

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -41,8 +41,7 @@ name = "teigiii-api-prod"
 [env.prod.vars]
 FIREBASE_PROJECT_ID = "everyone-teigi-prod"
 FIREBASE_PROJECT_NUMBER = "713374936833"
-# #186 で prod Worker の実 URL へ置換してから deploy する。
-AVATAR_BASE_URL = "https://api.prod.invalid/v1"
+AVATAR_BASE_URL = "https://teigiii-api-prod.tetsuo21ad.workers.dev/v1"
 
 [[env.prod.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## 概要

issue #186 の prod インフラ事前準備として、ストア提出・Worker デプロイより前に必要な設定を確定する。

- リリースバージョンを `1.1.0+8` に更新
- Flutter、Xcode、Worker の prod URL を `teigiii-api-prod.tetsuo21ad.workers.dev` に統一
- runbook に Xcode build setting の同期要件と `app_config` の `1.1.0` を反映

この PR は設定準備のみで、prod Worker デプロイ・D1 マイグレーション・データ投入は含まない。マージ後に runbook 順で実施する。

## 検証

- `nix develop --command just check-ios-flavors`
- `nix develop --command just server-validate-prod`
- `nix develop --command just analyze`
- `nix develop --command just test`（181 tests passed）
- `nix develop --command just docbridge-check`（0 errors, 0 warnings）

refs #186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the app to version **1.1.0+8**.
  * Connected production builds to the live production API.
  * Updated production avatar service routing.

* **Documentation**
  * Updated the deployment runbook with release-specific migration and verification values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->