### PR TITLE
chore: just setup から flutter clean を分離する (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ just setup
 
 direnv を使わない場合は、先に `nix develop` で開発シェルへ入ってください。
 
-`just setup` は `mobile_app/` と `backend/` の両方の依存関係を入れます。
+`just setup`（および `just mobile-setup`）は依存関係の導入のみで、`flutter clean` は実行しません。ビルドキャッシュを消すときは `just mobile-clean` を使ってください。
 
 # アプリ起動（run）
 

--- a/doc/plans/done/2026-07-20-just-setup-without-flutter-clean.md
+++ b/doc/plans/done/2026-07-20-just-setup-without-flutter-clean.md
@@ -1,0 +1,20 @@
+# just setup の clean 分離と justfile 整理 (#234)
+
+## 目的
+
+`just setup` / `mobile-setup` が毎回 `flutter clean` しないようにし、明示クリーン用レシピを分離する。あわせて justfile の命名非対称を解消する。
+
+## 実行手順
+
+1. `mobile-setup` から `flutter clean` を外し、`mobile-clean`（`flutter clean` のみ）を追加する
+2. `backend-lint` を `backend-analyze` にハードリネームする（中身は lint + typecheck のまま）
+3. justfile コメントと README を追従する
+4. `just --list` と参照 grep で完了条件を確認する
+
+## 完了条件
+
+- [x] `just setup` / `just mobile-setup` が `flutter clean` を実行しない
+- [x] `just mobile-clean` が存在する
+- [x] `just backend-analyze` が旧 `backend-lint` 相当、`backend-lint` は存在しない
+- [x] README に clean 分離が書かれている
+- [x] Issue #234 の完了条件を満たす

--- a/justfile
+++ b/justfile
@@ -5,9 +5,10 @@ default:
 
 # --- 横断（モバイル + バックエンド）---
 
+# mobile / backend の依存を入れる（flutter clean はしない）
 setup: mobile-setup backend-setup
 
-analyze: mobile-analyze backend-lint
+analyze: mobile-analyze backend-analyze
 
 format: mobile-format backend-format
 
@@ -24,8 +25,13 @@ docbridge-check:
 
 # --- mobile（Flutter アプリ）---
 
+# 依存導入のみ（ビルドキャッシュは消さない）
 mobile-setup:
-    cd mobile_app && flutter clean && flutter pub get
+    cd mobile_app && flutter pub get
+
+# ビルドキャッシュを明示的に消すとき用
+mobile-clean:
+    cd mobile_app && flutter clean
 
 mobile-generate:
     cd mobile_app && dart run build_runner build --delete-conflicting-outputs
@@ -68,7 +74,8 @@ mobile-check-ios-native-asset binary sdk:
 backend-setup:
     cd backend && bun install
 
-backend-lint:
+# lint + typecheck（横断の `analyze` から呼ばれる）
+backend-analyze:
     cd backend && bun run lint && bun run typecheck
 
 backend-format:


### PR DESCRIPTION
## Summary
closes #234

- `mobile-setup` から `flutter clean` を外し、明示用の `mobile-clean` を追加
- `backend-lint` を `backend-analyze` にハードリネーム（`just analyze` の集約を追従）
- README に setup / clean の分離を追記

## Test plan
- [x] `just --list` で `mobile-clean` / `backend-analyze` が表示され、`backend-lint` が無い
- [x] `just --show mobile-setup` が `flutter pub get` のみ
- [ ] CI（check / deliver）が通ることを確認


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Dependency setup now installs packages without automatically running a Flutter clean, making setup faster and preserving local build artifacts.
  * Added a separate mobile cleanup command for cases where a full Flutter reset is needed.
  * Renamed the backend linting task to a broader analysis task, while retaining lint and type-check validation.

* **Documentation**
  * Updated development setup instructions to reflect the revised command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->