### PR TITLE
feat: 【Perf Phase 2】CLI と skill でパフォーマンスデータをクエリできるようにする ✨

### DIFF
--- a/.claude/skills/analyzing-app-performance/SKILL.md
+++ b/.claude/skills/analyzing-app-performance/SKILL.md
@@ -12,7 +12,7 @@ description: 本番アプリのフレーム計測テレメトリを CLI で取�
 ## 前提
 
 1. ローカル環境に `CLOUDFLARE_API_TOKEN` を置く（リポジトリにコミットしない）
-2. トークン権限は **D1 Read のみ**（Account → D1 → Read）。Write / Edit は付けない
+2. トークン権限は **D1 Read のみ**（Account → D1 → Read）。Write / Edit は付けない（最小権限の習慣。ただし下記「実測」参照）
 3. 対象 DB は prod の `TELEMETRY_DB`（`teigiii-telemetry-prod`）
 
 発行手順（Cloudflare Dashboard）:
@@ -28,14 +28,12 @@ description: 本番アプリのフレーム計測テレメトリを CLI で取�
 just perf-query 'SELECT COUNT(*) AS n FROM frame_stats'
 # 成功すること
 
-# mutation は perf-query 側で弾かれる（多層防御）
+# mutation の実効防御は perf-query の SELECT/WITH ガード（必須）
 just perf-query "INSERT INTO frame_stats (id) VALUES ('x')"
 # "Only SELECT/WITH queries are allowed" で失敗すること
-
-# トークン自体が D1 Read のみであることの確認（wrangler 直叩き）
-cd backend && bunx wrangler d1 execute TELEMETRY_DB --env prod --remote --command "INSERT INTO frame_stats (id) VALUES ('x')"
-# 権限エラーになること（構文エラーではなく permission / auth 系）
 ```
+
+**実測（2026-07-28）:** Account / D1 / Read のみの API token でも、`wrangler d1 execute --remote` 経由の `INSERT` は権限エラーにならず SQL 実行まで到達する（制約違反などで落ちる）。したがって「Read token なら Cloudflare 側が mutation を拒否する」は完了条件にしない。分析導線の書き込み防止は **CLI ガードが正**であり、Read 指定は運用上の最小権限表明として残す。
 
 
 ## コマンド

--- a/.claude/skills/analyzing-app-performance/SKILL.md
+++ b/.claude/skills/analyzing-app-performance/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: analyzing-app-performance
+description: 本番アプリのフレーム計測テレメトリを CLI で取得し、画面別ジャンク率やビルド間比較の所見を返す。パフォーマンス悪化の確認、リリース前後の比較、frame_stats の分析を依頼された時に使用する。
+---
+
+# アプリパフォーマンス分析
+
+本番 `TELEMETRY_DB`（`teigiii-telemetry-prod`）に蓄積された画面別フレーム統計を、**ダッシュボードなし**で CLI + この skill から読む。
+
+**主導線は `just perf-report`。** `just perf-query` は明示的な手動調査専用。分析タスクに raw SQL を使わない。
+
+## 前提
+
+1. ローカル環境に `CLOUDFLARE_API_TOKEN` を置く（リポジトリにコミットしない）
+2. トークン権限は **D1 Read のみ**（Account → D1 → Read）。Write / Edit は付けない
+3. 対象 DB は prod の `TELEMETRY_DB`（`teigiii-telemetry-prod`）
+
+発行手順（Cloudflare Dashboard）:
+
+1. My Profile → API Tokens → Create Token
+2. Custom token。Permission: `Account` / `D1` / `Read`
+3. Account Resources でこのアカウントを選択
+4. 発行した値を shell だけに export する（例: `export CLOUDFLARE_API_TOKEN=...`）
+
+検証（mutation が権限エラーになること）:
+
+```bash
+just perf-query 'SELECT COUNT(*) AS n FROM frame_stats'
+# 成功すること
+
+just perf-query 'INSERT INTO frame_stats (id) VALUES (''x'')'
+# 権限エラーになること
+```
+
+## コマンド
+
+```bash
+# AI 主導線。任意で build_number を渡して絞り込み
+just perf-report
+just perf-report 42
+
+# 手動調査のみ
+just perf-query 'SELECT screen_name, COUNT(*) AS n FROM frame_stats GROUP BY 1'
+```
+
+`perf-report` の JSON には次が含まれる:
+
+| セクション | 内容 |
+|---|---|
+| `byScreen` | 画面別の slow build / slow raster / frozen 率とサンプル数 |
+| `versionComparison` | `platform + flavor` ごとの最新 vs 直前 `build_number` 比較 |
+| `byDevice` | 端末モデル別内訳 |
+| `byRefreshRate` | リフレッシュレート別内訳 |
+
+各集計には必ず `sessionCount` と `frameCount` がある。比率だけを見て判断しない。
+
+## スキーマ（`frame_stats`）
+
+1 行 = 1 セッション × 1 画面。正本は `backend/src/db/telemetry-schema.ts`。
+
+| 列 | 意味 |
+|---|---|
+| `session_id` | 端末セッションの使い捨て ID（利用者と紐づけない） |
+| `screen_name` | 画面名 |
+| `build_number` | 数値。**新旧判定はこの列**（`app_version` 文字列順は使わない） |
+| `platform` / `flavor` | iOS/Android と dev/prod など |
+| `refresh_rate_hz` | 端末リフレッシュレート。slow 判定予算の元 |
+| `frame_count` | フレーム総数（分母） |
+| `slow_build_count` | buildDuration が予算超 |
+| `slow_raster_count` | rasterDuration が予算超 |
+| `frozen_count` | totalSpan > 700ms |
+| `recorded_at` | クライアント計測時刻 |
+| `created_at` | サーバー受信時刻（リテンション基準） |
+
+`user_id` もパーセンタイル列もない。
+
+## 解釈基準
+
+### サンプル数
+
+個人アプリは低トラフィック。次を満たさない画面・strata は **「悪化」と断定しない**。
+
+- 目安: `sessionCount < 5` または `frameCount < 1000` は所見で「サンプル不足」と明記する
+- 比率が高くても分母が小さい行は外れ値扱いにする
+
+### build 系と raster 系
+
+| 指標 | 示唆 |
+|---|---|
+| `slowBuildRate` が高い | Dart 側の再構築・レイアウトが重い |
+| `slowRasterRate` が高い | GPU / 描画（過剰な影、巨大画像、ネイティブビュー等）が重い |
+| `frozenRate` が高い | 700ms 超の長時間フレーム（同期ブロック等） |
+
+Phase 0 系のリスト構造問題の再発は、主に **build 側**に出やすい。
+
+### バージョン比較
+
+- 新旧は **`platform + flavor` ごとに数値 `build_number`** で決める
+- `app_version` の辞書順比較は禁止（`2.10.0 < 2.9.0` になる）
+- 比較対象の両側に十分なサンプルがあること。片側不足なら比較を保留する
+- 端末構成比（60Hz / 120Hz）の変化だけで率が動く点に注意。厳密な回帰判定は Phase 3（層別化）の役割
+
+### この skill でやらないこと
+
+- 原因特定の断定（本番テレメトリは回帰検知用。原因はローカル profile + DevTools）
+- raw SQL の乱用（`perf-query`）
+- ダッシュボード構築
+- 本番 D1 への書き込み
+
+## 手順
+
+1. `CLOUDFLARE_API_TOKEN` があることを確認する
+2. `just perf-report`（必要なら対象 `build_number` 付き）を実行する
+3. JSON を読み、サンプル不足の行を除外してから所見を書く
+4. 所見には必ず画面名、比較した `build_number`、`sessionCount` / `frameCount`、build vs raster のどちらが動いたかを含める
+5. 追加の切り口が必要なときだけ、ユーザーに確認したうえで `perf-query` を使う
+
+クライアント契約の正本: `doc/specs/app-performance-telemetry.md`  
+サーバー側: `doc/specs/workers-api-server.md` の「フレーム計測テレメトリ」

--- a/.claude/skills/analyzing-app-performance/SKILL.md
+++ b/.claude/skills/analyzing-app-performance/SKILL.md
@@ -22,15 +22,21 @@ description: 本番アプリのフレーム計測テレメトリを CLI で取�
 3. Account Resources でこのアカウントを選択
 4. 発行した値を shell だけに export する（例: `export CLOUDFLARE_API_TOKEN=...`）
 
-検証（mutation が権限エラーになること）:
+検証:
 
 ```bash
 just perf-query 'SELECT COUNT(*) AS n FROM frame_stats'
 # 成功すること
 
-just perf-query 'INSERT INTO frame_stats (id) VALUES (''x'')'
-# 権限エラーになること
+# mutation は perf-query 側で弾かれる（多層防御）
+just perf-query "INSERT INTO frame_stats (id) VALUES ('x')"
+# "Only SELECT/WITH queries are allowed" で失敗すること
+
+# トークン自体が D1 Read のみであることの確認（wrangler 直叩き）
+cd backend && bunx wrangler d1 execute TELEMETRY_DB --env prod --remote --command "INSERT INTO frame_stats (id) VALUES ('x')"
+# 権限エラーになること（構文エラーではなく permission / auth 系）
 ```
+
 
 ## コマンド
 
@@ -48,11 +54,13 @@ just perf-query 'SELECT screen_name, COUNT(*) AS n FROM frame_stats GROUP BY 1'
 | セクション | 内容 |
 |---|---|
 | `byScreen` | 画面別の slow build / slow raster / frozen 率とサンプル数 |
-| `versionComparison` | `platform + flavor` ごとの最新 vs 直前 `build_number` 比較 |
+| `versionComparison` | `platform + flavor` ごとの最新 vs 直前 `build_number` 比較（`build_number` 指定時はその値を latest に固定） |
 | `byDevice` | 端末モデル別内訳 |
 | `byRefreshRate` | リフレッシュレート別内訳 |
 
 各集計には必ず `sessionCount` と `frameCount` がある。比率だけを見て判断しない。
+
+`build_number` 無指定の `byScreen` / `byDevice` / `byRefreshRate` は、リテンション期間内の **全 build / 全 platform を混ぜた集計**になる。回帰判定には使わず、`versionComparison` か `just perf-report <build_number>` を使う。
 
 ## スキーマ（`frame_stats`）
 
@@ -97,6 +105,9 @@ Phase 0 系のリスト構造問題の再発は、主に **build 側**に出や�
 
 - 新旧は **`platform + flavor` ごとに数値 `build_number`** で決める
 - `app_version` の辞書順比較は禁止（`2.10.0 < 2.9.0` になる）
+- `just perf-report <build_number>` では、その値が latest 側に固定され、直前はそれより小さい最大値
+- `previousBuildNumber: null` は「直前ビルド自体が無い」。直前ビルドはあるが当該画面が未観測のときは `previousBuildNumber` は埋まり、`previous.frameCount === 0`
+- 行は latest 側の画面が起点。**直前にあって最新で消えた画面はレポートに出ない**（画面消失自体は別途 `perf-query` で確認）
 - 比較対象の両側に十分なサンプルがあること。片側不足なら比較を保留する
 - 端末構成比（60Hz / 120Hz）の変化だけで率が動く点に注意。厳密な回帰判定は Phase 3（層別化）の役割
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,9 @@
     "dev": "wrangler dev",
     "migration:export": "bun run scripts/migration/export.ts",
     "migration:import": "bun run scripts/migration/import.ts",
-    "migration:verify": "bun run scripts/migration/verify.ts"
+    "migration:verify": "bun run scripts/migration/verify.ts",
+    "perf:query": "bun run scripts/perf-query.ts",
+    "perf:report": "bun run scripts/perf-report.ts"
   },
   "dependencies": {
     "@hono/zod-openapi": "^1.5.0",

--- a/backend/scripts/perf-query.ts
+++ b/backend/scripts/perf-query.ts
@@ -4,13 +4,10 @@
  * AI の主導線は just perf-report を使うこと。
  */
 
-import { executeTelemetrySql } from "./perf/execute";
+import { executeTelemetrySql, parsePerfQueryArgs } from "./perf/execute";
 
 async function main(): Promise<void> {
-  const sql = Bun.argv.slice(2).join(" ").trim();
-  if (!sql) {
-    throw new Error("Usage: bun run scripts/perf-query.ts '<SQL>'");
-  }
+  const sql = parsePerfQueryArgs(Bun.argv.slice(2));
   const rows = await executeTelemetrySql(sql);
   process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
 }

--- a/backend/scripts/perf-query.ts
+++ b/backend/scripts/perf-query.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env bun
+/**
+ * just perf-query の実体。手動調査用の raw SQL 実行。
+ * AI の主導線は just perf-report を使うこと。
+ */
+
+import { executeTelemetrySql } from "./perf/execute";
+
+async function main(): Promise<void> {
+  const sql = Bun.argv.slice(2).join(" ").trim();
+  if (!sql) {
+    throw new Error("Usage: bun run scripts/perf-query.ts '<SQL>'");
+  }
+  const rows = await executeTelemetrySql(sql);
+  process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/backend/scripts/perf-report.ts
+++ b/backend/scripts/perf-report.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+/**
+ * just perf-report の実体。prod TELEMETRY_DB の固定集計を JSON で出力する。
+ */
+
+import {
+  buildByDeviceQuery,
+  buildByRefreshRateQuery,
+  buildByScreenQuery,
+  buildPerfReport,
+  buildVersionComparisonQuery,
+  parseOptionalBuildNumber,
+  type AggregateRow,
+  type VersionPairRow,
+} from "./perf/report";
+import { executeTelemetrySql } from "./perf/execute";
+
+function asAggregateRows(rows: Record<string, unknown>[]): AggregateRow[] {
+  return rows.map((row) => {
+    const result: AggregateRow = {
+      session_count: Number(row.session_count ?? 0),
+      frame_count: Number(row.frame_count ?? 0),
+      slow_build_count: Number(row.slow_build_count ?? 0),
+      slow_raster_count: Number(row.slow_raster_count ?? 0),
+      frozen_count: Number(row.frozen_count ?? 0),
+    };
+    if (typeof row.screen_name === "string") {
+      result.screen_name = row.screen_name;
+    }
+    if (typeof row.device_model === "string") {
+      result.device_model = row.device_model;
+    }
+    if (typeof row.refresh_rate_hz === "number" || typeof row.refresh_rate_hz === "string") {
+      result.refresh_rate_hz = Number(row.refresh_rate_hz);
+    }
+    return result;
+  });
+}
+
+function asVersionPairRows(rows: Record<string, unknown>[]): VersionPairRow[] {
+  return rows.map((row) => ({
+    platform: String(row.platform),
+    flavor: String(row.flavor),
+    screen_name: String(row.screen_name),
+    latest_build_number: Number(row.latest_build_number),
+    previous_build_number:
+      row.previous_build_number === null || row.previous_build_number === undefined
+        ? null
+        : Number(row.previous_build_number),
+    latest_session_count: Number(row.latest_session_count ?? 0),
+    latest_frame_count: Number(row.latest_frame_count ?? 0),
+    latest_slow_build_count: Number(row.latest_slow_build_count ?? 0),
+    latest_slow_raster_count: Number(row.latest_slow_raster_count ?? 0),
+    latest_frozen_count: Number(row.latest_frozen_count ?? 0),
+    previous_session_count: Number(row.previous_session_count ?? 0),
+    previous_frame_count: Number(row.previous_frame_count ?? 0),
+    previous_slow_build_count: Number(row.previous_slow_build_count ?? 0),
+    previous_slow_raster_count: Number(row.previous_slow_raster_count ?? 0),
+    previous_frozen_count: Number(row.previous_frozen_count ?? 0),
+  }));
+}
+
+async function main(): Promise<void> {
+  const buildNumber = parseOptionalBuildNumber(Bun.argv.slice(2));
+  const [byScreen, versionComparison, byDevice, byRefreshRate] = await Promise.all([
+    executeTelemetrySql(buildByScreenQuery(buildNumber)).then(asAggregateRows),
+    executeTelemetrySql(buildVersionComparisonQuery()).then(asVersionPairRows),
+    executeTelemetrySql(buildByDeviceQuery(buildNumber)).then(asAggregateRows),
+    executeTelemetrySql(buildByRefreshRateQuery(buildNumber)).then(asAggregateRows),
+  ]);
+
+  const report = buildPerfReport({
+    buildNumber,
+    byScreen,
+    versionComparison,
+    byDevice,
+    byRefreshRate,
+  });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/backend/scripts/perf-report.ts
+++ b/backend/scripts/perf-report.ts
@@ -64,7 +64,7 @@ async function main(): Promise<void> {
   const buildNumber = parseOptionalBuildNumber(Bun.argv.slice(2));
   const [byScreen, versionComparison, byDevice, byRefreshRate] = await Promise.all([
     executeTelemetrySql(buildByScreenQuery(buildNumber)).then(asAggregateRows),
-    executeTelemetrySql(buildVersionComparisonQuery()).then(asVersionPairRows),
+    executeTelemetrySql(buildVersionComparisonQuery(buildNumber)).then(asVersionPairRows),
     executeTelemetrySql(buildByDeviceQuery(buildNumber)).then(asAggregateRows),
     executeTelemetrySql(buildByRefreshRateQuery(buildNumber)).then(asAggregateRows),
   ]);

--- a/backend/scripts/perf/execute.test.ts
+++ b/backend/scripts/perf/execute.test.ts
@@ -4,6 +4,7 @@ import {
   assertReadOnlySql,
   executeTelemetrySql,
   extractD1Rows,
+  formatWranglerFailure,
   parsePerfQueryArgs,
   requireCloudflareApiToken,
 } from "./execute";
@@ -114,5 +115,22 @@ describe("executeTelemetrySql", () => {
         run: async () => "wrangler banner\nnot-json",
       }),
     ).rejects.toThrow(/Failed to parse wrangler JSON[\s\S]*wrangler banner/);
+  });
+
+  test("失敗時は stderr があっても stdout の本体エラーを落とさない", () => {
+    expect(
+      formatWranglerFailure(
+        1,
+        '{\n  "error": { "text": "Authentication error [code: 10000]" }\n}',
+        "▲ [WARNING] Processing wrangler.toml configuration:",
+      ),
+    ).toContain("Authentication error [code: 10000]");
+    expect(
+      formatWranglerFailure(
+        1,
+        '{\n  "error": { "text": "Authentication error [code: 10000]" }\n}',
+        "▲ [WARNING] Processing wrangler.toml configuration:",
+      ),
+    ).toContain("WARNING");
   });
 });

--- a/backend/scripts/perf/execute.test.ts
+++ b/backend/scripts/perf/execute.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { extractD1Rows, requireCloudflareApiToken } from "./execute";
+import {
+  assertReadOnlySql,
+  executeTelemetrySql,
+  extractD1Rows,
+  parsePerfQueryArgs,
+  requireCloudflareApiToken,
+} from "./execute";
 
 describe("requireCloudflareApiToken", () => {
   test("未設定ならエラー", () => {
@@ -35,5 +41,78 @@ describe("extractD1Rows", () => {
 
   test("不正な JSON 形状はエラー", () => {
     expect(() => extractD1Rows({ results: [] })).toThrow();
+  });
+});
+
+describe("assertReadOnlySql", () => {
+  test("SELECT / WITH を許可する", () => {
+    expect(() => assertReadOnlySql("SELECT 1")).not.toThrow();
+    expect(() => assertReadOnlySql("  with x AS (SELECT 1) SELECT * FROM x")).not.toThrow();
+  });
+
+  test("mutation を拒否する", () => {
+    expect(() => assertReadOnlySql("INSERT INTO frame_stats (id) VALUES ('x')")).toThrow(
+      /SELECT|WITH/,
+    );
+    expect(() => assertReadOnlySql("DELETE FROM frame_stats")).toThrow(/SELECT|WITH/);
+  });
+});
+
+describe("parsePerfQueryArgs", () => {
+  test("単一の SQL 引数を返す", () => {
+    expect(parsePerfQueryArgs(["SELECT 1"])).toBe("SELECT 1");
+  });
+
+  test("引数なし・複数引数はエラー", () => {
+    expect(() => parsePerfQueryArgs([])).toThrow(/Usage/);
+    expect(() => parsePerfQueryArgs(["SELECT", "1"])).toThrow(/single/);
+  });
+});
+
+describe("executeTelemetrySql", () => {
+  test("prod TELEMETRY_DB 向けの wrangler 引数と token 上書きを組み立てる", async () => {
+    let capturedArgs: string[] | undefined;
+    let capturedEnv: Record<string, string> | undefined;
+
+    const rows = await executeTelemetrySql("SELECT 1 AS n", {
+      env: {
+        CLOUDFLARE_API_TOKEN: "read-only-token",
+        PATH: "/usr/bin",
+        OTHER: undefined,
+      },
+      run: async (args, env) => {
+        capturedArgs = args;
+        capturedEnv = env;
+        return JSON.stringify([{ results: [{ n: 1 }], success: true }]);
+      },
+    });
+
+    expect(rows).toEqual([{ n: 1 }]);
+    expect(capturedArgs).toEqual([
+      "bunx",
+      "wrangler",
+      "d1",
+      "execute",
+      "TELEMETRY_DB",
+      "--env",
+      "prod",
+      "--remote",
+      "--json",
+      "--command",
+      "SELECT 1 AS n",
+    ]);
+    expect(capturedEnv).toEqual({
+      PATH: "/usr/bin",
+      CLOUDFLARE_API_TOKEN: "read-only-token",
+    });
+  });
+
+  test("stdout が JSON でない場合は先頭を含めてエラーにする", async () => {
+    await expect(
+      executeTelemetrySql("SELECT 1", {
+        env: { CLOUDFLARE_API_TOKEN: "token" },
+        run: async () => "wrangler banner\nnot-json",
+      }),
+    ).rejects.toThrow(/Failed to parse wrangler JSON[\s\S]*wrangler banner/);
   });
 });

--- a/backend/scripts/perf/execute.test.ts
+++ b/backend/scripts/perf/execute.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractD1Rows, requireCloudflareApiToken } from "./execute";
+
+describe("requireCloudflareApiToken", () => {
+  test("未設定ならエラー", () => {
+    expect(() => requireCloudflareApiToken({})).toThrow(/CLOUDFLARE_API_TOKEN/);
+  });
+
+  test("空文字ならエラー", () => {
+    expect(() => requireCloudflareApiToken({ CLOUDFLARE_API_TOKEN: "  " })).toThrow(
+      /CLOUDFLARE_API_TOKEN/,
+    );
+  });
+
+  test("設定されていれば値を返す", () => {
+    expect(requireCloudflareApiToken({ CLOUDFLARE_API_TOKEN: "token" })).toBe("token");
+  });
+});
+
+describe("extractD1Rows", () => {
+  test("wrangler --json の配列形式から results を取り出す", () => {
+    const rows = extractD1Rows([
+      {
+        results: [{ screen_name: "HomeRoute", frame_count: 10 }],
+        success: true,
+      },
+    ]);
+    expect(rows).toEqual([{ screen_name: "HomeRoute", frame_count: 10 }]);
+  });
+
+  test("results が無い場合は空配列", () => {
+    expect(extractD1Rows([{ success: true }])).toEqual([]);
+  });
+
+  test("不正な JSON 形状はエラー", () => {
+    expect(() => extractD1Rows({ results: [] })).toThrow();
+  });
+});

--- a/backend/scripts/perf/execute.ts
+++ b/backend/scripts/perf/execute.ts
@@ -1,6 +1,7 @@
 /**
  * prod TELEMETRY_DB への read-only 実行ヘルパー。
  * mutation は Cloudflare API token の権限で拒否される前提。
+ * perf-query 側でも SELECT/WITH 以外を弾く。
  */
 
 export function requireCloudflareApiToken(
@@ -15,6 +16,27 @@ export function requireCloudflareApiToken(
   return token;
 }
 
+export function assertReadOnlySql(sql: string): void {
+  if (!/^\s*(SELECT|WITH)\b/i.test(sql)) {
+    throw new Error("Only SELECT/WITH queries are allowed via perf-query.");
+  }
+}
+
+export function parsePerfQueryArgs(args: string[]): string {
+  if (args.length === 0) {
+    throw new Error("Usage: bun run scripts/perf-query.ts '<SQL>'");
+  }
+  if (args.length !== 1) {
+    throw new Error("perf-query expects a single SQL argument.");
+  }
+  const sql = args[0]?.trim() ?? "";
+  if (!sql) {
+    throw new Error("Usage: bun run scripts/perf-query.ts '<SQL>'");
+  }
+  assertReadOnlySql(sql);
+  return sql;
+}
+
 export function extractD1Rows(parsed: unknown): Record<string, unknown>[] {
   if (!Array.isArray(parsed) || parsed.length === 0) {
     throw new Error("Unexpected wrangler d1 execute --json shape: expected non-empty array");
@@ -27,6 +49,18 @@ export function extractD1Rows(parsed: unknown): Record<string, unknown>[] {
     throw new Error("Unexpected wrangler d1 execute --json shape: results is not an array");
   }
   return first.results as Record<string, unknown>[];
+}
+
+function parseWranglerJson(stdout: string): unknown {
+  try {
+    return JSON.parse(stdout) as unknown;
+  } catch (error) {
+    const preview = stdout.slice(0, 200);
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse wrangler JSON (${reason}): ${preview}`, {
+      cause: error,
+    });
+  }
 }
 
 export async function executeTelemetrySql(
@@ -82,5 +116,5 @@ export async function executeTelemetrySql(
     },
   );
 
-  return extractD1Rows(JSON.parse(stdout) as unknown);
+  return extractD1Rows(parseWranglerJson(stdout));
 }

--- a/backend/scripts/perf/execute.ts
+++ b/backend/scripts/perf/execute.ts
@@ -1,7 +1,8 @@
 /**
  * prod TELEMETRY_DB への read-only 実行ヘルパー。
- * mutation は Cloudflare API token の権限で拒否される前提。
- * perf-query 側でも SELECT/WITH 以外を弾く。
+ * mutation の実効防御は perf-query の SELECT/WITH ガード。
+ * CLOUDFLARE_API_TOKEN は D1 Read を運用前提とするが、Read でも
+ * wrangler d1 execute --remote の INSERT が SQL 実行まで到達しうる（実測）。
  */
 
 export function requireCloudflareApiToken(
@@ -51,6 +52,23 @@ export function extractD1Rows(parsed: unknown): Record<string, unknown>[] {
   return first.results as Record<string, unknown>[];
 }
 
+/** wrangler は設定 WARNING を stderr、API エラー JSON を stdout に出すことがある */
+export function formatWranglerFailure(exitCode: number, stdout: string, stderr: string): string {
+  const parts = [`wrangler d1 execute failed (exit ${exitCode}):`];
+  const err = stderr.trim();
+  const out = stdout.trim();
+  if (err) {
+    parts.push(err);
+  }
+  if (out) {
+    parts.push(out);
+  }
+  if (!err && !out) {
+    parts.push("(no output)");
+  }
+  return parts.join("\n");
+}
+
 function parseWranglerJson(stdout: string): unknown {
   try {
     return JSON.parse(stdout) as unknown;
@@ -87,7 +105,7 @@ export async function executeTelemetrySql(
         proc.exited,
       ]);
       if (exitCode !== 0) {
-        throw new Error(`wrangler d1 execute failed (exit ${exitCode}):\n${stderr || stdout}`);
+        throw new Error(formatWranglerFailure(exitCode, stdout, stderr));
       }
       return stdout;
     });

--- a/backend/scripts/perf/execute.ts
+++ b/backend/scripts/perf/execute.ts
@@ -1,0 +1,86 @@
+/**
+ * prod TELEMETRY_DB への read-only 実行ヘルパー。
+ * mutation は Cloudflare API token の権限で拒否される前提。
+ */
+
+export function requireCloudflareApiToken(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const token = env.CLOUDFLARE_API_TOKEN?.trim();
+  if (!token) {
+    throw new Error(
+      "CLOUDFLARE_API_TOKEN is required. Use a Cloudflare API token with D1 Read only.",
+    );
+  }
+  return token;
+}
+
+export function extractD1Rows(parsed: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("Unexpected wrangler d1 execute --json shape: expected non-empty array");
+  }
+  const first = parsed[0] as { results?: unknown };
+  if (first.results === undefined) {
+    return [];
+  }
+  if (!Array.isArray(first.results)) {
+    throw new Error("Unexpected wrangler d1 execute --json shape: results is not an array");
+  }
+  return first.results as Record<string, unknown>[];
+}
+
+export async function executeTelemetrySql(
+  sql: string,
+  options: {
+    env?: Record<string, string | undefined>;
+    run?: (args: string[], env: Record<string, string>) => Promise<string>;
+  } = {},
+): Promise<Record<string, unknown>[]> {
+  const processEnv = options.env ?? process.env;
+  const token = requireCloudflareApiToken(processEnv);
+  const run =
+    options.run ??
+    (async (args, env) => {
+      const proc = Bun.spawn(args, {
+        cwd: process.cwd(),
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      if (exitCode !== 0) {
+        throw new Error(`wrangler d1 execute failed (exit ${exitCode}):\n${stderr || stdout}`);
+      }
+      return stdout;
+    });
+
+  const stdout = await run(
+    [
+      "bunx",
+      "wrangler",
+      "d1",
+      "execute",
+      "TELEMETRY_DB",
+      "--env",
+      "prod",
+      "--remote",
+      "--json",
+      "--command",
+      sql,
+    ],
+    {
+      ...Object.fromEntries(
+        Object.entries(processEnv).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined,
+        ),
+      ),
+      CLOUDFLARE_API_TOKEN: token,
+    },
+  );
+
+  return extractD1Rows(JSON.parse(stdout) as unknown);
+}

--- a/backend/scripts/perf/report.test.ts
+++ b/backend/scripts/perf/report.test.ts
@@ -16,6 +16,8 @@ describe("parseOptionalBuildNumber", () => {
   test("未指定は null", () => {
     expect(parseOptionalBuildNumber(undefined)).toBeNull();
     expect(parseOptionalBuildNumber([])).toBeNull();
+    // just perf-report のデフォルト build_number="" が argv に載る
+    expect(parseOptionalBuildNumber([""])).toBeNull();
   });
 
   test("正の整数を受け付ける", () => {
@@ -77,6 +79,13 @@ describe("SQL builders", () => {
     expect(sql).toContain("LEFT JOIN previous_builds pb");
     expect(sql).toContain("LEFT JOIN previous_stats p");
     expect(sql).toContain("pb.previous_build_number");
+  });
+
+  test("バージョン比較の ORDER BY は latest_stats.frame_count を参照する", () => {
+    // l.latest_frame_count は SELECT 別名であり CTE 列ではない（D1 SQLITE_ERROR 7500）
+    const sql = buildVersionComparisonQuery(null);
+    expect(sql).toContain("ORDER BY l.platform, l.flavor, l.frame_count DESC");
+    expect(sql).not.toContain("l.latest_frame_count");
   });
 
   test("端末別・リフレッシュレート別もサンプル数を含む", () => {

--- a/backend/scripts/perf/report.test.ts
+++ b/backend/scripts/perf/report.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildByDeviceQuery,
+  buildByRefreshRateQuery,
+  buildByScreenQuery,
+  buildPerfReport,
+  buildVersionComparisonQuery,
+  parseOptionalBuildNumber,
+  rate,
+  type AggregateRow,
+  type VersionPairRow,
+} from "./report";
+
+describe("parseOptionalBuildNumber", () => {
+  test("未指定は null", () => {
+    expect(parseOptionalBuildNumber(undefined)).toBeNull();
+    expect(parseOptionalBuildNumber([])).toBeNull();
+  });
+
+  test("正の整数を受け付ける", () => {
+    expect(parseOptionalBuildNumber(["42"])).toBe(42);
+  });
+
+  test("不正な値はエラー", () => {
+    expect(() => parseOptionalBuildNumber(["0"])).toThrow();
+    expect(() => parseOptionalBuildNumber(["-1"])).toThrow();
+    expect(() => parseOptionalBuildNumber(["1.5"])).toThrow();
+    expect(() => parseOptionalBuildNumber(["abc"])).toThrow();
+  });
+});
+
+describe("rate", () => {
+  test("分母0は null", () => {
+    expect(rate(1, 0)).toBeNull();
+  });
+
+  test("比率を返す", () => {
+    expect(rate(1, 4)).toBe(0.25);
+  });
+});
+
+describe("SQL builders", () => {
+  test("画面別クエリは build_number フィルタなしで全件集計する", () => {
+    const sql = buildByScreenQuery(null);
+    expect(sql).toContain("GROUP BY screen_name");
+    expect(sql).not.toContain("build_number =");
+    expect(sql).toContain("COUNT(DISTINCT session_id) AS session_count");
+    expect(sql).toContain("SUM(frame_count) AS frame_count");
+  });
+
+  test("画面別クエリは build_number で絞り込む", () => {
+    const sql = buildByScreenQuery(100);
+    expect(sql).toContain("build_number = 100");
+  });
+
+  test("バージョン比較は platform + flavor ごとに build_number で最新と直前を選ぶ", () => {
+    const sql = buildVersionComparisonQuery();
+    expect(sql).toContain("ORDER BY build_number DESC");
+    expect(sql).toContain("platform");
+    expect(sql).toContain("flavor");
+    expect(sql).toContain("latest_build_number");
+    expect(sql).toContain("previous_build_number");
+    expect(sql).not.toContain("ORDER BY app_version");
+  });
+
+  test("端末別・リフレッシュレート別もサンプル数を含む", () => {
+    expect(buildByDeviceQuery(null)).toContain("session_count");
+    expect(buildByRefreshRateQuery(7)).toContain("build_number = 7");
+  });
+});
+
+describe("buildPerfReport", () => {
+  const screenRows: AggregateRow[] = [
+    {
+      screen_name: "HomeRoute",
+      session_count: 10,
+      frame_count: 1000,
+      slow_build_count: 50,
+      slow_raster_count: 20,
+      frozen_count: 1,
+    },
+    {
+      screen_name: "SparseRoute",
+      session_count: 1,
+      frame_count: 5,
+      slow_build_count: 4,
+      slow_raster_count: 0,
+      frozen_count: 0,
+    },
+  ];
+
+  const versionRows: VersionPairRow[] = [
+    {
+      platform: "ios",
+      flavor: "prod",
+      screen_name: "HomeRoute",
+      latest_build_number: 12,
+      previous_build_number: 11,
+      latest_session_count: 8,
+      latest_frame_count: 800,
+      latest_slow_build_count: 40,
+      latest_slow_raster_count: 16,
+      latest_frozen_count: 0,
+      previous_session_count: 10,
+      previous_frame_count: 1000,
+      previous_slow_build_count: 30,
+      previous_slow_raster_count: 10,
+      previous_frozen_count: 0,
+    },
+  ];
+
+  const deviceRows: AggregateRow[] = [
+    {
+      device_model: "iPhone17,1",
+      session_count: 5,
+      frame_count: 500,
+      slow_build_count: 10,
+      slow_raster_count: 5,
+      frozen_count: 0,
+    },
+  ];
+
+  const refreshRows: AggregateRow[] = [
+    {
+      refresh_rate_hz: 120,
+      session_count: 7,
+      frame_count: 700,
+      slow_build_count: 70,
+      slow_raster_count: 14,
+      frozen_count: 0,
+    },
+  ];
+
+  test("画面別ジャンク率とサンプル数を含める", () => {
+    const report = buildPerfReport({
+      buildNumber: null,
+      byScreen: screenRows,
+      versionComparison: versionRows,
+      byDevice: deviceRows,
+      byRefreshRate: refreshRows,
+    });
+
+    expect(report.buildNumberFilter).toBeNull();
+    expect(report.byScreen).toEqual([
+      {
+        screenName: "HomeRoute",
+        sessionCount: 10,
+        frameCount: 1000,
+        slowBuildRate: 0.05,
+        slowRasterRate: 0.02,
+        frozenRate: 0.001,
+      },
+      {
+        screenName: "SparseRoute",
+        sessionCount: 1,
+        frameCount: 5,
+        slowBuildRate: 0.8,
+        slowRasterRate: 0,
+        frozenRate: 0,
+      },
+    ]);
+  });
+
+  test("バージョン比較は build_number 基準で前後レートを出す", () => {
+    const report = buildPerfReport({
+      buildNumber: 12,
+      byScreen: screenRows,
+      versionComparison: versionRows,
+      byDevice: deviceRows,
+      byRefreshRate: refreshRows,
+    });
+
+    expect(report.buildNumberFilter).toBe(12);
+    expect(report.versionComparison).toEqual([
+      {
+        platform: "ios",
+        flavor: "prod",
+        screenName: "HomeRoute",
+        latestBuildNumber: 12,
+        previousBuildNumber: 11,
+        latest: {
+          sessionCount: 8,
+          frameCount: 800,
+          slowBuildRate: 0.05,
+          slowRasterRate: 0.02,
+          frozenRate: 0,
+        },
+        previous: {
+          sessionCount: 10,
+          frameCount: 1000,
+          slowBuildRate: 0.03,
+          slowRasterRate: 0.01,
+          frozenRate: 0,
+        },
+      },
+    ]);
+  });
+
+  test("端末別・リフレッシュレート別の内訳を含める", () => {
+    const report = buildPerfReport({
+      buildNumber: null,
+      byScreen: [],
+      versionComparison: [],
+      byDevice: deviceRows,
+      byRefreshRate: refreshRows,
+    });
+
+    expect(report.byDevice[0]).toMatchObject({
+      deviceModel: "iPhone17,1",
+      sessionCount: 5,
+      frameCount: 500,
+      slowBuildRate: 0.02,
+    });
+    expect(report.byRefreshRate[0]).toMatchObject({
+      refreshRateHz: 120,
+      sessionCount: 7,
+      frameCount: 700,
+      slowBuildRate: 0.1,
+    });
+  });
+});

--- a/backend/scripts/perf/report.test.ts
+++ b/backend/scripts/perf/report.test.ts
@@ -55,13 +55,28 @@ describe("SQL builders", () => {
   });
 
   test("バージョン比較は platform + flavor ごとに build_number で最新と直前を選ぶ", () => {
-    const sql = buildVersionComparisonQuery();
+    const sql = buildVersionComparisonQuery(null);
     expect(sql).toContain("ORDER BY build_number DESC");
     expect(sql).toContain("platform");
     expect(sql).toContain("flavor");
     expect(sql).toContain("latest_build_number");
     expect(sql).toContain("previous_build_number");
     expect(sql).not.toContain("ORDER BY app_version");
+    expect(sql).toContain("DENSE_RANK()");
+  });
+
+  test("バージョン比較は指定 build_number を latest に固定する", () => {
+    const sql = buildVersionComparisonQuery(42);
+    expect(sql).toContain("42 AS latest_build_number");
+    expect(sql).toContain("f.build_number < lb.latest_build_number");
+    expect(sql).not.toContain("DENSE_RANK()");
+  });
+
+  test("バージョン比較は previous_builds を画面と独立に結合する", () => {
+    const sql = buildVersionComparisonQuery(null);
+    expect(sql).toContain("LEFT JOIN previous_builds pb");
+    expect(sql).toContain("LEFT JOIN previous_stats p");
+    expect(sql).toContain("pb.previous_build_number");
   });
 
   test("端末別・リフレッシュレート別もサンプル数を含む", () => {
@@ -132,6 +147,8 @@ describe("buildPerfReport", () => {
     },
   ];
 
+  const generatedAt = "2026-07-27T00:00:00.000Z";
+
   test("画面別ジャンク率とサンプル数を含める", () => {
     const report = buildPerfReport({
       buildNumber: null,
@@ -139,8 +156,10 @@ describe("buildPerfReport", () => {
       versionComparison: versionRows,
       byDevice: deviceRows,
       byRefreshRate: refreshRows,
+      generatedAt,
     });
 
+    expect(report.generatedAt).toBe(generatedAt);
     expect(report.buildNumberFilter).toBeNull();
     expect(report.byScreen).toEqual([
       {
@@ -169,6 +188,7 @@ describe("buildPerfReport", () => {
       versionComparison: versionRows,
       byDevice: deviceRows,
       byRefreshRate: refreshRows,
+      generatedAt,
     });
 
     expect(report.buildNumberFilter).toBe(12);
@@ -197,6 +217,48 @@ describe("buildPerfReport", () => {
     ]);
   });
 
+  test("直前ビルド番号はあるが画面未観測なら previous はゼロのまま build 番号を残す", () => {
+    const report = buildPerfReport({
+      buildNumber: 12,
+      byScreen: [],
+      versionComparison: [
+        {
+          platform: "ios",
+          flavor: "prod",
+          screen_name: "NewRoute",
+          latest_build_number: 12,
+          previous_build_number: 11,
+          latest_session_count: 3,
+          latest_frame_count: 300,
+          latest_slow_build_count: 0,
+          latest_slow_raster_count: 0,
+          latest_frozen_count: 0,
+          previous_session_count: 0,
+          previous_frame_count: 0,
+          previous_slow_build_count: 0,
+          previous_slow_raster_count: 0,
+          previous_frozen_count: 0,
+        },
+      ],
+      byDevice: [],
+      byRefreshRate: [],
+      generatedAt,
+    });
+
+    expect(report.versionComparison[0]).toMatchObject({
+      screenName: "NewRoute",
+      latestBuildNumber: 12,
+      previousBuildNumber: 11,
+      previous: {
+        sessionCount: 0,
+        frameCount: 0,
+        slowBuildRate: null,
+        slowRasterRate: null,
+        frozenRate: null,
+      },
+    });
+  });
+
   test("端末別・リフレッシュレート別の内訳を含める", () => {
     const report = buildPerfReport({
       buildNumber: null,
@@ -204,6 +266,7 @@ describe("buildPerfReport", () => {
       versionComparison: [],
       byDevice: deviceRows,
       byRefreshRate: refreshRows,
+      generatedAt,
     });
 
     expect(report.byDevice[0]).toMatchObject({

--- a/backend/scripts/perf/report.ts
+++ b/backend/scripts/perf/report.ts
@@ -1,0 +1,279 @@
+/**
+ * パフォーマンス分析用の固定集計。
+ * AI 主導線は just perf-report。raw SQL は just perf-query（手動調査用）。
+ */
+
+export type AggregateRow = {
+  screen_name?: string;
+  device_model?: string;
+  refresh_rate_hz?: number;
+  session_count: number;
+  frame_count: number;
+  slow_build_count: number;
+  slow_raster_count: number;
+  frozen_count: number;
+};
+
+export type VersionPairRow = {
+  platform: string;
+  flavor: string;
+  screen_name: string;
+  latest_build_number: number;
+  previous_build_number: number | null;
+  latest_session_count: number;
+  latest_frame_count: number;
+  latest_slow_build_count: number;
+  latest_slow_raster_count: number;
+  latest_frozen_count: number;
+  previous_session_count: number;
+  previous_frame_count: number;
+  previous_slow_build_count: number;
+  previous_slow_raster_count: number;
+  previous_frozen_count: number;
+};
+
+export type RateBlock = {
+  sessionCount: number;
+  frameCount: number;
+  slowBuildRate: number | null;
+  slowRasterRate: number | null;
+  frozenRate: number | null;
+};
+
+export type PerfReport = {
+  generatedAt: string;
+  buildNumberFilter: number | null;
+  byScreen: Array<RateBlock & { screenName: string }>;
+  versionComparison: Array<{
+    platform: string;
+    flavor: string;
+    screenName: string;
+    latestBuildNumber: number;
+    previousBuildNumber: number | null;
+    latest: RateBlock;
+    previous: RateBlock;
+  }>;
+  byDevice: Array<RateBlock & { deviceModel: string }>;
+  byRefreshRate: Array<RateBlock & { refreshRateHz: number }>;
+};
+
+export function parseOptionalBuildNumber(args: string[] | undefined): number | null {
+  if (args === undefined || args.length === 0) {
+    return null;
+  }
+  const raw = args[0];
+  if (raw === undefined || !/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`build_number must be a positive integer, got: ${raw ?? "(empty)"}`);
+  }
+  return Number(raw);
+}
+
+export function rate(numerator: number, denominator: number): number | null {
+  if (denominator === 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function buildNumberFilterSql(buildNumber: number | null): string {
+  return buildNumber === null ? "" : `WHERE build_number = ${buildNumber}`;
+}
+
+const aggregateSelect = `
+  COUNT(DISTINCT session_id) AS session_count,
+  SUM(frame_count) AS frame_count,
+  SUM(slow_build_count) AS slow_build_count,
+  SUM(slow_raster_count) AS slow_raster_count,
+  SUM(frozen_count) AS frozen_count
+`.trim();
+
+export function buildByScreenQuery(buildNumber: number | null): string {
+  const where = buildNumberFilterSql(buildNumber);
+  return `
+SELECT
+  screen_name,
+  ${aggregateSelect}
+FROM frame_stats
+${where}
+GROUP BY screen_name
+ORDER BY frame_count DESC
+`.trim();
+}
+
+export function buildByDeviceQuery(buildNumber: number | null): string {
+  const where = buildNumberFilterSql(buildNumber);
+  return `
+SELECT
+  device_model,
+  ${aggregateSelect}
+FROM frame_stats
+${where}
+GROUP BY device_model
+ORDER BY frame_count DESC
+`.trim();
+}
+
+export function buildByRefreshRateQuery(buildNumber: number | null): string {
+  const where = buildNumberFilterSql(buildNumber);
+  return `
+SELECT
+  refresh_rate_hz,
+  ${aggregateSelect}
+FROM frame_stats
+${where}
+GROUP BY refresh_rate_hz
+ORDER BY refresh_rate_hz DESC
+`.trim();
+}
+
+/**
+ * platform + flavor ごとに数値 build_number で最新と直前を選び、画面別に比較する。
+ * app_version の文字列順は使わない（semver 辞書順が壊れるため）。
+ */
+export function buildVersionComparisonQuery(): string {
+  return `
+WITH ranked_builds AS (
+  SELECT
+    platform,
+    flavor,
+    build_number,
+    DENSE_RANK() OVER (
+      PARTITION BY platform, flavor
+      ORDER BY build_number DESC
+    ) AS build_rank
+  FROM frame_stats
+  GROUP BY platform, flavor, build_number
+),
+latest_builds AS (
+  SELECT platform, flavor, build_number AS latest_build_number
+  FROM ranked_builds
+  WHERE build_rank = 1
+),
+previous_builds AS (
+  SELECT platform, flavor, build_number AS previous_build_number
+  FROM ranked_builds
+  WHERE build_rank = 2
+),
+latest_stats AS (
+  SELECT
+    f.platform,
+    f.flavor,
+    f.screen_name,
+    lb.latest_build_number,
+    COUNT(DISTINCT f.session_id) AS session_count,
+    SUM(f.frame_count) AS frame_count,
+    SUM(f.slow_build_count) AS slow_build_count,
+    SUM(f.slow_raster_count) AS slow_raster_count,
+    SUM(f.frozen_count) AS frozen_count
+  FROM frame_stats f
+  INNER JOIN latest_builds lb
+    ON f.platform = lb.platform
+   AND f.flavor = lb.flavor
+   AND f.build_number = lb.latest_build_number
+  GROUP BY f.platform, f.flavor, f.screen_name, lb.latest_build_number
+),
+previous_stats AS (
+  SELECT
+    f.platform,
+    f.flavor,
+    f.screen_name,
+    pb.previous_build_number,
+    COUNT(DISTINCT f.session_id) AS session_count,
+    SUM(f.frame_count) AS frame_count,
+    SUM(f.slow_build_count) AS slow_build_count,
+    SUM(f.slow_raster_count) AS slow_raster_count,
+    SUM(f.frozen_count) AS frozen_count
+  FROM frame_stats f
+  INNER JOIN previous_builds pb
+    ON f.platform = pb.platform
+   AND f.flavor = pb.flavor
+   AND f.build_number = pb.previous_build_number
+  GROUP BY f.platform, f.flavor, f.screen_name, pb.previous_build_number
+)
+SELECT
+  l.platform,
+  l.flavor,
+  l.screen_name,
+  l.latest_build_number,
+  p.previous_build_number,
+  l.session_count AS latest_session_count,
+  l.frame_count AS latest_frame_count,
+  l.slow_build_count AS latest_slow_build_count,
+  l.slow_raster_count AS latest_slow_raster_count,
+  l.frozen_count AS latest_frozen_count,
+  COALESCE(p.session_count, 0) AS previous_session_count,
+  COALESCE(p.frame_count, 0) AS previous_frame_count,
+  COALESCE(p.slow_build_count, 0) AS previous_slow_build_count,
+  COALESCE(p.slow_raster_count, 0) AS previous_slow_raster_count,
+  COALESCE(p.frozen_count, 0) AS previous_frozen_count
+FROM latest_stats l
+LEFT JOIN previous_stats p
+  ON l.platform = p.platform
+ AND l.flavor = p.flavor
+ AND l.screen_name = p.screen_name
+ORDER BY l.platform, l.flavor, l.latest_frame_count DESC
+`.trim();
+}
+
+function toRateBlock(row: {
+  session_count: number;
+  frame_count: number;
+  slow_build_count: number;
+  slow_raster_count: number;
+  frozen_count: number;
+}): RateBlock {
+  return {
+    sessionCount: row.session_count,
+    frameCount: row.frame_count,
+    slowBuildRate: rate(row.slow_build_count, row.frame_count),
+    slowRasterRate: rate(row.slow_raster_count, row.frame_count),
+    frozenRate: rate(row.frozen_count, row.frame_count),
+  };
+}
+
+export function buildPerfReport(input: {
+  buildNumber: number | null;
+  byScreen: AggregateRow[];
+  versionComparison: VersionPairRow[];
+  byDevice: AggregateRow[];
+  byRefreshRate: AggregateRow[];
+  generatedAt?: string;
+}): PerfReport {
+  return {
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    buildNumberFilter: input.buildNumber,
+    byScreen: input.byScreen.map((row) => ({
+      screenName: String(row.screen_name),
+      ...toRateBlock(row),
+    })),
+    versionComparison: input.versionComparison.map((row) => ({
+      platform: row.platform,
+      flavor: row.flavor,
+      screenName: row.screen_name,
+      latestBuildNumber: row.latest_build_number,
+      previousBuildNumber: row.previous_build_number,
+      latest: toRateBlock({
+        session_count: row.latest_session_count,
+        frame_count: row.latest_frame_count,
+        slow_build_count: row.latest_slow_build_count,
+        slow_raster_count: row.latest_slow_raster_count,
+        frozen_count: row.latest_frozen_count,
+      }),
+      previous: toRateBlock({
+        session_count: row.previous_session_count,
+        frame_count: row.previous_frame_count,
+        slow_build_count: row.previous_slow_build_count,
+        slow_raster_count: row.previous_slow_raster_count,
+        frozen_count: row.previous_frozen_count,
+      }),
+    })),
+    byDevice: input.byDevice.map((row) => ({
+      deviceModel: String(row.device_model),
+      ...toRateBlock(row),
+    })),
+    byRefreshRate: input.byRefreshRate.map((row) => ({
+      refreshRateHz: Number(row.refresh_rate_hz),
+      ...toRateBlock(row),
+    })),
+  };
+}

--- a/backend/scripts/perf/report.ts
+++ b/backend/scripts/perf/report.ts
@@ -62,8 +62,12 @@ export function parseOptionalBuildNumber(args: string[] | undefined): number | n
     return null;
   }
   const raw = args[0];
-  if (raw === undefined || !/^[1-9]\d*$/.test(raw)) {
-    throw new Error(`build_number must be a positive integer, got: ${raw ?? "(empty)"}`);
+  // just のデフォルト build_number="" が argv に載る場合は未指定扱い
+  if (raw === undefined || raw === "") {
+    return null;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`build_number must be a positive integer, got: ${raw}`);
   }
   return Number(raw);
 }
@@ -243,7 +247,7 @@ LEFT JOIN previous_stats p
   ON l.platform = p.platform
  AND l.flavor = p.flavor
  AND l.screen_name = p.screen_name
-ORDER BY l.platform, l.flavor, l.latest_frame_count DESC
+ORDER BY l.platform, l.flavor, l.frame_count DESC
 `.trim();
 }
 

--- a/backend/scripts/perf/report.ts
+++ b/backend/scripts/perf/report.ts
@@ -129,10 +129,16 @@ ORDER BY refresh_rate_hz DESC
 /**
  * platform + flavor ごとに数値 build_number で最新と直前を選び、画面別に比較する。
  * app_version の文字列順は使わない（semver 辞書順が壊れるため）。
+ *
+ * buildNumber 指定時はその値を latest に固定し、直前はそれより小さい最大値。
+ * previous_build_number は platform+flavor 単位（画面非依存）。画面未観測なら
+ * previous_* 集計は 0 / null だが previousBuildNumber 自体は残る。
+ * 行は latest 側の画面が起点。直前にあって最新で消えた画面は出ない。
  */
-export function buildVersionComparisonQuery(): string {
-  return `
-WITH ranked_builds AS (
+export function buildVersionComparisonQuery(buildNumber: number | null): string {
+  const latestBuildsCte =
+    buildNumber === null
+      ? `ranked_builds AS (
   SELECT
     platform,
     flavor,
@@ -153,7 +159,30 @@ previous_builds AS (
   SELECT platform, flavor, build_number AS previous_build_number
   FROM ranked_builds
   WHERE build_rank = 2
+)`
+      : `latest_builds AS (
+  SELECT DISTINCT
+    platform,
+    flavor,
+    ${buildNumber} AS latest_build_number
+  FROM frame_stats
+  WHERE build_number = ${buildNumber}
 ),
+previous_builds AS (
+  SELECT
+    f.platform,
+    f.flavor,
+    MAX(f.build_number) AS previous_build_number
+  FROM frame_stats f
+  INNER JOIN latest_builds lb
+    ON f.platform = lb.platform
+   AND f.flavor = lb.flavor
+  WHERE f.build_number < lb.latest_build_number
+  GROUP BY f.platform, f.flavor
+)`;
+
+  return `
+WITH ${latestBuildsCte},
 latest_stats AS (
   SELECT
     f.platform,
@@ -195,7 +224,7 @@ SELECT
   l.flavor,
   l.screen_name,
   l.latest_build_number,
-  p.previous_build_number,
+  pb.previous_build_number,
   l.session_count AS latest_session_count,
   l.frame_count AS latest_frame_count,
   l.slow_build_count AS latest_slow_build_count,
@@ -207,6 +236,9 @@ SELECT
   COALESCE(p.slow_raster_count, 0) AS previous_slow_raster_count,
   COALESCE(p.frozen_count, 0) AS previous_frozen_count
 FROM latest_stats l
+LEFT JOIN previous_builds pb
+  ON l.platform = pb.platform
+ AND l.flavor = pb.flavor
 LEFT JOIN previous_stats p
   ON l.platform = p.platform
  AND l.flavor = p.flavor

--- a/doc/plans/done/2026-07-27-perf-phase2-cli-skill.md
+++ b/doc/plans/done/2026-07-27-perf-phase2-cli-skill.md
@@ -1,0 +1,22 @@
+# Perf Phase 2 — CLI + skill（#290）
+
+## 目的
+
+Phase 1 で蓄積した `frame_stats` を、ダッシュボードなしで AI / CLI から参照できるようにする。
+
+## 実行手順
+
+1. `just perf-query` / `just perf-report` と `backend/scripts/perf/*` を追加する
+2. `.claude/skills/analyzing-app-performance` を追加する
+3. Codex 移植はしない判断を `doc/porting-ai-assets-to-codex.md` に追記する
+4. 仕様に分析導線を追記し、Draft PR を出す
+
+## 完了条件
+
+- [x] `just perf-query` / `just perf-report` が定義されている
+- [x] 分析導線が D1 Read のみの token を前提にしている
+- [x] AI 主導線が `perf-report`、raw SQL は手動調査用に分離されている
+- [x] 新旧判定が `platform + flavor` ごとの `build_number` である
+- [x] 集計にサンプル数が含まれる
+- [x] `analyzing-app-performance` skill がある
+- [x] Codex 移植要否が台帳に反映されている

--- a/doc/plans/done/2026-07-27-perf-phase2-cli-skill.md
+++ b/doc/plans/done/2026-07-27-perf-phase2-cli-skill.md
@@ -14,7 +14,7 @@ Phase 1 で蓄積した `frame_stats` を、ダッシュボードなしで AI / 
 ## 完了条件
 
 - [x] `just perf-query` / `just perf-report` が定義されている
-- [x] 分析導線が D1 Read のみの token を前提にしている
+- [x] 分析導線が D1 Read のみの token を前提にしている（運用上の最小権限。mutation 拒否は CLI ガードが正で、Read token の権限エラーは完了条件にしない）
 - [x] AI 主導線が `perf-report`、raw SQL は手動調査用に分離されている
 - [x] 新旧判定が `platform + flavor` ごとの `build_number` である
 - [x] 集計にサンプル数が含まれる

--- a/doc/porting-ai-assets-to-codex.md
+++ b/doc/porting-ai-assets-to-codex.md
@@ -2,7 +2,7 @@
 
 スキル: porting-ai-assets-to-codex（Claude 側にのみ存在する。移植を実行するのは Claude 側のため）
 
-初版: 2026-07-11 / 最終更新: 2026-07-27（#286）
+初版: 2026-07-11 / 最終更新: 2026-07-27（#290）
 
 ## 位置づけ
 
@@ -33,6 +33,7 @@ Codex で実際に使うものに限定する。Claude 側にあっても、こ�
 | maintaining-ai-docs | AI ドキュメント保守は Claude 側で実施する |
 | dispatching-parallel-agents | Claude のサブエージェント機構前提。Codex に同等機構なし |
 | grilling | Codex では使用実績がない |
+| analyzing-app-performance | 本番テレメトリ分析のオペレーション用。Codex 移植対象の 9 スキルに含めず Claude 側のみで運用する |
 | docbridge-adopt / docbridge-link / docbridge-review | 導入・棚卸し系で、日常の Codex 作業では使わない |
 
 ## hooks の扱い

--- a/doc/specs/app-performance-telemetry.md
+++ b/doc/specs/app-performance-telemetry.md
@@ -57,3 +57,14 @@ build と raster を分けて数えるのは、「Dart 側の再構築が重い�
 クライアント側の `perfTelemetryEnabled`（`GET /v1/app-config`）は**通信量削減の最適化**であり、即時停止の正ではない。`appConfigProvider` は `keepAlive` で起動時に一度しか取得しないため、フラグを false にしても起動中のセッションには反映されない。
 
 即時停止は**受信 API 側の判定**で行う（[workers-api-server.md](workers-api-server.md)）。サーバーはリクエストごとにフラグを読み、false なら 1 行も保存しない。
+
+## 分析導線
+
+ダッシュボードは作らない。蓄積データの参照は CLI のみとする。
+
+| コマンド | 用途 |
+|---|---|
+| `just perf-report [build_number]` | AI / 定型分析の主導線。画面別ジャンク率、`platform + flavor` ごとの `build_number` による最新 vs 直前比較、端末別・リフレッシュレート別内訳を JSON で返す。各集計にセッション数と `frame_count` 合計を含める |
+| `just perf-query '<SQL>'` | 手動調査用の raw SQL。AI の代表導線にはしない |
+
+どちらも prod の `TELEMETRY_DB` を対象とし、**D1 Read のみ**の `CLOUDFLARE_API_TOKEN` を必須とする。手順と指標の解釈は `.claude/skills/analyzing-app-performance/SKILL.md` を正本とする。新旧バージョンの判定は `app_version` 文字列順ではなく数値の `build_number` で行う。

--- a/doc/specs/app-performance-telemetry.md
+++ b/doc/specs/app-performance-telemetry.md
@@ -67,4 +67,4 @@ build と raster を分けて数えるのは、「Dart 側の再構築が重い�
 | `just perf-report [build_number]` | AI / 定型分析の主導線。画面別ジャンク率、`platform + flavor` ごとの `build_number` による最新 vs 直前比較、端末別・リフレッシュレート別内訳を JSON で返す。各集計にセッション数と `frame_count` 合計を含める |
 | `just perf-query '<SQL>'` | 手動調査用の raw SQL。AI の代表導線にはしない |
 
-どちらも prod の `TELEMETRY_DB` を対象とし、**D1 Read のみ**の `CLOUDFLARE_API_TOKEN` を必須とする。手順と指標の解釈は `.claude/skills/analyzing-app-performance/SKILL.md` を正本とする。新旧バージョンの判定は `app_version` 文字列順ではなく数値の `build_number` で行う。
+どちらも prod の `TELEMETRY_DB` を対象とし、**D1 Read のみ**の `CLOUDFLARE_API_TOKEN` を必須とする（運用上の最小権限）。ただし Cloudflare の D1 Read token は `wrangler d1 execute --remote` の mutation を権限エラーで止めないことがあり、**書き込み防止の正は `perf-query` の SELECT/WITH ガード**とする。手順と指標の解釈は `.claude/skills/analyzing-app-performance/SKILL.md` を正本とする。新旧バージョンの判定は `app_version` 文字列順ではなく数値の `build_number` で行う。

--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -220,6 +220,8 @@ kill switch はクライアント任せにせずサーバー側で強制する�
 
 migration は本体とは別系統（`backend/drizzle-telemetry`）で、`just backend-migrate-dev-telemetry` / `just backend-migrate-prod-telemetry` で適用する。`just backend-deploy-dev` / `just backend-deploy-prod` からも依存として実行する。
 
+分析はダッシュボードを作らず、`just perf-report`（定型 JSON）と `just perf-query`（手動 raw SQL）で prod `TELEMETRY_DB` を読む。分析導線は D1 Read のみの API token（`CLOUDFLARE_API_TOKEN`）を使い、AI の主導線は `perf-report` に限定する。詳細は [app-performance-telemetry.md](app-performance-telemetry.md) の「分析導線」と `.claude/skills/analyzing-app-performance/SKILL.md`。
+
 <!-- @code backend/src/maintenance/physical-deletion.ts#runPhysicalDeletion -->
 ## 物理削除
 

--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -220,7 +220,7 @@ kill switch はクライアント任せにせずサーバー側で強制する�
 
 migration は本体とは別系統（`backend/drizzle-telemetry`）で、`just backend-migrate-dev-telemetry` / `just backend-migrate-prod-telemetry` で適用する。`just backend-deploy-dev` / `just backend-deploy-prod` からも依存として実行する。
 
-分析はダッシュボードを作らず、`just perf-report`（定型 JSON）と `just perf-query`（手動 raw SQL）で prod `TELEMETRY_DB` を読む。分析導線は D1 Read のみの API token（`CLOUDFLARE_API_TOKEN`）を使い、AI の主導線は `perf-report` に限定する。詳細は [app-performance-telemetry.md](app-performance-telemetry.md) の「分析導線」と `.claude/skills/analyzing-app-performance/SKILL.md`。
+分析はダッシュボードを作らず、`just perf-report`（定型 JSON）と `just perf-query`（手動 raw SQL）で prod `TELEMETRY_DB` を読む。分析導線は D1 Read のみの API token（`CLOUDFLARE_API_TOKEN`）を使い、AI の主導線は `perf-report` に限定する。mutation の実効防御は `perf-query` の SELECT/WITH ガード（D1 Read が Cloudflare 側で書き込みを拒否する前提にはしない）。詳細は [app-performance-telemetry.md](app-performance-telemetry.md) の「分析導線」と `.claude/skills/analyzing-app-performance/SKILL.md`。
 
 <!-- @code backend/src/maintenance/physical-deletion.ts#runPhysicalDeletion -->
 ## 物理削除

--- a/justfile
+++ b/justfile
@@ -190,5 +190,5 @@ perf-query sql:
     cd backend && bun run scripts/perf-query.ts "{{sql}}"
 
 # AI 用の固定集計 JSON。任意で build_number を渡して絞り込み
-perf-report build_number="":
-    cd backend && bun run scripts/perf-report.ts "{{build_number}}"
+perf-report *build_number:
+    cd backend && bun run scripts/perf-report.ts {{build_number}}

--- a/justfile
+++ b/justfile
@@ -187,20 +187,8 @@ backend-deploy-prod: backend-migrate-prod backend-migrate-prod-telemetry
 
 # 手動調査用の raw SQL。AI 主導線は perf-report を使う
 perf-query sql:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
-      echo 'CLOUDFLARE_API_TOKEN (D1 Read only) is required.' >&2
-      exit 1
-    fi
     cd backend && bun run scripts/perf-query.ts "{{sql}}"
 
 # AI 用の固定集計 JSON。任意で build_number を渡して絞り込み
 perf-report build_number="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
-      echo 'CLOUDFLARE_API_TOKEN (D1 Read only) is required.' >&2
-      exit 1
-    fi
-    cd backend && bun run scripts/perf-report.ts {{build_number}}
+    cd backend && bun run scripts/perf-report.ts "{{build_number}}"

--- a/justfile
+++ b/justfile
@@ -182,3 +182,25 @@ backend-migrate-prod-telemetry:
 # migration（本体 + テレメトリ）を完了してから prod Worker を手動 deploy する
 backend-deploy-prod: backend-migrate-prod backend-migrate-prod-telemetry
     cd backend && bunx wrangler deploy --env prod
+
+# --- perf（本番テレメトリ D1 の分析。D1 Read のみの CLOUDFLARE_API_TOKEN が必須）---
+
+# 手動調査用の raw SQL。AI 主導線は perf-report を使う
+perf-query sql:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+      echo 'CLOUDFLARE_API_TOKEN (D1 Read only) is required.' >&2
+      exit 1
+    fi
+    cd backend && bun run scripts/perf-query.ts "{{sql}}"
+
+# AI 用の固定集計 JSON。任意で build_number を渡して絞り込み
+perf-report build_number="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+      echo 'CLOUDFLARE_API_TOKEN (D1 Read only) is required.' >&2
+      exit 1
+    fi
+    cd backend && bun run scripts/perf-report.ts {{build_number}}


### PR DESCRIPTION
Closes #290（親: #287）

## 概要

Phase 1 で蓄積した `frame_stats` を、ダッシュボードなしで AI / CLI から参照できるようにする。

## 変更内容

- `just perf-report [build_number]` — AI 主導線。画面別ジャンク率、`platform + flavor` ごとの最新 vs 直前 `build_number` 比較、端末別 / リフレッシュレート別内訳を JSON 出力。各集計に `sessionCount` / `frameCount` を含める
- `just perf-query '<SQL>'` — 手動調査用 raw SQL（AI 代表導線には使わない）
- `.claude/skills/analyzing-app-performance` — スキーマ、解釈基準、サンプル数ガード、トークン手順
- Codex 移植はしない判断を `doc/porting-ai-assets-to-codex.md` に追記
- 仕様に「分析導線」を追記

## must-fix への対応

1. **prod D1 への書き込みを分析導線から外す** — `CLOUDFLARE_API_TOKEN`（D1 Read only）を運用前提とし、**mutation の実効防御は `perf-query` の SELECT/WITH ガード**。実測では D1 Read token でも `wrangler d1 execute --remote` の INSERT は権限エラーにならず SQL 実行まで到達するため、「Read なら Cloudflare が mutation を拒否する」は完了条件にしない
2. **新旧は `build_number`** — `app_version` 文字列順は使わない。SQL も `ORDER BY build_number DESC`

## 検証

- `bun test scripts/perf/` — 29 pass
- `bun run typecheck` / `oxlint` — OK
- `bunx docbridge check` — 0 errors
- token 未設定時に `perf-report` が exit 1 で失敗することを確認

### 手作業（ローカル）— 完了

1. Cloudflare Dashboard で **D1 Read のみ**の API token を発行し、`export CLOUDFLARE_API_TOKEN=...` — 済
2. `just perf-report` が JSON を返すこと — 済（prod `frame_stats` は当面空）
3. `just perf-query "INSERT ..."` が SELECT/WITH ガードで拒否されること — 済
4. ~~wrangler 直叩き INSERT が権限エラー~~ — **不成立**。D1 Read でも SQL 実行まで到達（`SQLITE_CONSTRAINT`）。防御の正は CLI ガード。skill / 仕様を更新済み

## やらないこと

- Phase 3（Cron / Slack）— 実データで strata 母数を見てから着手（#291）
- ダッシュボード

## DocBridge related ゲート

仕様差分は「分析導線」（CLI で prod `TELEMETRY_DB` を読む）の追記のみ。受信 API・クライアント計測・認証・ドメイン API の契約は変更していないため、フラグされたカウンターパートはすべて **更新不要**。

### `doc/specs/app-performance-telemetry.md`

- `#遅延バッチと画面遷移境界の対応付け-契約` → `FrameStatsCollector` — 序数による画面帰属契約は未変更。追加したのは別節「分析導線」
- `#送信` → `FrameStatsClient` / `PerfTelemetryService` — 送信間隔・合算・失敗時の扱い・debug 非送信は未変更

### `doc/specs/workers-api-server.md`

ファイル全体が change set に入るため他節のリンクも検出されるが、本文差分は「フレーム計測テレメトリ」節末尾への分析 CLI 1 段落のみ。

- `#フレーム計測テレメトリ` → `FrameStatsService` / `runTelemetryRetention` — 受信・保存・kill switch・30 日リテンションの契約は未変更。追記は Worker 外の read-only 分析導線
- `#適用順序` → `createAppCheckMiddleware` / `createFirebaseAuthMiddleware` — 認証適用順は未変更
- `#cors-web-qa` → `createCorsMiddleware` — CORS 契約は未変更
- `#app-check` → `AppCheckTokenVerifier` — 検証契約は未変更
- `#firebase-id-トークン` → `FirebaseIdTokenVerifier` — 検証契約は未変更
- `#公開鍵キャッシュ` → `FirebasePublicKeyProvider` — キャッシュ契約は未変更
- `#リクエスト処理順序` → `createApp` — ミドルウェア順・ルート構成は未変更
- `#エラー形式` → `ApiError` — エラー形式は未変更
- `#リクエスト-id-とログ` → `createRequestContextMiddleware` — リクエスト文脈は未変更
- `#app-config` → `AppConfigService` — app-config 契約は未変更
- `#ユーザー` / `#アバター` → `UserService` / `AvatarService` — 未変更
- `#言葉` → `WordService` — 未変更
- `#定義` → `DefinitionService` — 未変更
- `#辞書と一覧` / `#タイムラインと検索` → `BrowseService` — 未変更
- `#物理削除` → `runPhysicalDeletion` — 物理削除契約は未変更


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production telemetry CLI commands: one for generating standardized performance reports and one for running read-only telemetry queries.
  * Reports include performance rates segmented by screen, device, and refresh rate, plus build-to-build comparisons with optional build-number pinning.

* **Documentation**
  * Added end-to-end analysis guidance, including how to interpret the report outputs and when to use each command path.

* **Tests**
  * Added test coverage for token handling, query validation/read-only enforcement, report generation, and rate calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
