### PR TITLE
fix: prod の Firebase iOS アプリ登録を既存ユーザーが引き継げるものへ戻す

### DIFF
--- a/ios/prod/GoogleService-Info.plist
+++ b/ios/prod/GoogleService-Info.plist
@@ -25,7 +25,7 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:713374936833:ios:245c65657f69da4a927500</string>
+	<string>1:713374936833:ios:662108d31ce8b881927500</string>
 	<key>ADMOB_APP_ID</key>
 	<string>ca-app-pub-8953668343211620~8262506548</string>
 </dict>

--- a/ios/scripts/check_flavor_configuration.sh
+++ b/ios/scripts/check_flavor_configuration.sh
@@ -174,6 +174,6 @@ check_flavor \
   "Teigiii prod" \
   everyone-teigi-prod \
   713374936833 \
-  1:713374936833:ios:245c65657f69da4a927500
+  1:713374936833:ios:662108d31ce8b881927500
 
 echo "iOS flavor configurations are valid."

--- a/lib/util/firebase_options/firebase_options_prod.dart
+++ b/lib/util/firebase_options/firebase_options_prod.dart
@@ -59,7 +59,7 @@ class DefaultFirebaseOptions {
 
   static const FirebaseOptions ios = FirebaseOptions(
     apiKey: 'AIzaSyBNT2hZYfxyV-K7lOd-Z-Uk9qMu1tEOZiI',
-    appId: '1:713374936833:ios:245c65657f69da4a927500',
+    appId: '1:713374936833:ios:662108d31ce8b881927500',
     messagingSenderId: '713374936833',
     projectId: 'everyone-teigi-prod',
     storageBucket: 'everyone-teigi-prod.appspot.com',


### PR DESCRIPTION
## 背景

TestFlight (1.1.0+8) の実機検証で、ストア版（Firestore 時代）から引き続き使っていたアカウントではなく新規アカウントが作成される問題を発見した。

## 根本原因

commit 11043e82（昨日）で `GoogleService-Info.plist` の `BUNDLE_ID` 不一致（`com.toda.teigiApp` vs 実際の `com.toda.teigiii`）を修正する際、**既存の Firebase iOS アプリ登録の Bundle ID を直すのではなく、新規の iOS アプリを Firebase コンソールに登録して差し替えてしまっていた**（PR #213）。

Firebase Auth の匿名セッションは端末の Keychain 上で `GOOGLE_APP_ID`（Firebase アプリ登録の識別子）単位に保存されるため、新規登録への切り替えは実質的に**既存ユーザー全員のログインセッションを失効**させる。初回起動時に匿名ログインからやり直しになり、空の新規アカウントが作られる。

実機検証で確認: prod D1 の `users` テーブルが 192 → 193 件に増加し、新規行の `created_at` が TestFlight 起動直後の時刻と一致していた。

## 影響調査（要約。詳細はコミットメッセージ）

- API_KEY / GCM_SENDER_ID / PROJECT_ID は新旧登録で同一
- Google Sign-In（OAuth client）は未使用、影響なし
- サーバー側の App Check 検証（`server/src/auth/app-check.ts`）は `projectNumber` のみを検証し特定の Firebase アプリ登録に依存しないため、この変更によるサーバー側の影響なし
- Crashlytics はビルド時に flavor 別 plist から動的に `GOOGLE_APP_ID` を読むため追従
- AdMob の `ADMOB_APP_ID` は独立 ID のため保持して問題なし
- CD（deliver.yml）に `GOOGLE_APP_ID` のハードコードなし、影響なし
- Android は今回のコミットの対象外（ストア配信停止中でスコープ外）

## 変更内容

`GOOGLE_APP_ID` を旧登録（`1:713374936833:ios:662108d31ce8b881927500`）へ戻す。`BUNDLE_ID` は正しい値（`com.toda.teigiii`）のまま維持。

- `ios/prod/GoogleService-Info.plist`
- `lib/util/firebase_options/firebase_options_prod.dart`
- `ios/scripts/check_flavor_configuration.sh`

## 検証

- `just check-ios-flavors` パス（"iOS flavor configurations are valid."）

## 残タスク（コード外・手動）

- **Firebase コンソールで旧アプリ登録（`...881927500`）の Bundle ID を `com.toda.teigiii` に修正する**
- 念のため旧登録の App Check 設定が有効なままか確認する
- 新規登録（`...245c65657f69da4a927500`）は当面未使用のまま残し、後日整理する
- マージ後に再ビルド・再 TestFlight 配布し、既存アカウントが引き継がれることを実機で再確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFuDvszWhagt98Jgakqhhy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the production iOS Firebase configuration to use the correct app identifier.
  * Improved consistency between production app settings and configuration validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->