### PR TITLE
fix: 投稿日時表示をローカルタイムゾーンに変換する (#249)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -91,6 +91,9 @@ jobs:
     if: needs.changes.outputs.mobile == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # toDisplayFormat の UTC→ローカル変換漏れを検出するため非 UTC に固定
+      TZ: Asia/Tokyo
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/doc/plans/done/2026-07-22-fix-display-format-local.md
+++ b/doc/plans/done/2026-07-22-fix-display-format-local.md
@@ -1,0 +1,19 @@
+# 投稿日時 UTC 表示の修正 (#249)
+
+## 目的
+
+定義詳細画面の投稿日時が UTC のまま表示されるバグを修正する。絶対時刻の壁時計整形を `toDisplayFormat()` にチョークポイント化し、内部で `toLocal()` する。
+
+## 実行手順
+
+1. `toDisplayFormat` の回帰テストに「UTC 入力 → ローカル表示」ケースを追加し、失敗を確認する（RED）
+2. `toDisplayFormat()` 内で `toLocal()` を呼ぶよう修正する（GREEN）
+3. `overlay_in_maintenance_dialog.dart` の冗長な `.toLocal()` を整理する
+4. 該当テストを通し、PR を作成する（`closes #249`）
+
+## 完了条件
+
+- [x] `toDisplayFormat()` が内部で `toLocal()` を行う
+- [x] UTC DateTime を渡すとローカル変換される回帰テストがある
+- [x] 定義詳細の投稿日時がローカルタイムゾーンで表示される（上記修正で担保）
+- [x] PR が `closes #249` を含む

--- a/justfile
+++ b/justfile
@@ -42,8 +42,9 @@ mobile-analyze:
 mobile-format:
     cd mobile_app && dart format .
 
+# 日時表示の回帰テストが UTC では検出漏れになるため Asia/Tokyo に固定する
 mobile-test:
-    cd mobile_app && flutter test
+    cd mobile_app && TZ=Asia/Tokyo flutter test
 
 mobile-coverage:
     cd mobile_app && flutter test --coverage

--- a/mobile_app/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
+++ b/mobile_app/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
@@ -19,7 +19,7 @@ class OverlayInMaintenanceDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final scheduledEndTime =
-        appMaintenance.scheduledEndTime?.toLocal().toDisplayFormat() ?? '未定';
+        appMaintenance.scheduledEndTime?.toDisplayFormat() ?? '未定';
 
     return WillPopScope(
       onWillPop: () async => false,

--- a/mobile_app/lib/util/extension/date_time_extension.dart
+++ b/mobile_app/lib/util/extension/date_time_extension.dart
@@ -29,8 +29,10 @@ extension DateTimeExtension on DateTime {
   }
 
   /// UIで表示する形式に変換する
+  ///
+  /// 絶対時刻の壁時計表示のチョークポイント。UTC の DateTime もローカルに変換してから整形する。
   String toDisplayFormat() {
-    return DateFormat('yyyy/MM/dd HH:mm').format(this);
+    return DateFormat('yyyy/MM/dd HH:mm').format(toLocal());
   }
 
   /// 呼び出したインスタンスの時刻から1時間以上が経過しているかを返す

--- a/mobile_app/test/util/extension/date_time_extension_test.dart
+++ b/mobile_app/test/util/extension/date_time_extension_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:teigi_app/util/extension/date_time_extension.dart';
 
 void main() {
@@ -137,6 +138,22 @@ void main() {
 
       // * Assert
       expect(expected, '2023/10/22 14:30');
+    });
+
+    test('UTC DateTime はローカルタイムゾーンの壁時計で表示される', () {
+      // * Arrange
+      // API が返す ISO 8601（末尾 Z）相当の UTC DateTime
+      final utcDate = DateTime.parse('2023-10-22T05:30:00.000Z');
+
+      // * Act
+      final actual = utcDate.toDisplayFormat();
+
+      // * Assert
+      expect(utcDate.isUtc, isTrue);
+      expect(
+        actual,
+        DateFormat('yyyy/MM/dd HH:mm').format(utcDate.toLocal()),
+      );
     });
   });
 

--- a/mobile_app/test/util/extension/date_time_extension_test.dart
+++ b/mobile_app/test/util/extension/date_time_extension_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart';
 import 'package:teigi_app/util/extension/date_time_extension.dart';
 
 void main() {
@@ -142,7 +141,8 @@ void main() {
 
     test('UTC DateTime はローカルタイムゾーンの壁時計で表示される', () {
       // * Arrange
-      // API が返す ISO 8601（末尾 Z）相当の UTC DateTime
+      // API が返す ISO 8601（末尾 Z）相当の UTC DateTime。
+      // 期待値は Asia/Tokyo（UTC+9）固定。CI / just mobile-test も同 TZ で実行する。
       final utcDate = DateTime.parse('2023-10-22T05:30:00.000Z');
 
       // * Act
@@ -150,10 +150,7 @@ void main() {
 
       // * Assert
       expect(utcDate.isUtc, isTrue);
-      expect(
-        actual,
-        DateFormat('yyyy/MM/dd HH:mm').format(utcDate.toLocal()),
-      );
+      expect(actual, '2023/10/22 14:30');
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 対象Issue

- #249

# やった事

- `toDisplayFormat()` 内で `toLocal()` を呼び、絶対時刻の壁時計整形をチョークポイント化
- UTC 入力 → ローカル表示の回帰テストを追加（期待値は `2023/10/22 14:30` 固定）
- `just mobile-test` と CI `mobile-test` job を `TZ=Asia/Tokyo` に固定し、`toLocal()` 欠落を CI で検出可能にした
- メンテナンスダイアログの冗長な `.toLocal()` を整理
- 実施 plan を `doc/plans/done/` へ移動

closes #249

# やらなかった事

- `custom_lint` による `DateFormat` 直接使用の禁止（Issue 対象外）
- Instant / Timestamp 値オブジェクトの導入（Issue 対象外）
- 定義詳細画面の実機/シミュレータでの目視確認（Cloud VM では不可）

# 動作確認

- `TZ=Asia/Tokyo flutter test test/util/extension/date_time_extension_test.dart` → 全 15 件 pass
- `TZ=UTC` では固定期待値により fail（CI TZ 固定が必須であることを確認）
- `toLocal()` を外すと `TZ=Asia/Tokyo` でも `05:30` で fail（回帰検出を確認）

# その他

なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7461e9e-6e92-4332-9085-c21943d0dd65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7461e9e-6e92-4332-9085-c21943d0dd65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

