### PR TITLE
ci: Flutter ジョブを slim shell と bootstrap 分離で高速化する

### DIFF
--- a/.github/actions/ci-nix-setup/action.yml
+++ b/.github/actions/ci-nix-setup/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  flutter-cache-hit:
+    description: Whether the Flutter SDK bootstrap cache was restored (exact key hit)
+    value: ${{ steps.flutter-cache.outputs.cache-hit || '' }}
+
 runs:
   using: composite
   steps:
@@ -22,6 +27,7 @@ runs:
       uses: DeterminateSystems/determinate-nix-action@v3
 
     - name: Cache Flutter SDK bootstrap
+      id: flutter-cache
       if: inputs.cache-flutter == 'true'
       uses: actions/cache@v4
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,17 +74,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: CI Nix setup
+        id: nix
         uses: ./.github/actions/ci-nix-setup
         with:
           cache-flutter: "true"
           cache-pub: "true"
           touch-env: "true"
 
+      # Actions cache miss のときだけ flutterSrc を実現して .nix/flutter を構築する
+      - name: Bootstrap Flutter SDK
+        if: steps.nix.outputs.flutter-cache-hit != 'true'
+        run: nix run .#bootstrap-flutter
+
       - name: Install dependencies
-        run: nix develop --command just mobile-setup
+        run: nix develop .#ci-mobile --command just mobile-setup
 
       - name: Analyze
-        run: nix develop --command just mobile-analyze
+        run: nix develop .#ci-mobile --command just mobile-analyze
 
   mobile-test:
     needs: changes
@@ -99,17 +105,22 @@ jobs:
         uses: actions/checkout@v4
 
       - name: CI Nix setup
+        id: nix
         uses: ./.github/actions/ci-nix-setup
         with:
           cache-flutter: "true"
           cache-pub: "true"
           touch-env: "true"
 
+      - name: Bootstrap Flutter SDK
+        if: steps.nix.outputs.flutter-cache-hit != 'true'
+        run: nix run .#bootstrap-flutter
+
       - name: Install dependencies
-        run: nix develop --command just mobile-setup
+        run: nix develop .#ci-mobile --command just mobile-setup
 
       - name: Test
-        run: nix develop --command just mobile-test
+        run: nix develop .#ci-mobile --command just mobile-test
 
   backend-analyze:
     needs: changes

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,10 +81,21 @@ jobs:
           cache-pub: "true"
           touch-env: "true"
 
-      # Actions cache miss のときだけ flutterSrc を実現して .nix/flutter を構築する
+      # exact cache miss でも restore-keys で旧 SDK が戻ることがある。
+      # stamp 一致なら nix run（flutterSrc 実現）を避け、不一致のときだけ bootstrap する。
       - name: Bootstrap Flutter SDK
         if: steps.nix.outputs.flutter-cache-hit != 'true'
-        run: nix run .#bootstrap-flutter
+        run: |
+          set -euo pipefail
+          version="$(nix eval --raw .#flutterVersion)"
+          expected="$(nix eval --raw .#flutterToolchainRevision)"
+          flutter_root=".nix/flutter/${version}"
+          stamp_file="${flutter_root}/.nix-flutter-version"
+          if [ -x "${flutter_root}/bin/flutter" ] && [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$expected" ]; then
+            echo "Flutter SDK already present (${expected}); skip bootstrap"
+            exit 0
+          fi
+          nix run .#bootstrap-flutter
 
       - name: Install dependencies
         run: nix develop .#ci-mobile --command just mobile-setup
@@ -114,7 +125,17 @@ jobs:
 
       - name: Bootstrap Flutter SDK
         if: steps.nix.outputs.flutter-cache-hit != 'true'
-        run: nix run .#bootstrap-flutter
+        run: |
+          set -euo pipefail
+          version="$(nix eval --raw .#flutterVersion)"
+          expected="$(nix eval --raw .#flutterToolchainRevision)"
+          flutter_root=".nix/flutter/${version}"
+          stamp_file="${flutter_root}/.nix-flutter-version"
+          if [ -x "${flutter_root}/bin/flutter" ] && [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$expected" ]; then
+            echo "Flutter SDK already present (${expected}); skip bootstrap"
+            exit 0
+          fi
+          nix run .#bootstrap-flutter
 
       - name: Install dependencies
         run: nix develop .#ci-mobile --command just mobile-setup

--- a/doc/plans/2026-07-25-ci-flutter-speedup.md
+++ b/doc/plans/2026-07-25-ci-flutter-speedup.md
@@ -37,11 +37,18 @@
 - `nix develop`（default）も従来どおり成功
 - 未 bootstrap 時は `nix run .#bootstrap-flutter` を案内して exit 1
 - 既存 stamp では `bootstrap-flutter` が early-exit
+- `nix develop .#ci-mobile --command just mobile-setup` / `mobile-analyze` 成功
+
+## CI 初回観測（#274）
+
+- `Install dependencies` は ~75s → ~7s に短縮（slim shell 効果）
+- ただし exact cache miss + restore-keys 部分ヒット時に `nix run .#bootstrap-flutter` が走り、flutterSrc 実現で ~67s 残存
+- 対策: stamp 一致なら bootstrap を skip（`nix eval` のみ）するよう追従
 
 ## 完了条件
 
 - [x] Issue と Draft PR がある
-- [ ] キャッシュヒット時に `Install dependencies` が ~75s から大幅短縮される（CI で確認）
+- [ ] キャッシュヒット時（または stamp 一致の restore-keys）に bootstrap が skip され、ジョブが短縮される（CI で確認）
 - [x] ローカル `nix develop`（default）の Flutter 利用が従来どおり動く
 - [x] 無関係な `prod.xcscheme` 変更を含めない
 

--- a/doc/plans/2026-07-25-ci-flutter-speedup.md
+++ b/doc/plans/2026-07-25-ci-flutter-speedup.md
@@ -1,0 +1,48 @@
+# CI Flutter 高速化（slim shell + bootstrap 分離）
+
+## 目的
+
+`check.yml` の mobile-analyze / mobile-test を短縮する。直近成功 run ではジョブ ~2.5 分のうち setup（Nix + `nix develop`）が約 7 割。
+
+## 現状の内訳（キャッシュヒット時）
+
+| ステップ | 時間 | 主因 |
+|---------|------|------|
+| CI Nix setup | ~30s | Nix 安装 + Flutter キャッシュ展開 |
+| Install dependencies | ~75s | `flutterSrc` 実現 ~52s + 不要パッケージ ~20s |
+| Analyze / Test | ~35–50s | 実作業 |
+
+不要パッケージの closure 概算: openapi-generator ~470MB、lcov ~375MB、bun ~140MB。
+
+## 方針
+
+1. `bootstrap-flutter` を分離し、runtime の `flutter`/`dart` ラッパーは `flutterSrc` 非依存にする
+2. `devShells.ci-mobile`（flutter / dart / just のみ）を追加
+3. `check.yml` は `nix develop .#ci-mobile` を使い、Flutter キャッシュ miss 時のみ `nix run .#bootstrap-flutter`
+4. Magic Nix Cache / FlakeHub は使わない（前回 #237 で不採用）
+
+## 実行手順
+
+1. `flake.nix` を上記どおり変更
+2. `ci-nix-setup` に Flutter キャッシュ hit 出力を追加
+3. `check.yml` の mobile jobs を更新
+4. ローカルで wrapper 参照・ci-mobile・bootstrap を検証
+5. Issue #273 → Draft PR（`closes #273`）
+
+## ローカル検証結果
+
+- `flutter` ラッパーの store 参照に `flutterSrc`（`*-source`）なし / `bootstrap-flutter` にはあり
+- `devShells.ci-mobile` closure ~103MB vs `default` ~6.2GB（openapi / bun / lcov / bootstrap を含まない）
+- 既存 `.nix/flutter` で `nix develop .#ci-mobile --command flutter --version` 成功
+- `nix develop`（default）も従来どおり成功
+- 未 bootstrap 時は `nix run .#bootstrap-flutter` を案内して exit 1
+- 既存 stamp では `bootstrap-flutter` が early-exit
+
+## 完了条件
+
+- [x] Issue と Draft PR がある
+- [ ] キャッシュヒット時に `Install dependencies` が ~75s から大幅短縮される（CI で確認）
+- [x] ローカル `nix develop`（default）の Flutter 利用が従来どおり動く
+- [x] 無関係な `prod.xcscheme` 変更を含めない
+
+実行完了後、本ファイルを `doc/plans/done/` へ移動してコミットする。

--- a/flake.nix
+++ b/flake.nix
@@ -37,38 +37,69 @@
             flutterReleases.${pkgs.stdenv.hostPlatform.system}
               or (throw "Unsupported system for Flutter ${flutterVersion}: ${pkgs.stdenv.hostPlatform.system}");
           flutterSrc = pkgs.fetchzip release;
-          mkFlutterWrapper = name: executable: pkgs.writeShellApplication {
-            inherit name;
+          resolveRepoRoot = ''
+            repo_root="$PWD"
+            maybe_root="$(command -v git >/dev/null 2>&1 && git rev-parse --show-toplevel 2>/dev/null || true)"
+            if [ -n "$maybe_root" ]; then
+              repo_root="$maybe_root"
+            fi
+          '';
+          # Bootstrap owns flutterSrc / rsync / patch. Runtime wrappers intentionally
+          # do not reference flutterSrc so CI can skip realizing the SDK tarball
+          # when .nix/flutter is restored from Actions cache.
+          bootstrapFlutter = pkgs.writeShellApplication {
+            name = "bootstrap-flutter";
             # rsync を runtimeInputs に入れると exec 先の flutter → xcodebuild にも
             # PATH が継承され、exportArchive が起動する rsync server が GNU 版に
             # 化けて `--extended-attributes` 非対応で "Copy failed" になる。
             # rsync は PATH 注入せず絶対パスで呼ぶ。
             runtimeInputs = [
               pkgs.coreutils
-              pkgs.git
               pkgs.patch
             ];
             text = ''
-              repo_root="$PWD"
-              maybe_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-              if [ -n "$maybe_root" ]; then
-                repo_root="$maybe_root"
+              ${resolveRepoRoot}
+
+              flutter_root="''${FLUTTER_ROOT:-$repo_root/.nix/flutter/${flutterVersion}}"
+              stamp="$flutter_root/.nix-flutter-version"
+              if [ -x "$flutter_root/bin/flutter" ] && [ -f "$stamp" ] && [ "$(cat "$stamp")" = "${flutterToolchainRevision}" ]; then
+                echo "[nix] Flutter SDK already bootstrapped at $flutter_root" >&2
+                exit 0
               fi
+
+              tmp="$flutter_root.tmp"
+              rm -rf "$tmp"
+              mkdir -p "$(dirname "$tmp")"
+              ${pkgs.rsync}/bin/rsync -a --delete "${flutterSrc}/" "$tmp/"
+              chmod -R u+w "$tmp"
+              patch -d "$tmp" -p1 < ${./nix/patches/flutter-ios-15.patch}
+              patch -d "$tmp" -p1 < ${./nix/patches/flutter-ios-native-assets.patch}
+              rm -f "$tmp/bin/cache/flutter_tools.snapshot" "$tmp/bin/cache/flutter_tools.stamp"
+              printf '%s\n' "${flutterToolchainRevision}" > "$tmp/.nix-flutter-version"
+              rm -rf "$flutter_root"
+              mv "$tmp" "$flutter_root"
+              echo "[nix] Flutter SDK bootstrapped at $flutter_root" >&2
+            '';
+          };
+          mkFlutterWrapper = name: executable: pkgs.writeShellApplication {
+            inherit name;
+            # git は pkgs.git を入れずホストの git を使う（closure 肥大化を避ける）。
+            runtimeInputs = [
+              pkgs.coreutils
+            ];
+            text = ''
+              ${resolveRepoRoot}
 
               flutter_root="''${FLUTTER_ROOT:-$repo_root/.nix/flutter/${flutterVersion}}"
               stamp="$flutter_root/.nix-flutter-version"
               if [ ! -x "$flutter_root/bin/${executable}" ] || [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "${flutterToolchainRevision}" ]; then
-                tmp="$flutter_root.tmp"
-                rm -rf "$tmp"
-                mkdir -p "$(dirname "$tmp")"
-                ${pkgs.rsync}/bin/rsync -a --delete "${flutterSrc}/" "$tmp/"
-                chmod -R u+w "$tmp"
-                patch -d "$tmp" -p1 < ${./nix/patches/flutter-ios-15.patch}
-                patch -d "$tmp" -p1 < ${./nix/patches/flutter-ios-native-assets.patch}
-                rm -f "$tmp/bin/cache/flutter_tools.snapshot" "$tmp/bin/cache/flutter_tools.stamp"
-                printf '%s\n' "${flutterToolchainRevision}" > "$tmp/.nix-flutter-version"
-                rm -rf "$flutter_root"
-                mv "$tmp" "$flutter_root"
+                if command -v bootstrap-flutter >/dev/null 2>&1; then
+                  bootstrap-flutter
+                else
+                  echo "[nix] Flutter SDK is not bootstrapped at $flutter_root" >&2
+                  echo "[nix] Run: nix run .#bootstrap-flutter" >&2
+                  exit 1
+                fi
               fi
 
               export FLUTTER_ROOT="$flutter_root"
@@ -79,9 +110,16 @@
           };
           flutterTool = mkFlutterWrapper "flutter" "flutter";
           dartTool = mkFlutterWrapper "dart" "dart";
+          # check.yml mobile jobs: Flutter analyze/test only.
+          ciMobilePackages = [
+            flutterTool
+            dartTool
+            pkgs.just
+          ];
           toolPackages = [
             flutterTool
             dartTool
+            bootstrapFlutter
             pkgs.just
             pkgs.lcov
             pkgs.git
@@ -90,10 +128,11 @@
             pkgs.jq
             pkgs.ripgrep
             pkgs.openapi-generator-cli
-          ] ++ lib.optionals pkgs.stdenv.isDarwin [ pkgs.cocoapods ];
+          ]
+          ++ lib.optionals pkgs.stdenv.isDarwin [ pkgs.cocoapods ];
         in
         {
-          inherit flutterTool dartTool toolPackages;
+          inherit bootstrapFlutter flutterTool dartTool ciMobilePackages toolPackages;
         };
     in
     {
@@ -106,6 +145,7 @@
         {
           flutter = tools.flutterTool;
           dart = tools.dartTool;
+          bootstrap-flutter = tools.bootstrapFlutter;
           default = tools.flutterTool;
         }
       );
@@ -136,6 +176,15 @@
               echo "[nix] Run tasks with: just <task>" >&2
             '';
           };
+          # Mobile CI (analyze/test): no openapi-generator / bun / lcov / git closure.
+          # Pair with Actions cache of .nix/flutter and optional bootstrap-flutter on miss.
+          ci-mobile = pkgs.mkShellNoCC {
+            packages = tools.ciMobilePackages;
+            shellHook = ''
+              export PUB_CACHE="''${PUB_CACHE:-$PWD/.nix/pub-cache}"
+              echo "[nix] teigi_app ci-mobile shell ready (Flutter ${flutterVersion}, just)" >&2
+            '';
+          };
         }
       );
 
@@ -151,6 +200,10 @@
         dart = {
           type = "app";
           program = "${self.packages.${system}.dart}/bin/dart";
+        };
+        bootstrap-flutter = {
+          type = "app";
+          program = "${self.packages.${system}.bootstrap-flutter}/bin/bootstrap-flutter";
         };
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -53,9 +53,11 @@
             # PATH が継承され、exportArchive が起動する rsync server が GNU 版に
             # 化けて `--extended-attributes` 非対応で "Copy failed" になる。
             # rsync は PATH 注入せず絶対パスで呼ぶ。
+            # gitMinimal は resolveRepoRoot（standalone `nix run`）用。
             runtimeInputs = [
               pkgs.coreutils
               pkgs.patch
+              pkgs.gitMinimal
             ];
             text = ''
               ${resolveRepoRoot}
@@ -81,39 +83,65 @@
               echo "[nix] Flutter SDK bootstrapped at $flutter_root" >&2
             '';
           };
-          mkFlutterWrapper = name: executable: pkgs.writeShellApplication {
-            inherit name;
-            # git は pkgs.git を入れずホストの git を使う（closure 肥大化を避ける）。
-            runtimeInputs = [
-              pkgs.coreutils
-            ];
-            text = ''
-              ${resolveRepoRoot}
+          # Standalone packages/apps keep gitMinimal so `PATH=/bin nix run .#flutter`
+          # still resolves the repo root and satisfies Flutter's own git calls.
+          # CI wrappers omit it and rely on the runner's ambient git to keep
+          # ci-mobile closure small.
+          mkFlutterWrapper =
+            {
+              name,
+              executable,
+              withGit ? true,
+            }:
+            pkgs.writeShellApplication {
+              inherit name;
+              runtimeInputs = [
+                pkgs.coreutils
+              ]
+              ++ lib.optionals withGit [ pkgs.gitMinimal ];
+              text = ''
+                ${resolveRepoRoot}
 
-              flutter_root="''${FLUTTER_ROOT:-$repo_root/.nix/flutter/${flutterVersion}}"
-              stamp="$flutter_root/.nix-flutter-version"
-              if [ ! -x "$flutter_root/bin/${executable}" ] || [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "${flutterToolchainRevision}" ]; then
-                if command -v bootstrap-flutter >/dev/null 2>&1; then
-                  bootstrap-flutter
-                else
-                  echo "[nix] Flutter SDK is not bootstrapped at $flutter_root" >&2
-                  echo "[nix] Run: nix run .#bootstrap-flutter" >&2
-                  exit 1
+                flutter_root="''${FLUTTER_ROOT:-$repo_root/.nix/flutter/${flutterVersion}}"
+                stamp="$flutter_root/.nix-flutter-version"
+                if [ ! -x "$flutter_root/bin/${executable}" ] || [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "${flutterToolchainRevision}" ]; then
+                  if command -v bootstrap-flutter >/dev/null 2>&1; then
+                    bootstrap-flutter
+                  else
+                    echo "[nix] Flutter SDK is not bootstrapped at $flutter_root" >&2
+                    echo "[nix] Run: nix run .#bootstrap-flutter" >&2
+                    exit 1
+                  fi
                 fi
-              fi
 
-              export FLUTTER_ROOT="$flutter_root"
-              export PUB_CACHE="''${PUB_CACHE:-$repo_root/.nix/pub-cache}"
-              mkdir -p "$PUB_CACHE"
-              exec "$flutter_root/bin/${executable}" "$@"
-            '';
+                export FLUTTER_ROOT="$flutter_root"
+                export PUB_CACHE="''${PUB_CACHE:-$repo_root/.nix/pub-cache}"
+                mkdir -p "$PUB_CACHE"
+                exec "$flutter_root/bin/${executable}" "$@"
+              '';
+            };
+          flutterTool = mkFlutterWrapper {
+            name = "flutter";
+            executable = "flutter";
           };
-          flutterTool = mkFlutterWrapper "flutter" "flutter";
-          dartTool = mkFlutterWrapper "dart" "dart";
+          dartTool = mkFlutterWrapper {
+            name = "dart";
+            executable = "dart";
+          };
+          flutterToolCi = mkFlutterWrapper {
+            name = "flutter";
+            executable = "flutter";
+            withGit = false;
+          };
+          dartToolCi = mkFlutterWrapper {
+            name = "dart";
+            executable = "dart";
+            withGit = false;
+          };
           # check.yml mobile jobs: Flutter analyze/test only.
           ciMobilePackages = [
-            flutterTool
-            dartTool
+            flutterToolCi
+            dartToolCi
             pkgs.just
           ];
           toolPackages = [

--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,10 @@
         };
     in
     {
+      # CI が flutterSrc を実現せず stamp 照合できるように公開する。
+      flutterVersion = flutterVersion;
+      flutterToolchainRevision = flutterToolchainRevision;
+
       packages = forAllSystems (
         system:
         let


### PR DESCRIPTION
# 対象Issue

- closes #273

# やった事

- `bootstrap-flutter` を分離し、runtime の `flutter`/`dart` ラッパーを `flutterSrc` 非依存にした
- CI 用 `devShells.ci-mobile`（flutter / dart / just のみ）を追加
- `check.yml` の mobile jobs を `nix develop .#ci-mobile` に切り替え、Flutter キャッシュ miss 時のみ bootstrap
- `ci-nix-setup` に `flutter-cache-hit` 出力を追加

# やらなかった事

- deliver.yml / bump-pull-request.yml の変更
- analyze と test のジョブ統合
- Magic Nix Cache の再導入
- 無関係な `prod.xcscheme` のローカル変更は含めていない

# 動作確認

## ローカル

- `flutter` ラッパーの store 参照に `*-source` なし / `bootstrap-flutter` にはあり
- shell closure: `ci-mobile` ~103MB vs `default` ~6.2GB
- `nix develop .#ci-mobile --command flutter --version` 成功
- `nix develop --command flutter --version`（default）成功
- 未 bootstrap 時は案内メッセージ付きで exit 1
- `nix develop .#ci-mobile --command just mobile-setup` / `mobile-analyze` 成功

## CI（この PR で確認）

- 初回: flake 変更で Flutter キャッシュ miss → bootstrap が走る想定
- 2 回目以降: bootstrap skip + slim shell で `Install dependencies` 短縮を確認したい
- 比較元: 直近成功 run で Install dependencies ~75s / ジョブ全体 ~2.5 分

# その他

- 計画: `doc/plans/2026-07-25-ci-flutter-speedup.md`
- 見積もり効果（キャッシュヒット時）: Install dependencies から flutterSrc 実現 ~52s + 不要パッケージ ~20s を削減 → mobile ジョブ壁時計を ~1–1.5 分帯へ近づける想定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Accelerated mobile analysis and test checks by using a focused CI environment and avoiding unnecessary Flutter setup work.
  - Flutter setup now skips redundant bootstrapping when a valid cache or matching local installation is available.
  - Added a dedicated Flutter bootstrap command for reliable SDK preparation when needed.
- **Documentation**
  - Added a plan documenting the CI performance improvements, validation steps, and expected caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->