### PR TITLE
docs: collaborating-on-github にレビュー投稿手順を追加

### DIFF
--- a/.agents/skills/collaborating-on-github/SKILL.md
+++ b/.agents/skills/collaborating-on-github/SKILL.md
@@ -33,6 +33,10 @@ description: GitHub CLI を使った Issue、PR、進捗共有の操作 — コ�
 2. Draft 状態でセルフレビューと検証を完了する。
 3. レビュー準備ができたら: `gh pr ready <number>`
 
+### レビューの投稿
+
+指摘は本文にまとめず、該当行にインラインコメントとして付ける。レビュー本文とインラインを 1 リクエストで投稿する手順、行指定（`line` / `start_line` / `side`）、インラインを付けられないケースの扱いは [references/gh-commands.md](references/gh-commands.md) を参照。
+
 ### 作業前の同期
 
 PR 関連の作業を始める前に、ベースブランチを同期する:

--- a/.agents/skills/collaborating-on-github/references/gh-commands.md
+++ b/.agents/skills/collaborating-on-github/references/gh-commands.md
@@ -97,6 +97,37 @@ git pull --ff-only origin "$base_branch"
 git switch "$head_branch"
 ```
 
+## インラインコメント付きレビューの投稿
+
+レビュー本文とインラインコメントは 1 リクエストでまとめて投稿する。本文に改行やバッククォートが入るため、JSON をファイルに書いて `--input` で渡す。
+
+```bash
+# 1. インラインを付けられる行か事前確認する（patch が空のファイルには付けられない）
+gh api "repos/<owner>/<repo>/pulls/<number>/files?per_page=100" --paginate \
+  --jq '.[] | "\(.filename) status=\(.status) patch_len=\(.patch|length? // 0)"'
+
+# 2. レビューを投稿する
+cat > review.json <<'JSON'
+{
+  "event": "COMMENT",
+  "body": "<レビュー本文>",
+  "comments": [
+    {"path": "<file>", "line": 58, "side": "RIGHT", "body": "<指摘>"},
+    {"path": "<file>", "line": 51, "start_line": 49, "side": "RIGHT", "body": "<複数行への指摘>"}
+  ]
+}
+JSON
+gh api -X POST "repos/<owner>/<repo>/pulls/<number>/reviews" --input review.json --jq '.html_url'
+
+# 3. 着弾を確認する
+gh api "repos/<owner>/<repo>/pulls/<number>/comments" --jq '.[] | "\(.path):\(.line)"'
+```
+
+- `event`: `COMMENT` / `APPROVE` / `REQUEST_CHANGES`
+- `line` は変更後ファイルの行番号（`side: "RIGHT"`）。範囲で指すときは `start_line` を併用する
+- 修正案は body 内に ` ```suggestion ` ブロックで書く。レビュイーが GitHub 上でそのまま commit できる
+- **制約**: diff の hunk 内の行にしか付けられない。rename のみで patch が空のファイル（手順 1 で `patch_len=0`）は 422 になるため、その指摘はレビュー本文に回す
+
 ## レビューコメント / スレッド
 
 ```bash

--- a/.claude/skills/collaborating-on-github/SKILL.md
+++ b/.claude/skills/collaborating-on-github/SKILL.md
@@ -33,6 +33,10 @@ description: GitHub CLI を使った Issue、PR、進捗共有の操作 — コ�
 2. Draft 状態でセルフレビューと検証を完了する。
 3. レビュー準備ができたら: `gh pr ready <number>`
 
+### レビューの投稿
+
+指摘は本文にまとめず、該当行にインラインコメントとして付ける。レビュー本文とインラインを 1 リクエストで投稿する手順、行指定（`line` / `start_line` / `side`）、インラインを付けられないケースの扱いは [references/gh-commands.md](references/gh-commands.md) を参照。
+
 ### 作業前の同期
 
 PR 関連の作業を始める前に、ベースブランチを同期する:

--- a/.claude/skills/collaborating-on-github/references/gh-commands.md
+++ b/.claude/skills/collaborating-on-github/references/gh-commands.md
@@ -97,6 +97,37 @@ git pull --ff-only origin "$base_branch"
 git switch "$head_branch"
 ```
 
+## インラインコメント付きレビューの投稿
+
+レビュー本文とインラインコメントは 1 リクエストでまとめて投稿する。本文に改行やバッククォートが入るため、JSON をファイルに書いて `--input` で渡す。
+
+```bash
+# 1. インラインを付けられる行か事前確認する（patch が空のファイルには付けられない）
+gh api "repos/<owner>/<repo>/pulls/<number>/files?per_page=100" --paginate \
+  --jq '.[] | "\(.filename) status=\(.status) patch_len=\(.patch|length? // 0)"'
+
+# 2. レビューを投稿する
+cat > review.json <<'JSON'
+{
+  "event": "COMMENT",
+  "body": "<レビュー本文>",
+  "comments": [
+    {"path": "<file>", "line": 58, "side": "RIGHT", "body": "<指摘>"},
+    {"path": "<file>", "line": 51, "start_line": 49, "side": "RIGHT", "body": "<複数行への指摘>"}
+  ]
+}
+JSON
+gh api -X POST "repos/<owner>/<repo>/pulls/<number>/reviews" --input review.json --jq '.html_url'
+
+# 3. 着弾を確認する
+gh api "repos/<owner>/<repo>/pulls/<number>/comments" --jq '.[] | "\(.path):\(.line)"'
+```
+
+- `event`: `COMMENT` / `APPROVE` / `REQUEST_CHANGES`
+- `line` は変更後ファイルの行番号（`side: "RIGHT"`）。範囲で指すときは `start_line` を併用する
+- 修正案は body 内に ` ```suggestion ` ブロックで書く。レビュイーが GitHub 上でそのまま commit できる
+- **制約**: diff の hunk 内の行にしか付けられない。rename のみで patch が空のファイル（手順 1 で `patch_len=0`）は 422 になるため、その指摘はレビュー本文に回す
+
 ## レビューコメント / スレッド
 
 ```bash


### PR DESCRIPTION
## 概要

`collaborating-on-github` スキルに「レビューする側が GitHub PR にインラインコメントを投稿する手順」を追記した。コード変更はなし（純追加のみ）。

## 背景

PR #231 のレビューでインラインコメントを付けようとしたところ、既存スキルには「インラインコメントの取得」（`gh-commands.md`）と「インラインコメントへの返信」（`receiving-code-review` スキル）しかなく、レビューする側が投稿する手順が欠落していた。そのため初回はテキスト出力に留まり、指摘を受けて投稿し直す手戻りが発生した。

## 変更内容

- `SKILL.md`: 「### レビューの投稿」セクションを新設（方針のみ、手順は reference へ委譲）
- `references/gh-commands.md`: 「## インラインコメント付きレビューの投稿」セクションを新設
  - `patch_len` 事前確認 → `review.json` を `gh api -X POST .../reviews --input` で投稿 → 着弾確認、の 3 手順
  - `event` の 3 値、`line`/`start_line`/`side` の指定方法、` ```suggestion ` ブロック
  - rename のみで patch が空のファイルは 422 になるため、レビュー本文に回すという制約

`.claude/` が正本、`.agents/` はその複製同期。

closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for submitting inline pull request review comments on specific changed lines.
  * Documented how to include review summaries and inline comments in a single submission.
  * Clarified line selection, suggestion formatting, post-submission verification, and handling files without applicable diffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->