### PR TITLE
ci: Crashlytics scripts を lockfile から準備

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: nix develop --command just setup
 
+      - name: Resolve iOS Swift packages
+        run: xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme prod
+
       - name: Build ipa
         run: nix develop --command flutter build ipa --flavor prod --dart-define-from-file=dart_defines/prod.json --export-options-plist=./ios/ExportOptions.plist
 

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -58,7 +58,10 @@ jobs:
         run: nix develop --command just setup
 
       - name: Resolve iOS Swift packages
-        run: xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme prod
+        run: |
+          xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme prod \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+          echo "CRASHLYTICS_RUN_SCRIPT=$RUNNER_TEMP/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run" >> "$GITHUB_ENV"
 
       - name: Build ipa
         run: nix develop --command flutter build ipa --flavor prod --dart-define-from-file=dart_defines/prod.json --export-options-plist=./ios/ExportOptions.plist

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -57,11 +57,27 @@ jobs:
       - name: Install dependencies
         run: nix develop --command just setup
 
-      - name: Resolve iOS Swift packages
+      - name: Prepare Crashlytics scripts
         run: |
-          xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme prod \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
-          echo "CRASHLYTICS_RUN_SCRIPT=$RUNNER_TEMP/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run" >> "$GITHUB_ENV"
+          package_resolved=ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+          firebase_revision="$(
+            jq -r '.pins[] | select(.identity == "firebase-ios-sdk") | .state.revision' \
+              "$package_resolved"
+          )"
+          if [[ -z "$firebase_revision" || "$firebase_revision" == "null" ]]; then
+            echo "Firebase iOS SDK revision was not found in $package_resolved." >&2
+            exit 1
+          fi
+
+          crashlytics_dir="$RUNNER_TEMP/FirebaseCrashlytics"
+          mkdir -p "$crashlytics_dir"
+          for script in run upload-symbols; do
+            curl --fail --location --silent --show-error \
+              "https://raw.githubusercontent.com/firebase/firebase-ios-sdk/$firebase_revision/Crashlytics/$script" \
+              --output "$crashlytics_dir/$script"
+            chmod +x "$crashlytics_dir/$script"
+          done
+          echo "CRASHLYTICS_RUN_SCRIPT=$crashlytics_dir/run" >> "$GITHUB_ENV"
 
       - name: Build ipa
         run: nix develop --command flutter build ipa --flavor prod --dart-define-from-file=dart_defines/prod.json --export-options-plist=./ios/ExportOptions.plist

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n  exit 0\nfi\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"$PROJECT_DIR/$flavor/GoogleService-Info.plist\"\n";
+			shellScript = "if [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n  exit 0\nfi\ncrashlytics_run=\"${CRASHLYTICS_RUN_SCRIPT:-${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run}\"\n\"$crashlytics_run\" -gsp \"$PROJECT_DIR/$flavor/GoogleService-Info.plist\"\n";
 		};
 		FFAE953596CBE45DAD7DD1D8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/scripts/check_flavor_configuration.sh
+++ b/ios/scripts/check_flavor_configuration.sh
@@ -24,6 +24,11 @@ if ! grep -Fq 'SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run' "$xcod
   exit 1
 fi
 
+if ! grep -Fq 'CRASHLYTICS_RUN_SCRIPT' "$xcode_project"; then
+  echo "Crashlytics must accept an explicit run script path for clean CI builds." >&2
+  exit 1
+fi
+
 if grep -Fq 'PODS_ROOT/FirebaseCrashlytics' "$xcode_project"; then
   echo "Crashlytics must not use the CocoaPods upload-symbols path." >&2
   exit 1
@@ -46,6 +51,13 @@ build_ipa_line="$(
 if [[ -z "$resolve_packages_line" ]] || [[ -z "$build_ipa_line" ]] ||
   ((resolve_packages_line >= build_ipa_line)); then
   echo "The deliver workflow must resolve iOS Swift packages before building the IPA." >&2
+  exit 1
+fi
+
+if ! grep -Fq -- '-clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"' "$deliver_workflow" ||
+  ! grep -Fq 'CRASHLYTICS_RUN_SCRIPT=$RUNNER_TEMP/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run' \
+    "$deliver_workflow"; then
+  echo "The deliver workflow must pass its fixed Crashlytics run script path to Xcode." >&2
   exit 1
 fi
 

--- a/ios/scripts/check_flavor_configuration.sh
+++ b/ios/scripts/check_flavor_configuration.sh
@@ -7,6 +7,7 @@ workspace="$project_root/ios/Runner.xcworkspace"
 plugin_package="$project_root/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift"
 framework_package="$project_root/ios/Flutter/ephemeral/Packages/.packages/FlutterFramework/Package.swift"
 xcode_project="$project_root/ios/Runner.xcodeproj/project.pbxproj"
+deliver_workflow="$project_root/.github/workflows/deliver.yml"
 
 if [[ ! -f "$plugin_package" ]] || ! grep -Fq '.iOS("15.0")' "$plugin_package"; then
   echo "FlutterGeneratedPluginSwiftPackage is not configured for iOS 15.0. Run 'just setup'." >&2
@@ -30,6 +31,21 @@ fi
 
 if ! grep -Fq -- '-gsp \"$PROJECT_DIR/$flavor/GoogleService-Info.plist\"' "$xcode_project"; then
   echo "Crashlytics must receive the flavor-specific GoogleService-Info.plist." >&2
+  exit 1
+fi
+
+resolve_packages_line="$(
+  grep -nF 'xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme prod' \
+    "$deliver_workflow" | head -1 | cut -d: -f1 || true
+)"
+build_ipa_line="$(
+  grep -nF 'flutter build ipa --flavor prod' "$deliver_workflow" |
+    head -1 |
+    cut -d: -f1 || true
+)"
+if [[ -z "$resolve_packages_line" ]] || [[ -z "$build_ipa_line" ]] ||
+  ((resolve_packages_line >= build_ipa_line)); then
+  echo "The deliver workflow must resolve iOS Swift packages before building the IPA." >&2
   exit 1
 fi
 

--- a/ios/scripts/check_flavor_configuration.sh
+++ b/ios/scripts/check_flavor_configuration.sh
@@ -39,25 +39,27 @@ if ! grep -Fq -- '-gsp \"$PROJECT_DIR/$flavor/GoogleService-Info.plist\"' "$xcod
   exit 1
 fi
 
-resolve_packages_line="$(
-  grep -nF 'xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme prod' \
-    "$deliver_workflow" | head -1 | cut -d: -f1 || true
+prepare_crashlytics_line="$(
+  grep -nF 'name: Prepare Crashlytics scripts' "$deliver_workflow" |
+    head -1 |
+    cut -d: -f1 || true
 )"
 build_ipa_line="$(
   grep -nF 'flutter build ipa --flavor prod' "$deliver_workflow" |
     head -1 |
     cut -d: -f1 || true
 )"
-if [[ -z "$resolve_packages_line" ]] || [[ -z "$build_ipa_line" ]] ||
-  ((resolve_packages_line >= build_ipa_line)); then
-  echo "The deliver workflow must resolve iOS Swift packages before building the IPA." >&2
+if [[ -z "$prepare_crashlytics_line" ]] || [[ -z "$build_ipa_line" ]] ||
+  ((prepare_crashlytics_line >= build_ipa_line)); then
+  echo "The deliver workflow must prepare Crashlytics before building the IPA." >&2
   exit 1
 fi
 
-if ! grep -Fq -- '-clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"' "$deliver_workflow" ||
-  ! grep -Fq 'CRASHLYTICS_RUN_SCRIPT=$RUNNER_TEMP/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run' \
-    "$deliver_workflow"; then
-  echo "The deliver workflow must pass its fixed Crashlytics run script path to Xcode." >&2
+if ! grep -Fq 'select(.identity == "firebase-ios-sdk")' "$deliver_workflow" ||
+  ! grep -Fq 'raw.githubusercontent.com/firebase/firebase-ios-sdk/$firebase_revision/Crashlytics/$script' \
+    "$deliver_workflow" ||
+  ! grep -Fq 'CRASHLYTICS_RUN_SCRIPT=$crashlytics_dir/run' "$deliver_workflow"; then
+  echo "The deliver workflow must download locked Crashlytics scripts and pass their path to Xcode." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## 概要

Issue #186 の手動 CD 検証で判明した iOS archive 失敗を修正します。

クリーンな GitHub Actions runner では、Crashlytics の build phase 実行時点で `DerivedData/.../SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run` が存在せず、archive が失敗していました。Xcode の Swift Package 解決先は runner 上で安定しないため、その内部配置には依存しません。

## 変更内容

- `Package.resolved` に固定された Firebase iOS SDK の commit revision を取得
- 同 revision の公式リポジトリから `Crashlytics/run` と `upload-symbols` を一時ディレクトリへ準備
- Xcode build phase に `CRASHLYTICS_RUN_SCRIPT` を渡し、ローカルビルドでは従来の DerivedData path を fallback として維持
- Crashlytics 準備が IPA build より前にあり、lockfile revision を使うことを `check-ios-flavors` で回帰検査

## 検証

- `nix develop --command just check-ios-flavors`
- `nix run nixpkgs#actionlint -- -shellcheck= -pyflakes= .github/workflows/deliver.yml`
- `nix run nixpkgs#shellcheck -- -e SC2016 ios/scripts/check_flavor_configuration.sh`
- `nix develop --command just docbridge-check`
- GitHub Actions `deliver` run 29718813245（`upload=false`）
  - `Prepare Crashlytics scripts`: success
  - `Build ipa`: success
  - `Detect path for ipa file`: success
  - `Upload to App Store Connect`: skipped

Refs #186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS release builds by ensuring Firebase Crashlytics scripts are prepared from the locked SDK version.
  * Added validation to detect incomplete Crashlytics configuration before delivery builds begin.
  * Maintained flavor-specific Crashlytics symbol uploads while supporting simulator builds without unnecessary uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->