### PR TITLE
feat: 移行 verify に R2 アバターの Content-Type 検証を追加する

### DIFF
--- a/backend/scripts/migration/verify.test.ts
+++ b/backend/scripts/migration/verify.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
-import { diffRows, parseD1JsonOutput, reclassifyAvatarUrl, recomputeExpectedState } from "./verify";
-import type { Snapshot } from "./verify";
+import {
+  buildR2ObjectUrl,
+  diffAvatarObject,
+  diffRows,
+  parseD1JsonOutput,
+  reclassifyAvatarUrl,
+  recomputeExpectedState,
+  requireR2RestCredentials,
+} from "./verify";
+import type { R2ObjectMeta, Snapshot } from "./verify";
 
 const defaultIconUrl =
   "https://firebasestorage.googleapis.com/v0/b/everyone-teigi-prod.appspot.com/o/common%2Fdefault_icon_image%2Fghost_writer.png?alt=media&token=dummy";
@@ -184,9 +192,7 @@ describe("recomputeExpectedState", () => {
       updatedAt: 1,
     });
     snapshot.userProfiles = [makeProfile("actor"), makeProfile("target")];
-    snapshot.userFollows = [
-      { id: "f1", followerId: "target", followingId: "actor", createdAt: 5 },
-    ];
+    snapshot.userFollows = [{ id: "f1", followerId: "target", followingId: "actor", createdAt: 5 }];
 
     const state = recomputeExpectedState(snapshot, 0);
     // 反転バグがあると follower_id=target になり落ちる。
@@ -230,5 +236,100 @@ describe("diffRows", () => {
     const diff = diffRows("t", [{ id: "1", v: "a" }], [{ id: "1", v: "b" }], (r) => r.id as string);
     expect(diff.mismatched).toHaveLength(1);
     expect(diff.mismatched[0]!.key).toBe("1");
+  });
+});
+
+describe("requireR2RestCredentials", () => {
+  test("token と account id を取り出す", () => {
+    expect(
+      requireR2RestCredentials({ CLOUDFLARE_API_TOKEN: "t", CLOUDFLARE_ACCOUNT_ID: "a" }),
+    ).toEqual({ apiToken: "t", accountId: "a" });
+  });
+
+  test("空白のみは未設定として扱う", () => {
+    expect(() =>
+      requireR2RestCredentials({ CLOUDFLARE_API_TOKEN: "  ", CLOUDFLARE_ACCOUNT_ID: "a" }),
+    ).toThrow(/CLOUDFLARE_API_TOKEN/);
+  });
+
+  test("account id が無ければ fail-fast する", () => {
+    expect(() => requireR2RestCredentials({ CLOUDFLARE_API_TOKEN: "t" })).toThrow(
+      /CLOUDFLARE_ACCOUNT_ID/,
+    );
+  });
+});
+
+describe("buildR2ObjectUrl", () => {
+  test("account id / バケット / キーから REST API の URL を組み立てる", () => {
+    expect(buildR2ObjectUrl("acc", "teigiii-prod-avatars", "avatars/u1")).toBe(
+      "https://api.cloudflare.com/client/v4/accounts/acc/r2/buckets/teigiii-prod-avatars/objects/avatars/u1",
+    );
+  });
+});
+
+describe("diffAvatarObject", () => {
+  const okMeta: R2ObjectMeta = { status: 200, contentType: "image/png", byteLength: 100 };
+
+  test("サイズと Content-Type が一致すれば問題なし", () => {
+    expect(diffAvatarObject("u1", "avatars/u1", 100, okMeta)).toEqual([]);
+  });
+
+  test("取得できないオブジェクトを報告する", () => {
+    const problems = diffAvatarObject("u1", "avatars/u1", 100, {
+      status: 404,
+      contentType: null,
+      byteLength: 0,
+    });
+    expect(problems).toEqual([
+      { uid: "u1", problem: "R2 オブジェクトが取得できない（status=404）: avatars/u1" },
+    ]);
+  });
+
+  test("バイトサイズ不一致を報告する", () => {
+    const problems = diffAvatarObject("u1", "avatars/u1", 100, { ...okMeta, byteLength: 99 });
+    expect(problems).toEqual([
+      { uid: "u1", problem: "バイトサイズ不一致: expected=100 actual=99" },
+    ]);
+  });
+
+  test("Content-Type が image/png でなければ報告する", () => {
+    const problems = diffAvatarObject("u1", "avatars/u1", 100, {
+      ...okMeta,
+      contentType: "application/octet-stream",
+    });
+    expect(problems).toEqual([
+      {
+        uid: "u1",
+        problem: "Content-Type 不一致: expected=image/png actual=application/octet-stream",
+      },
+    ]);
+  });
+
+  test("Content-Type 欠落を報告する", () => {
+    const problems = diffAvatarObject("u1", "avatars/u1", 100, { ...okMeta, contentType: null });
+    expect(problems).toEqual([
+      { uid: "u1", problem: "Content-Type 不一致: expected=image/png actual=(なし)" },
+    ]);
+  });
+
+  test("Content-Type のパラメータと大文字小文字は無視する", () => {
+    expect(
+      diffAvatarObject("u1", "avatars/u1", 100, { ...okMeta, contentType: "Image/PNG" }),
+    ).toEqual([]);
+    expect(
+      diffAvatarObject("u1", "avatars/u1", 100, {
+        ...okMeta,
+        contentType: "image/png; charset=binary",
+      }),
+    ).toEqual([]);
+  });
+
+  test("サイズと Content-Type の両方が不正なら両方報告する", () => {
+    const problems = diffAvatarObject("u1", "avatars/u1", 100, {
+      status: 200,
+      contentType: "text/plain",
+      byteLength: 1,
+    });
+    expect(problems).toHaveLength(2);
   });
 });

--- a/backend/scripts/migration/verify.ts
+++ b/backend/scripts/migration/verify.ts
@@ -8,16 +8,23 @@
 // readingSubGroup / normalizeText は移行専用ロジックではなくサーバー本体の
 // 共有ロジック（独自の unit test を持つ）のため、ここでは import して使う。
 //
+// D1 は wrangler CLI（OAuth）で読むが、R2 は Cloudflare REST API を直接叩く。
+// wrangler の `r2 object get` はレスポンスの body しか返さず Content-Type を捨てるため、
+// CLI 経由では保存済みの HTTP metadata を突合できない（`head` / `info` サブコマンドも無い）。
+// REST の GET /accounts/{id}/r2/buckets/{bucket}/objects/{key} は body と metadata ヘッダーを
+// 同時に返すので、1 リクエストでバイトサイズと Content-Type の両方を検証する。
+//
 // 使い方:
+//   export CLOUDFLARE_API_TOKEN=...   # R2 Read のみの API token
+//   export CLOUDFLARE_ACCOUNT_ID=...
 //   bun run scripts/migration/verify.ts \
 //     --snapshot ./migration-snapshots/prod-2026-07-20 \
 //     --d1-database teigiii-prod \
 //     --r2-bucket teigiii-prod-avatars
 
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { readFile, stat } from "node:fs/promises";
+import { resolve } from "node:path";
 import { parseArgs, promisify } from "node:util";
 
 import { normalizeText } from "../../src/lib/normalize";
@@ -343,6 +350,89 @@ function normalizeD1Row<T extends Record<string, unknown>>(row: Record<string, u
   return row as T;
 }
 
+// ---- R2 実オブジェクト取得・突合 ----
+
+/** 移行対象アバターは default / custom とも PNG のため、期待値は定数で固定する。 */
+const expectedAvatarContentType = "image/png";
+
+export type R2RestCredentials = { apiToken: string; accountId: string };
+
+export function requireR2RestCredentials(
+  env: Record<string, string | undefined> = process.env,
+): R2RestCredentials {
+  const apiToken = env["CLOUDFLARE_API_TOKEN"]?.trim();
+  const accountId = env["CLOUDFLARE_ACCOUNT_ID"]?.trim();
+  if (!apiToken) {
+    throw new Error(
+      "CLOUDFLARE_API_TOKEN が必要です（R2 の Read のみを持つ API token を使ってください）。R2 突合は Content-Type を読むため REST API 経由で行います。",
+    );
+  }
+  if (!accountId) {
+    throw new Error("CLOUDFLARE_ACCOUNT_ID が必要です（R2 REST API の呼び出しに使います）。");
+  }
+  return { apiToken, accountId };
+}
+
+export function buildR2ObjectUrl(accountId: string, bucket: string, key: string): string {
+  // key はパスへ生のまま埋める。wrangler の r2 object get / put も同じ実装で、
+  // import.ts は put 側を通してアップロードしているため、ここで再エンコードすると
+  // 「import が実際に書いたオブジェクト」と別のキーを参照してしまう。
+  // なお key は `avatars/{encodeURIComponent(uid)}` 形式、uid は Firebase Auth の
+  // 28 文字英数字（スナップショット 192 件全てで確認済み）で、エンコードは恒等写像。
+  return `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects/${key}`;
+}
+
+export type R2ObjectMeta = { status: number; contentType: string | null; byteLength: number };
+
+export type AvatarProblem = { uid: string; problem: string };
+
+/** 1 オブジェクト分の期待値（スナップショットのファイルサイズ + PNG）と実データを突合する。 */
+export function diffAvatarObject(
+  uid: string,
+  avatarKey: string,
+  expectedSize: number,
+  actual: R2ObjectMeta,
+): AvatarProblem[] {
+  if (actual.status !== 200) {
+    return [
+      { uid, problem: `R2 オブジェクトが取得できない（status=${actual.status}）: ${avatarKey}` },
+    ];
+  }
+  const problems: AvatarProblem[] = [];
+  if (actual.byteLength !== expectedSize) {
+    problems.push({
+      uid,
+      problem: `バイトサイズ不一致: expected=${expectedSize} actual=${actual.byteLength}`,
+    });
+  }
+  // Content-Type はパラメータ（`; charset=...`）を落とし、大文字小文字を無視して比較する。
+  const mediaType = actual.contentType?.split(";")[0]?.trim().toLowerCase();
+  if (mediaType !== expectedAvatarContentType) {
+    problems.push({
+      uid,
+      problem: `Content-Type 不一致: expected=${expectedAvatarContentType} actual=${actual.contentType ?? "(なし)"}`,
+    });
+  }
+  return problems;
+}
+
+export type R2ObjectFetcher = (key: string) => Promise<R2ObjectMeta>;
+
+function createR2ObjectFetcher(credentials: R2RestCredentials, bucket: string): R2ObjectFetcher {
+  return async (key) => {
+    const response = await fetch(buildR2ObjectUrl(credentials.accountId, bucket, key), {
+      headers: { authorization: `Bearer ${credentials.apiToken}` },
+    });
+    const body = await response.arrayBuffer();
+    if (!response.ok) return { status: response.status, contentType: null, byteLength: 0 };
+    return {
+      status: response.status,
+      contentType: response.headers.get("content-type"),
+      byteLength: body.byteLength,
+    };
+  };
+}
+
 // ---- CLI ----
 
 type Args = {
@@ -378,12 +468,10 @@ async function verifyR2Avatars(
   expected: ExpectedState,
   snapshot: Snapshot,
   snapshotDir: string,
-  bucket: string,
-  serverDir: string,
-): Promise<{ uid: string; problem: string }[]> {
+  fetchObject: R2ObjectFetcher,
+): Promise<AvatarProblem[]> {
   const manifestByUid = new Map(snapshot.avatarManifest.entries.map((e) => [e.uid, e]));
-  const problems: { uid: string; problem: string }[] = [];
-  const tmpDir = await mkdtemp(join(tmpdir(), "migration-verify-"));
+  const problems: AvatarProblem[] = [];
 
   for (const user of expected.users) {
     if (user.avatar_key === null) continue;
@@ -404,25 +492,18 @@ async function verifyR2Avatars(
       continue;
     }
 
-    const downloadPath = join(tmpDir, `${encodeURIComponent(user.id)}.bin`);
+    let actual: R2ObjectMeta;
     try {
-      await execFileAsync(
-        "./node_modules/.bin/wrangler",
-        // put と異なり get は -y を受け付けない（Unknown argument になる）
-        ["r2", "object", "get", `${bucket}/${user.avatar_key}`, "--file", downloadPath, "--remote"],
-        { cwd: serverDir, maxBuffer: 1024 * 1024 * 64 },
-      );
-    } catch {
-      problems.push({ uid: user.id, problem: `R2 オブジェクトが取得できない: ${user.avatar_key}` });
-      continue;
-    }
-    const actualSize = (await stat(downloadPath)).size;
-    if (actualSize !== expectedSize) {
+      actual = await fetchObject(user.avatar_key);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
       problems.push({
         uid: user.id,
-        problem: `バイトサイズ不一致: expected=${expectedSize} actual=${actualSize}`,
+        problem: `R2 オブジェクトの取得に失敗: ${user.avatar_key}（${reason}）`,
       });
+      continue;
     }
+    problems.push(...diffAvatarObject(user.id, user.avatar_key, expectedSize, actual));
   }
 
   return problems;
@@ -430,6 +511,8 @@ async function verifyR2Avatars(
 
 async function main(): Promise<void> {
   const args = parseCliArgs(process.argv.slice(2));
+  // D1 の全件突合に入る前に R2 の認証不足で落としたいので、ここで fail-fast する。
+  const credentials = requireR2RestCredentials();
   const serverDir = resolve(import.meta.dirname, "../..");
   const snapshotDir = resolve(args.snapshot);
 
@@ -527,11 +610,12 @@ async function main(): Promise<void> {
     expected,
     snapshot,
     snapshotDir,
-    args.r2Bucket,
-    serverDir,
+    createR2ObjectFetcher(credentials, args.r2Bucket),
   );
   if (avatarProblems.length === 0) {
-    console.log(`  OK（${expected.users.filter((u) => u.avatar_key !== null).length} 件）`);
+    console.log(
+      `  OK（${expected.users.filter((u) => u.avatar_key !== null).length} 件: バイトサイズ + Content-Type）`,
+    );
   } else {
     hasProblem = true;
     console.log(`  NG（${avatarProblems.length} 件）`);
@@ -542,7 +626,9 @@ async function main(): Promise<void> {
     console.error("検証 NG");
     process.exitCode = 1;
   } else {
-    console.log("検証 OK: 全件突合、意図的差分の整合、R2 アバターすべて一致");
+    console.log(
+      "検証 OK: 全件突合、意図的差分の整合、R2 アバター（バイトサイズ + Content-Type）すべて一致",
+    );
   }
 }
 


### PR DESCRIPTION
## 概要

移行の独立検証器 `backend/scripts/migration/verify.ts` に、R2 アバターオブジェクトの `Content-Type` 検証を追加する。

closes #218

## 課題と解決

issue のとおり、wrangler CLI には R2 オブジェクトの HTTP metadata を読む手段が無い。wrangler の実装を確認したところ、内部では REST の `GET /accounts/{id}/r2/buckets/{bucket}/objects/{key}` を叩いているが、レスポンスの `body` だけを返してヘッダーを捨てている（`getR2Object`）。

そこで R2 の突合を wrangler CLI から同 REST API の直接呼び出しへ置き換えた。この API は body と metadata ヘッダーを同時に返すため、**1 リクエストでバイトサイズと Content-Type の両方**を検証できる（従来はサイズのみ・一時ファイルへのダウンロードが必要だった）。

## 認証モデル

R2 検証は REST 必須に統一した。

- `CLOUDFLARE_API_TOKEN`（R2 の Read のみ）+ `CLOUDFLARE_ACCOUNT_ID` を必須とし、D1 の全件突合に入る前に fail-fast する
- D1 側は従来どおり wrangler CLI（OAuth）
- 「token が無ければ Content-Type だけ SKIP」という選択肢もあったが、経路が 2 本になる上に「SKIP でも検証 OK」と出て検証強度が落ちるため採らなかった

## 検証内容

| 項目 | 期待値 |
| --- | --- |
| status | 200（非 200 はそこで打ち切り、以降は突合しない） |
| バイトサイズ | スナップショット内の実ファイルサイズ |
| Content-Type | `image/png`（パラメータ `; charset=...` を落とし、大文字小文字は無視） |

サイズと Content-Type が両方おかしい場合は両方まとめて報告する。

## 検証

- `just backend-analyze` / `just backend-test`（bun 205 + vitest 119）/ `just docbridge-check` すべてグリーン
- 新規テスト 12 件（`requireR2RestCredentials` / `buildR2ObjectUrl` / `diffAvatarObject`）を TDD で先に書き RED を確認
- **未実施**: 実 prod オブジェクトへの疎通確認。R2 Read の API token が手元に無いため。REST GET が Content-Type を返すことは Cloudflare API ドキュメントの「returns the object body along with metadata headers」と wrangler の実装で裏付けている

## レビュー済みの論点

Codex のレビューで「key 内の `%` が二重エンコードされず別オブジェクトを参照する」という指摘を受けたが、以下の理由で修正せずコメントで根拠を明示するに留めた。

1. `import.ts` のアップロードも wrangler `r2 object put` 経由で、wrangler は put/get とも objectName を生のままパスへ埋める。verify だけ二重エンコードすると **import が実際に書いたオブジェクトを取りに行かなくなる**
2. スナップショット 3 種・全 192 ユーザーの ID は全件 28 文字英数字で `encodeURIComponent` が恒等写像。到達不能なケース

## 補足

一斉切替（#186）は 2026-07-21 に完了済みで、その時点の `import.ts` には既に `--content-type image/png` が入っている。本 PR の価値は事後の再検証と、将来のリハーサル・再移行時の担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxDHSQukFvEKPoxbATA1bu