### PR TITLE
fix: exportArchive の Copy failed を解消（rsync PATH 汚染）

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -82,8 +82,16 @@ jobs:
       - name: Build ipa
         run: nix develop --command flutter build ipa --flavor prod --dart-define-from-file=dart_defines/prod.json --export-options-plist=./ios/ExportOptions.plist
 
+      # flutter build ipa は exportArchive 失敗でも exit 0 を返すため、
+      # IPA 不在をここで検出してビルド検証を fail させる
       - name: Detect path for ipa file
-        run: echo "IPA_PATH=$(find build/ios/ipa -type f -name '*.ipa')" >> $GITHUB_ENV
+        run: |
+          ipa_path="$(find build/ios/ipa -type f -name '*.ipa' | head -n 1)"
+          if [[ -z "$ipa_path" ]]; then
+            echo "No .ipa found under build/ios/ipa" >&2
+            exit 1
+          fi
+          echo "IPA_PATH=$ipa_path" >> "$GITHUB_ENV"
 
       - name: Upload to App Store Connect
         if: github.event_name != 'workflow_dispatch' || inputs.upload

--- a/flake.nix
+++ b/flake.nix
@@ -39,11 +39,14 @@
           flutterSrc = pkgs.fetchzip release;
           mkFlutterWrapper = name: executable: pkgs.writeShellApplication {
             inherit name;
+            # rsync を runtimeInputs に入れると exec 先の flutter → xcodebuild にも
+            # PATH が継承され、exportArchive が起動する rsync server が GNU 版に
+            # 化けて `--extended-attributes` 非対応で "Copy failed" になる。
+            # rsync は PATH 注入せず絶対パスで呼ぶ。
             runtimeInputs = [
               pkgs.coreutils
               pkgs.git
               pkgs.patch
-              pkgs.rsync
             ];
             text = ''
               repo_root="$PWD"
@@ -58,7 +61,7 @@
                 tmp="$flutter_root.tmp"
                 rm -rf "$tmp"
                 mkdir -p "$(dirname "$tmp")"
-                rsync -a --delete "${flutterSrc}/" "$tmp/"
+                ${pkgs.rsync}/bin/rsync -a --delete "${flutterSrc}/" "$tmp/"
                 chmod -R u+w "$tmp"
                 patch -d "$tmp" -p1 < ${./nix/patches/flutter-ios-15.patch}
                 patch -d "$tmp" -p1 < ${./nix/patches/flutter-ios-native-assets.patch}


### PR DESCRIPTION
## 概要

deliver の TestFlight アップロードが `error: exportArchive Copy failed` で失敗する問題を修正する（issue #186 の事前準備 4 のブロッカー）。

## 根本原因

flake.nix の flutter ラッパー（writeShellApplication）が `runtimeInputs` 経由で GNU rsync 3.4.4 を PATH 先頭に注入しており、exec 先の flutter → xcodebuild まで継承される。Xcode の IPA 作成ステップは `/usr/bin/rsync`（Apple 版）を `-E`（extended-attributes）付きで起動するが、rsync の server 側プロセスは PATH 解決で GNU 版が起動されるため `--extended-attributes: unknown option` で失敗する。

IDEDistributionPipeline.log（ローカル再現）:
```
Running /usr/bin/rsync '-8aPhhE' ...
rsync: on remote machine: --extended-attributes: unknown option
rsync error: syntax or usage error (code 1) at main.c(1806) [server=3.4.4]
Step "<IDEDistributionCreateIPAStep>" failed with error ... "Copy failed"
```

同型の既知事例: fastlane/fastlane#29528

## 変更内容

1. **flake.nix**: `pkgs.rsync` を runtimeInputs から除去し、toolchain 同期は絶対パス（`${pkgs.rsync}/bin/rsync`）で呼ぶ
2. **deliver.yml**: `flutter build ipa` は exportArchive 失敗でも exit 0 を返すため、Detect ステップで IPA 不在なら fail させる（本日 05:17 のビルド検証が IPA 未生成のまま green になっていた偽陽性の再発防止）

## 検証

- 修正前: ローカルで CI と同一の `Copy failed` を再現（IPA 未生成・flutter は exit 0）
- 修正後: 同一コマンドで `build/ios/ipa/Teigiii.ipa`（38.3MB）の生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFuDvszWhagt98Jgakqhhy