### PR TITLE
docs(agents): Cursor Cloud 開発環境セットアップ手順を追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,23 @@ just test
 ```
 
 **MCP サーバー例**: github, mobile-mcp
+
+## Cursor Cloud specific instructions
+
+Cursor Cloud の VM 向けの非自明な注意点のみを記載する。標準コマンドは `justfile` を参照。
+
+### ツールチェーン
+- Cloud VM では Nix を使わない（`flake.nix` はローカル / CI 用）。`bun` / `flutter` 3.41.8 / `dart` / `just` は snapshot に導入済みで `/usr/local/bin` から解決できる。
+- 依存の更新は起動時の update script（`bun install --frozen-lockfile` + `flutter pub get`）で自動実行される。`just setup` を再実行する必要は通常ない。
+
+### mobile_app/.env（重要）
+- `mobile_app/.env` は `*.env` として git-ignore されるが、`pubspec.yaml` の必須アセットであり、無いと `flutter test` / `flutter build` が "No file or variants found for asset: .env" で失敗する。
+- update script が未存在時に AdMob テスト広告 ID 入りで自動生成する。CI は空ファイル（`touch mobile_app/.env`）で十分。
+
+### backend（Cloudflare Workers API）
+- `just backend-dev`（= `wrangler dev`）は :8787 で起動し、D1 / R2 は Miniflare のローカルエミュレーションで自動供給される。外部 DB は不要。
+- 全エンドポイントが Firebase App Check トークン必須の設計のため、有効な Firebase トークンなしの生 curl は `GET /v1/app-config` を含め 401 (`app_check_invalid`) になる。API のコア機能検証は `just backend-test`（unit + `@cloudflare/vitest-pool-workers` の統合テスト、mock verifier を注入）で行う。
+
+### mobile_app（Flutter）
+- Android SDK / エミュレータ / iOS シミュレータ / 実機がなく、実 Firebase も必要なため、Cloud VM では `flutter run` による対話起動は不可。headless では lint / test / codegen のみ実施できる。
+- 生成コード（`*.g.dart` / `*.freezed.dart` / `*.gr.dart`）はコミット済み。CI は build_runner を実行しないため、`just analyze` / `just test` 前に `just mobile-generate` は必須ではない（`.dart` を変更・追加した場合のみ再生成する）。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Cursor Cloud VM 上で teigiii モノレポ（`backend` / `mobile_app`）の開発環境をセットアップし、lint / test / build / run を検証した。コード変更はなく、`AGENTS.md` に将来の Cloud エージェント向けの非自明な注意点を追記したのみ。

## 実施内容

- ツールチェーン導入（snapshot に永続化、`/usr/local/bin` から解決）: `bun` 1.3.14 / Flutter 3.41.8（Dart 3.11.5）/ `just` 1.57.0
- update script 設定: `bun install --frozen-lockfile` + `flutter pub get`（+ 未存在時に git-ignore の `mobile_app/.env` を AdMob テスト ID で自動生成）
- `AGENTS.md` に `## Cursor Cloud specific instructions` を追記

## 検証結果

### backend（Cloudflare Workers API）
- `just backend-lint`（oxlint + `tsc --noEmit`）→ PASS（0 エラー）
- `just backend-test` → unit 143 pass / workers 統合 93 pass（言葉・定義・タイムライン・検索などを実ルート + ローカル D1 で検証）
- `just backend-dev`（`wrangler dev`）→ `http://localhost:8787` で起動、ローカル D1 / R2 バインディング確認、ライブ HTTP 応答確認

### mobile_app（Flutter）
- `flutter pub get` / build_runner / `just mobile-analyze`（0 エラー）/ `just mobile-test`（181 pass）
- headless のため `flutter run` の対話起動は不可（端末/エミュレータ・実 Firebase 必須）

## 補足

- `.env` は `*.env` として git-ignore される必須アセットのため、update script が未存在時に自動生成する（CI は空ファイルで代替）。
- 全 API が Firebase App Check 必須の設計のため、生 curl は 401 になる。コア機能検証は mock verifier を注入する workers 統合テストで実施。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dad2f57f-0449-4225-90a6-d048025b5fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dad2f57f-0449-4225-90a6-d048025b5fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

