### PR TITLE
chore: #315 formatter 往復を SDK dart format 正で定着させる 🔧

### DIFF
--- a/doc/plans/done/2026-08-05-315-format-ping-pong.md
+++ b/doc/plans/done/2026-08-05-315-format-ping-pong.md
@@ -1,0 +1,38 @@
+# #315: formatter 往復書き換えの解消
+
+## 目的
+
+`just format` と `just mobile-generate` が同じ生成物を別スタイルで書き換え、リポジトリ状態が収束しない問題を解消する。
+
+## 背景
+
+Issue #315 の推奨は B（生成物を `dart format` から除外）+ C（手書き整形）だった。
+その後 #320 が別経路で完了条件を満たした:
+
+- C: format drift 解消コミットで手書きソースを整形済み
+- generate 末尾に `dart format .` を追加し、生成物も SDK スタイルに揃える
+- CI に `mobile-format-check` / backend `format:check` を追加
+
+本 plan では **B には戻さない**。除外すると format-check が生成物の崩れを見逃し、#320 の CI 前提と矛盾する。正本は SDK の `dart format`。`dart_style` 3.x への依存更新（A）は別途。
+
+## 実行手順
+
+1. `just format` → clean rebuild の `just mobile-generate` → `just format` で差分ゼロを確認する
+2. 残差があれば取り込み、往復が消えるまで繰り返す
+3. `justfile` の format / generate コメントに #315 の方針を明記する（挙動変更なし）
+4. `just format-check` が通ることを確認する
+5. 本 plan を `doc/plans/done/` へ移し、`closes #315` の PR を出す
+
+## 完了条件
+
+- clean な状態で `just format` → `just mobile-generate`（`.dart_tool/build` 削除後）→ `just format` を通しても git 差分が出ない
+- CI に format チェックを入れる判断が明示されている（#320 で追加済み）
+- Issue #315 を閉じられる PR がある
+
+## 実行結果
+
+- `just format` は mobile 575 / backend 75 とも 0 changed
+- clean rebuild の `just mobile-generate` は build_runner 後に 105 生成物を SDK format で再整形し、最終的にスタイル往復は消える
+- 残差は `definition_for_write_notifier.g.dart` の Riverpod create hash 1 行のみ（スタイルではない）。取り込み後、再クリーン生成でも安定
+- `just format-check` 成功
+- `justfile` コメントに #315 方針（SDK format 正・生成物除外しない・A は後続）を明記

--- a/justfile
+++ b/justfile
@@ -36,8 +36,10 @@ mobile-setup:
 mobile-clean:
     cd mobile_app && flutter clean
 
-# build_runner の出力は dart format 済みではないため、生成後に必ず整形する
-# （これがないと mobile-format-check が生成物で落ちる）
+# build_runner は transitive の dart_style 2.x（旧スタイル）で出力する。
+# SDK の dart format（tall style）を正とし、生成後に必ず整形する（#315 / #320）。
+# 生成物を format 対象から除外しない。除外すると format-check が生成物の崩れを見逃す。
+# dart_style 3.x への依存更新は別途（Issue #315 の案 A）。
 mobile-generate:
     cd mobile_app && dart run build_runner build --delete-conflicting-outputs
     cd mobile_app && dart format .
@@ -45,10 +47,11 @@ mobile-generate:
 mobile-analyze:
     cd mobile_app && flutter analyze --no-fatal-infos
 
+# 生成物を含む mobile_app 全体を SDK の dart format で揃える（#315: 除外しない）
 mobile-format:
     cd mobile_app && dart format .
 
-# 整形せずに違反の有無だけを判定する（CI 用）
+# 整形せずに違反の有無だけを判定する（CI 用。生成物も対象）
 mobile-format-check:
     cd mobile_app && dart format --set-exit-if-changed --output=none .
 

--- a/mobile_app/lib/feature/definition/application/definition_for_write_notifier.g.dart
+++ b/mobile_app/lib/feature/definition/application/definition_for_write_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'definition_for_write_notifier.dart';
 // **************************************************************************
 
 String _$definitionForWriteNotifierHash() =>
-    r'8bedfa7806dec8f96615a2955d48c88f3b9440fa';
+    r'447d9ab6f3ec70169a4e8cd063bce16c3f69261a';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 対象Issue

- closes #315

# やった事

- #320 で入った方針（SDK の `dart format` を正とし、`mobile-generate` 末尾で生成物も整形する）を #315 の完了条件として検証・定着させた
- Issue 推奨の B（生成物を format 対象から除外）は採用しない。除外すると `mobile-format-check` が生成物のスタイル崩れを見逃し、#320 の CI 前提と矛盾するため
- `justfile` の `mobile-generate` / `mobile-format` / `mobile-format-check` コメントに上記方針を明記（挙動変更なし）
- clean rebuild 後に安定して残った `definition_for_write_notifier.g.dart` の Riverpod create hash 差分を取り込み（スタイル往復ではない）
- plan を `doc/plans/done/2026-08-05-315-format-ping-pong.md` に記録

# やらなかった事

- `dart_style` 3.x への依存更新（Issue 案 A。別途）
- 生成物を `dart format` から除外する案 B
- backend oxfmt の追加変更（#320 で drift 解消済み）

# 動作確認

Cloud VM（Flutter 3.41.8 / Dart 3.11.5）:

1. `just format` → mobile 575 files / backend 75 files とも 0 changed
2. `rm -rf mobile_app/.dart_tool/build && just mobile-generate` → build_runner 後に 105 生成物を SDK format で再整形。最終ツリーはスタイル往復なし
3. 再クリーン生成でも create hash は安定
4. `just format` 再実行 → 0 changed
5. `just format-check` 成功

# その他

- CI への format チェック追加は #320 で実施済み（本 PR では判断の明文化のみ）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd18a-1120-7d8e-bf88-2e085b0d4190?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd18a-1120-7d8e-bf88-2e085b0d4190&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

