### PR TITLE
ci: CD の手動実行をビルド検証専用にする

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      upload:
+        description: Upload the signed IPA to App Store Connect
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -58,6 +64,7 @@ jobs:
         run: echo "IPA_PATH=$(find build/ios/ipa -type f -name '*.ipa')" >> $GITHUB_ENV
 
       - name: Upload to App Store Connect
+        if: github.event_name != 'workflow_dispatch' || inputs.upload
         env:
           APPLE_APPLE_ID: ${{ secrets.APPLE_APPLE_ID }}
           APPLE_APP_PASS: ${{ secrets.APPLE_APP_PASS }}


### PR DESCRIPTION
## 概要

issue #186 の TestFlight 提出前に、更新した iOS 署名 Secrets を App Store Connect へアップロードせず検証できるようにする。

- `workflow_dispatch` に boolean 入力 `upload` を追加（デフォルト `false`）
- 手動実行のデフォルトは署名済み IPA のビルドまでとし、App Store Connect upload を skip
- tag push 時は従来どおり自動 upload
- 手動実行でも `upload: true` を明示した場合だけ upload

## 検証

- `nix run nixpkgs#actionlint -- -shellcheck= -pyflakes= .github/workflows/deliver.yml`
- `nix develop --command just docbridge-check`（0 errors, 0 warnings）
- staged diff が `deliver.yml` のみで、Secret 値を含まないことを確認

マージ後、`upload: false` で手動実行し、P12 / provisioning profile / 署名済み IPA build を実環境で検証する。

refs #186
