### PR TITLE
fix: nix devshell バナーが bump-pull-request の GITHUB_ENV 書き込みを壊す問題を修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,8 +130,10 @@
                   export CXX="$(xcrun --find clang++)"
                 fi
               ''}
-              echo "[nix] teigi_app dev shell ready (Flutter ${flutterVersion}, just, lcov${lib.optionalString pkgs.stdenv.isDarwin ", CocoaPods"})"
-              echo "[nix] Run tasks with: just <task>"
+              # stdout は `$(nix develop --command ...)` で捕捉されるコマンド出力用に空けておく。
+              # バナーは informational なので stderr へ出す。
+              echo "[nix] teigi_app dev shell ready (Flutter ${flutterVersion}, just, lcov${lib.optionalString pkgs.stdenv.isDarwin ", CocoaPods"})" >&2
+              echo "[nix] Run tasks with: just <task>" >&2
             '';
           };
         }


### PR DESCRIPTION
## 背景

issue #186 の再ビルドのため `bump-pull-request.yml`（`bump: build`）を初めて実行したところ、`Bump version` ステップが `Unable to process file command 'env' successfully` で失敗した（run 29724688710）。

## 根本原因

`echo "BUMP_VERSION=$(nix develop --command dart run cider version)" >> "$GITHUB_ENV"` が、Nix devshell の shellHook が出す起動バナー（`[nix] teigi_app dev shell ready...` / `[nix] Run tasks with: just <task>`）まで一緒に stdout として捕捉してしまい、$GITHUB_ENV への書き込みが複数行の不正フォーマットになっていた。

バナーは Nix flake 移行時（bed9658）に導入されて以来ずっとこの状態だったが、`bump-pull-request.yml` が今回まで一度も実行されたことがなく（実行履歴 1 件のみ）発覚していなかった。

## 変更内容

`flake.nix` の shellHook 内の 2 つの `echo` を stderr へリダイレクト（`>&2`）。informational なバナーは stdout（コマンド置換で捕捉される値）を汚さないのが適切。

## 検証

```
$ VER=$(nix develop --command dart run cider version 2>/dev/null); echo "captured=[$VER]"
captured=[1.1.0+8]
```

単一行の値のみが捕捉されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFuDvszWhagt98Jgakqhhy