### PR TITLE
fix: PR #296 レビュー指摘 — seed 反映・世代破棄・domain 境界

### DIFF
--- a/mobile_app/lib/feature/definition/application/definition_seed_store.dart
+++ b/mobile_app/lib/feature/definition/application/definition_seed_store.dart
@@ -21,11 +21,25 @@ DefinitionSeedStore definitionSeedStore(DefinitionSeedStoreRef ref) =>
 class DefinitionSeedStore {
   final _seeds = <String, Definition>{};
 
+  /// 現在保持しているシードの ID 集合。
+  Set<String> get ids => _seeds.keys.toSet();
+
   /// 一覧取得で得られた定義をまとめて投入する。
   void seedAll(Iterable<Definition> definitions) {
     for (final definition in definitions) {
       _seeds[definition.id] = definition;
     }
+  }
+
+  /// フィードの世代を丸ごと置き換える。
+  ///
+  /// 既存のシードをすべて破棄したうえで [definitions] を投入する。
+  /// 戻り値は置き換え前に保持していた ID 集合。
+  Set<String> replaceAll(Iterable<Definition> definitions) {
+    final previousIds = ids;
+    _seeds.clear();
+    seedAll(definitions);
+    return previousIds;
   }
 
   /// [definitionId] のシードを返す。未投入の場合は null。

--- a/mobile_app/lib/feature/definition/domain/definition.dart
+++ b/mobile_app/lib/feature/definition/domain/definition.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:teigiii_api/teigiii_api.dart';
 
 import 'definition_for_write.dart';
 
@@ -21,25 +20,6 @@ class Definition with _$Definition {
     required bool isLikedByUser,
     required DateTime createdAt,
   }) = _Definition;
-
-  /// API の [DefinitionResponse] から [Definition] を組み立てる。
-  ///
-  /// 定義単体取得とタイムライン取得で同じマッピングを使うため、
-  /// 変換ロジックはここに集約する。
-  factory Definition.fromResponse(DefinitionResponse response) => Definition(
-    id: response.id,
-    wordId: response.word.id,
-    word: response.word.word,
-    wordReading: response.word.reading,
-    authorId: response.author.id,
-    authorName: response.author.name,
-    authorImageUrl: response.author.avatarUrl,
-    definition: response.body,
-    isPublic: response.status == DefinitionStatus.public,
-    likesCount: response.likesCount,
-    isLikedByUser: response.isLikedByMe,
-    createdAt: response.createdAt,
-  );
 
   const Definition._();
 

--- a/mobile_app/lib/feature/definition/repository/definition_response_mapper.dart
+++ b/mobile_app/lib/feature/definition/repository/definition_response_mapper.dart
@@ -1,0 +1,23 @@
+import 'package:teigiii_api/teigiii_api.dart';
+
+import '../domain/definition.dart';
+
+/// API の [DefinitionResponse] から [Definition] への変換。
+///
+/// 定義単体取得とタイムライン取得で同じマッピングを使うため、
+/// 変換ロジックは repository 層に集約する。
+/// domain は Freezed のみに依存する規約を守る。
+Definition definitionFromResponse(DefinitionResponse response) => Definition(
+  id: response.id,
+  wordId: response.word.id,
+  word: response.word.word,
+  wordReading: response.word.reading,
+  authorId: response.author.id,
+  authorName: response.author.name,
+  authorImageUrl: response.author.avatarUrl,
+  definition: response.body,
+  isPublic: response.status == DefinitionStatus.public,
+  likesCount: response.likesCount,
+  isLikedByUser: response.isLikedByMe,
+  createdAt: response.createdAt,
+);

--- a/mobile_app/lib/feature/definition/repository/fetch_definition_repository.dart
+++ b/mobile_app/lib/feature/definition/repository/fetch_definition_repository.dart
@@ -5,6 +5,7 @@ import 'package:teigiii_api/teigiii_api.dart';
 import '../../../core/api/api_exception.dart';
 import '../../../core/api/api_providers.dart';
 import '../domain/definition.dart';
+import 'definition_response_mapper.dart';
 
 part 'fetch_definition_repository.g.dart';
 
@@ -28,7 +29,7 @@ class FetchDefinitionRepository {
       final response = await _definitionsApi.v1DefinitionsIdGet(
         id: definitionId,
       );
-      return Definition.fromResponse(response.data!);
+      return definitionFromResponse(response.data!);
     } on DioException catch (exception) {
       throw ApiException.fromDioException(exception);
     }

--- a/mobile_app/lib/feature/timeline/application/discover_timeline_state.dart
+++ b/mobile_app/lib/feature/timeline/application/discover_timeline_state.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../util/mixin/fetch_more_mixin.dart';
 import '../../definition/application/definition_seed_store.dart';
+import '../../definition/application/definition_state.dart';
 import '../../definition/domain/definition.dart';
 import '../domain/discover_feed_list_state.dart';
 import '../repository/discover_timeline_repository.dart';
@@ -19,10 +20,25 @@ class DiscoverTimelineStateNotifier extends _$DiscoverTimelineStateNotifier
         .read(discoverTimelineRepositoryProvider)
         .fetchDiscoverTimeline(cursor);
 
-    // 各 tile が定義を再取得しないよう、取得済みの定義をシードとして投入する。
-    ref
-        .read(definitionSeedStoreProvider)
-        .seedAll(result.list.whereType<Definition>());
+    final definitions = result.list.whereType<Definition>().toList();
+    final store = ref.read(definitionSeedStoreProvider);
+
+    // 初回・refresh（cursor == null）はフィード世代を丸ごと置き換える。
+    // fetchMore は追記のみ。いずれの場合も seed 更新後に
+    // definitionProvider を invalidate し、購読中の tile へ反映する。
+    final idsToInvalidate = <String>{};
+    if (cursor == null) {
+      idsToInvalidate
+        ..addAll(store.replaceAll(definitions))
+        ..addAll(definitions.map((definition) => definition.id));
+    } else {
+      store.seedAll(definitions);
+      idsToInvalidate.addAll(definitions.map((definition) => definition.id));
+    }
+
+    for (final id in idsToInvalidate) {
+      ref.invalidate(definitionProvider(id));
+    }
 
     return result;
   }

--- a/mobile_app/lib/feature/timeline/application/discover_timeline_state.g.dart
+++ b/mobile_app/lib/feature/timeline/application/discover_timeline_state.g.dart
@@ -7,23 +7,20 @@ part of 'discover_timeline_state.dart';
 // **************************************************************************
 
 String _$discoverTimelineStateNotifierHash() =>
-    r'45fac3d9a1d56ce2174b85ab2d0337a6acc28c12';
+    r'ce9e38427769920991b442e7aa1fbc54331ab299';
 
 /// See also [DiscoverTimelineStateNotifier].
 @ProviderFor(DiscoverTimelineStateNotifier)
-final discoverTimelineStateNotifierProvider =
-    AsyncNotifierProvider<
-      DiscoverTimelineStateNotifier,
-      DiscoverFeedListState
-    >.internal(
-      DiscoverTimelineStateNotifier.new,
-      name: r'discoverTimelineStateNotifierProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$discoverTimelineStateNotifierHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+final discoverTimelineStateNotifierProvider = AsyncNotifierProvider<
+    DiscoverTimelineStateNotifier, DiscoverFeedListState>.internal(
+  DiscoverTimelineStateNotifier.new,
+  name: r'discoverTimelineStateNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$discoverTimelineStateNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 typedef _$DiscoverTimelineStateNotifier = AsyncNotifier<DiscoverFeedListState>;
 // ignore_for_file: type=lint

--- a/mobile_app/lib/feature/timeline/repository/discover_timeline_repository.dart
+++ b/mobile_app/lib/feature/timeline/repository/discover_timeline_repository.dart
@@ -4,7 +4,7 @@ import 'package:teigiii_api/teigiii_api.dart';
 
 import '../../../core/api/api_exception.dart';
 import '../../../core/api/api_providers.dart';
-import '../../definition/domain/definition.dart';
+import '../../definition/repository/definition_response_mapper.dart';
 import '../domain/discover_feed_list_state.dart';
 
 part 'discover_timeline_repository.g.dart';
@@ -31,7 +31,7 @@ class DiscoverTimelineRepository {
         list: page.items
             .map<dynamic>((item) {
               if (item is DiscoverFeedDefinitionItem) {
-                return Definition.fromResponse(item.activity.definition);
+                return definitionFromResponse(item.activity.definition);
               }
               if (item is DiscoverFeedWordRegisteredItem) {
                 return item.activity;

--- a/mobile_app/test/feature/definition/repository/definition_response_mapper_test.dart
+++ b/mobile_app/test/feature/definition/repository/definition_response_mapper_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:teigi_app/feature/definition/domain/definition.dart';
+import 'package:teigi_app/feature/definition/repository/definition_response_mapper.dart';
 import 'package:teigiii_api/teigiii_api.dart';
 
 void main() {
@@ -28,10 +28,10 @@ void main() {
     );
   }
 
-  group('Definition.fromResponse', () {
+  group('definitionFromResponse', () {
     test('全フィールドを DefinitionResponse からマッピングする', () {
       // * Act
-      final definition = Definition.fromResponse(
+      final definition = definitionFromResponse(
         buildResponse(status: DefinitionStatus.public),
       );
 
@@ -55,7 +55,7 @@ void main() {
 
     test('avatarUrl が null の場合 authorImageUrl も null になる', () {
       // * Act
-      final definition = Definition.fromResponse(
+      final definition = definitionFromResponse(
         buildResponse(status: DefinitionStatus.public, avatarUrl: null),
       );
 
@@ -66,19 +66,19 @@ void main() {
     test('status が public の場合のみ isPublic が true になる', () {
       // * Act & Assert
       expect(
-        Definition.fromResponse(
+        definitionFromResponse(
           buildResponse(status: DefinitionStatus.public),
         ).isPublic,
         isTrue,
       );
       expect(
-        Definition.fromResponse(
+        definitionFromResponse(
           buildResponse(status: DefinitionStatus.private),
         ).isPublic,
         isFalse,
       );
       expect(
-        Definition.fromResponse(
+        definitionFromResponse(
           buildResponse(status: DefinitionStatus.draft),
         ).isPublic,
         isFalse,

--- a/mobile_app/test/feature/timeline/application/discover_timeline_state_test.dart
+++ b/mobile_app/test/feature/timeline/application/discover_timeline_state_test.dart
@@ -3,18 +3,27 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:teigi_app/feature/definition/application/definition_seed_store.dart';
+import 'package:teigi_app/feature/definition/application/definition_state.dart';
 import 'package:teigi_app/feature/definition/domain/definition.dart';
+import 'package:teigi_app/feature/definition/repository/fetch_definition_repository.dart';
 import 'package:teigi_app/feature/timeline/application/discover_timeline_state.dart';
 import 'package:teigi_app/feature/timeline/domain/discover_feed_list_state.dart';
 import 'package:teigi_app/feature/timeline/repository/discover_timeline_repository.dart';
+import 'package:teigi_app/feature/user_profile/repository/user_profile_repository.dart';
 import 'package:teigiii_api/teigiii_api.dart';
 
 import '../../../mock/mock_data.dart';
 import 'discover_timeline_state_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<DiscoverTimelineRepository>()])
+@GenerateNiceMocks([
+  MockSpec<DiscoverTimelineRepository>(),
+  MockSpec<FetchDefinitionRepository>(),
+  MockSpec<UserProfileRepository>(),
+])
 void main() {
   final mockDiscoverTimelineRepository = MockDiscoverTimelineRepository();
+  final mockFetchDefinitionRepository = MockFetchDefinitionRepository();
+  final mockUserProfileRepository = MockUserProfileRepository();
 
   late ProviderContainer container;
 
@@ -24,12 +33,22 @@ void main() {
         discoverTimelineRepositoryProvider.overrideWithValue(
           mockDiscoverTimelineRepository,
         ),
+        fetchDefinitionRepositoryProvider.overrideWithValue(
+          mockFetchDefinitionRepository,
+        ),
+        userProfileRepositoryProvider.overrideWithValue(
+          mockUserProfileRepository,
+        ),
       ],
     );
     addTearDown(container.dispose);
   });
 
-  tearDown(() => reset(mockDiscoverTimelineRepository));
+  tearDown(() {
+    reset(mockDiscoverTimelineRepository);
+    reset(mockFetchDefinitionRepository);
+    reset(mockUserProfileRepository);
+  });
 
   final wordRegisteredActivity = WordRegisteredActivity(
     type: WordRegisteredActivityTypeEnum.wordRegistered,
@@ -98,6 +117,114 @@ void main() {
           .value!;
       expect(state.list.whereType<Definition>().length, 2);
       expect(state.hasMore, isFalse);
+    });
+
+    test('同一 ID を再取得した場合、購読中の definitionProvider も新しい値になる', () async {
+      // * Arrange
+      final oldDefinition = firstDefinition.copyWith(
+        definition: '古い本文',
+        likesCount: 1,
+        isLikedByUser: false,
+      );
+      final newDefinition = firstDefinition.copyWith(
+        definition: '新しい本文',
+        likesCount: 9,
+        isLikedByUser: true,
+      );
+      when(
+        mockDiscoverTimelineRepository.fetchDiscoverTimeline(null),
+      ).thenAnswer(
+        (_) async => DiscoverFeedListState(
+          list: [oldDefinition],
+          nextCursor: null,
+          hasMore: false,
+        ),
+      );
+      await container.read(discoverTimelineStateNotifierProvider.future);
+      final before = await container.read(
+        definitionProvider(oldDefinition.id).future,
+      );
+      expect(before.definition, '古い本文');
+      expect(before.likesCount, 1);
+
+      when(
+        mockDiscoverTimelineRepository.fetchDiscoverTimeline(null),
+      ).thenAnswer(
+        (_) async => DiscoverFeedListState(
+          list: [newDefinition],
+          nextCursor: null,
+          hasMore: false,
+        ),
+      );
+
+      // * Act
+      container.invalidate(discoverTimelineStateNotifierProvider);
+      await container.read(discoverTimelineStateNotifierProvider.future);
+      final after = await container.read(
+        definitionProvider(oldDefinition.id).future,
+      );
+
+      // * Assert
+      expect(after.definition, '新しい本文');
+      expect(after.likesCount, 9);
+      expect(after.isLikedByUser, isTrue);
+      verifyNever(mockFetchDefinitionRepository.fetchDefinition(any));
+    });
+
+    test('refresh 後に消えた ID のシードは破棄され単体取得に戻る', () async {
+      // * Arrange
+      when(
+        mockDiscoverTimelineRepository.fetchDiscoverTimeline(null),
+      ).thenAnswer(
+        (_) async => DiscoverFeedListState(
+          list: [firstDefinition, secondDefinition],
+          nextCursor: null,
+          hasMore: false,
+        ),
+      );
+      await container.read(discoverTimelineStateNotifierProvider.future);
+      expect(
+        container.read(definitionSeedStoreProvider).read(secondDefinition.id),
+        secondDefinition,
+      );
+
+      when(
+        mockDiscoverTimelineRepository.fetchDiscoverTimeline(null),
+      ).thenAnswer(
+        (_) async => DiscoverFeedListState(
+          list: [firstDefinition],
+          nextCursor: null,
+          hasMore: false,
+        ),
+      );
+      when(
+        mockFetchDefinitionRepository.fetchDefinition(secondDefinition.id),
+      ).thenAnswer((_) async => secondDefinition.copyWith(likesCount: 42));
+      when(
+        mockUserProfileRepository.fetchUserProfile(secondDefinition.authorId),
+      ).thenAnswer((_) async => mockUserProfile);
+
+      // * Act
+      container.invalidate(discoverTimelineStateNotifierProvider);
+      await container.read(discoverTimelineStateNotifierProvider.future);
+
+      // * Assert
+      expect(
+        container.read(definitionSeedStoreProvider).read(secondDefinition.id),
+        isNull,
+      );
+      expect(
+        container.read(definitionSeedStoreProvider).read(firstDefinition.id),
+        firstDefinition,
+      );
+
+      final fetched = await container.read(
+        definitionProvider(secondDefinition.id).future,
+      );
+      expect(fetched.likesCount, 42);
+      verify(
+        mockFetchDefinitionRepository.fetchDefinition(secondDefinition.id),
+      ).called(1);
     });
   });
 }

--- a/mobile_app/test/feature/timeline/application/discover_timeline_state_test.mocks.dart
+++ b/mobile_app/test/feature/timeline/application/discover_timeline_state_test.mocks.dart
@@ -3,13 +3,19 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i6;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:teigi_app/feature/definition/domain/definition.dart' as _i3;
+import 'package:teigi_app/feature/definition/repository/fetch_definition_repository.dart'
+    as _i7;
 import 'package:teigi_app/feature/timeline/domain/discover_feed_list_state.dart'
     as _i2;
 import 'package:teigi_app/feature/timeline/repository/discover_timeline_repository.dart'
-    as _i3;
+    as _i5;
+import 'package:teigi_app/feature/user_profile/domain/user_profile.dart' as _i4;
+import 'package:teigi_app/feature/user_profile/repository/user_profile_repository.dart'
+    as _i8;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -26,32 +32,133 @@ import 'package:teigi_app/feature/timeline/repository/discover_timeline_reposito
 
 class _FakeDiscoverFeedListState_0 extends _i1.SmartFake
     implements _i2.DiscoverFeedListState {
-  _FakeDiscoverFeedListState_0(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
+  _FakeDiscoverFeedListState_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeDefinition_1 extends _i1.SmartFake implements _i3.Definition {
+  _FakeDefinition_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeUserProfile_2 extends _i1.SmartFake implements _i4.UserProfile {
+  _FakeUserProfile_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [DiscoverTimelineRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDiscoverTimelineRepository extends _i1.Mock
-    implements _i3.DiscoverTimelineRepository {
+    implements _i5.DiscoverTimelineRepository {
   @override
-  _i4.Future<_i2.DiscoverFeedListState> fetchDiscoverTimeline(String? cursor) =>
+  _i6.Future<_i2.DiscoverFeedListState> fetchDiscoverTimeline(String? cursor) =>
       (super.noSuchMethod(
-            Invocation.method(#fetchDiscoverTimeline, [cursor]),
-            returnValue: _i4.Future<_i2.DiscoverFeedListState>.value(
-              _FakeDiscoverFeedListState_0(
-                this,
-                Invocation.method(#fetchDiscoverTimeline, [cursor]),
-              ),
-            ),
-            returnValueForMissingStub:
-                _i4.Future<_i2.DiscoverFeedListState>.value(
-                  _FakeDiscoverFeedListState_0(
-                    this,
-                    Invocation.method(#fetchDiscoverTimeline, [cursor]),
-                  ),
-                ),
-          )
-          as _i4.Future<_i2.DiscoverFeedListState>);
+        Invocation.method(
+          #fetchDiscoverTimeline,
+          [cursor],
+        ),
+        returnValue: _i6.Future<_i2.DiscoverFeedListState>.value(
+            _FakeDiscoverFeedListState_0(
+          this,
+          Invocation.method(
+            #fetchDiscoverTimeline,
+            [cursor],
+          ),
+        )),
+        returnValueForMissingStub: _i6.Future<_i2.DiscoverFeedListState>.value(
+            _FakeDiscoverFeedListState_0(
+          this,
+          Invocation.method(
+            #fetchDiscoverTimeline,
+            [cursor],
+          ),
+        )),
+      ) as _i6.Future<_i2.DiscoverFeedListState>);
+}
+
+/// A class which mocks [FetchDefinitionRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockFetchDefinitionRepository extends _i1.Mock
+    implements _i7.FetchDefinitionRepository {
+  @override
+  _i6.Future<_i3.Definition> fetchDefinition(String? definitionId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchDefinition,
+          [definitionId],
+        ),
+        returnValue: _i6.Future<_i3.Definition>.value(_FakeDefinition_1(
+          this,
+          Invocation.method(
+            #fetchDefinition,
+            [definitionId],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i6.Future<_i3.Definition>.value(_FakeDefinition_1(
+          this,
+          Invocation.method(
+            #fetchDefinition,
+            [definitionId],
+          ),
+        )),
+      ) as _i6.Future<_i3.Definition>);
+}
+
+/// A class which mocks [UserProfileRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockUserProfileRepository extends _i1.Mock
+    implements _i8.UserProfileRepository {
+  @override
+  _i6.Future<_i4.UserProfile> fetchUserProfile(String? userId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchUserProfile,
+          [userId],
+        ),
+        returnValue: _i6.Future<_i4.UserProfile>.value(_FakeUserProfile_2(
+          this,
+          Invocation.method(
+            #fetchUserProfile,
+            [userId],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i6.Future<_i4.UserProfile>.value(_FakeUserProfile_2(
+          this,
+          Invocation.method(
+            #fetchUserProfile,
+            [userId],
+          ),
+        )),
+      ) as _i6.Future<_i4.UserProfile>);
+
+  @override
+  _i6.Future<void> updateUserProfile(_i4.UserProfile? userProfileForWrite) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUserProfile,
+          [userProfileForWrite],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
 }

--- a/mobile_app/test/feature/timeline/repository/discover_timeline_repository_test.dart
+++ b/mobile_app/test/feature/timeline/repository/discover_timeline_repository_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:teigi_app/core/api/api_exception.dart';
-import 'package:teigi_app/feature/definition/domain/definition.dart';
+import 'package:teigi_app/feature/definition/repository/definition_response_mapper.dart';
 import 'package:teigi_app/feature/timeline/repository/discover_timeline_repository.dart';
 import 'package:teigiii_api/teigiii_api.dart';
 
@@ -71,7 +71,7 @@ void main() {
       expect(state.list.length, 2);
       expect(
         state.list.first,
-        Definition.fromResponse(definitionItem.activity.definition),
+        definitionFromResponse(definitionItem.activity.definition),
       );
       expect(state.list[1], wordRegisteredActivity);
       expect(state.nextCursor, 'cursor1');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#296 のレビュー指摘対応。同一コミットは親ブランチ `fix/288-293-infinity-scroll-perf` へ fast-forward 済み（#296 に反映済み）。

この PR は追跡用。親側に取り込み済みのため追加マージは不要。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa23f-5935-7f32-b6ac-c69fe42fac5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa23f-5935-7f32-b6ac-c69fe42fac5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

