### PR TITLE
fix: bump-pull-request の bump 入力に default を設定

### DIFF
--- a/.github/workflows/bump-pull-request.yml
+++ b/.github/workflows/bump-pull-request.yml
@@ -6,6 +6,7 @@ on:
       bump:
         type: choice
         description: Please Choice Bump Target
+        default: build
         options:
           - build
           - patch


### PR DESCRIPTION
## 背景

PR #226 のマージ後に `bump-pull-request.yml` を再実行したところ、別のエラーで再度失敗した（run 29725397291）。

## 根本原因

`Bump version` ステップの `nix develop --command dart run cider bump "" --bump-build` — `github.event.inputs.bump` が空文字列だった。`bump` 入力は `type: choice` だが `default` が未設定のため、workflow_dispatch を明示選択なしで実行すると空文字列になり、`cider bump ""` が使用法エラー（exit 64）で失敗する。

PR #226（GITHUB_ENV 破損の修正）で初めてこのステップの手前まで進めるようになったため、今回発覚した。

## 変更内容

`bump` 入力に `default: build` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFuDvszWhagt98Jgakqhhy