### PR TITLE
feat: #322 backend prod deploy を安全に再開できるようにする

### DIFF
--- a/backend/scripts/drift-check.sh
+++ b/backend/scripts/drift-check.sh
@@ -9,6 +9,9 @@
 #   2. prod D1 / prod テレメトリ D1 の未適用 migration
 #
 # 実行には wrangler の OAuth ログイン（just backend-deploy-prod と同じ）が必要。
+#
+# 終了コード: 0 = 一致 / 1 = 乖離あり / 2 = 検査自体が失敗（認証切れ・API 障害など）。
+# 「乖離」と「検査不能」を混同すると、通知を見た側が prod の状態を誤って安心するため分ける。
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -18,10 +21,27 @@ develop_sha="$(git rev-parse origin/develop)"
 
 cd backend
 
-version_id="$(bunx wrangler deployments status --env prod --json 2>/dev/null |
-  jq -er '.versions[0].version_id')"
-deployed_sha="$(bunx wrangler versions view "$version_id" --env prod --json 2>/dev/null |
-  jq -r '.resources.bindings[] | select(.name == "DEPLOYED_SHA") | .text')"
+stderr_file="$(mktemp)"
+trap 'rm -f "$stderr_file"' EXIT
+
+# wrangler の stderr は握り潰さない。認証切れや API 障害を「原因不明の非 0 終了」にすると、
+# 乖離しているのか検査できていないのかを実行者が区別できなくなる。
+# exit を効かせるため、この関数はサブシェル（コマンド置換）の中から呼ばない。
+fail() {
+  printf 'drift-check could not run: %s\n' "$1" >&2
+  cat "$stderr_file" >&2
+  exit 2
+}
+
+status_json="$(bunx wrangler deployments status --env prod --json 2>"$stderr_file")" ||
+  fail 'wrangler deployments status --env prod'
+version_id="$(jq -er '.versions[0].version_id' <<<"$status_json")" ||
+  fail 'no version id in deployments status output'
+
+version_json="$(bunx wrangler versions view "$version_id" --env prod --json 2>"$stderr_file")" ||
+  fail "wrangler versions view ${version_id} --env prod"
+deployed_sha="$(jq -r '.resources.bindings[] | select(.name == "DEPLOYED_SHA") | .text' \
+  <<<"$version_json")" || fail 'could not read DEPLOYED_SHA from version bindings'
 
 drifted=0
 
@@ -41,7 +61,8 @@ fi
 
 for binding in DB TELEMETRY_DB; do
   printf '\n--- %s の未適用 migration ---\n' "$binding"
-  migrations="$(bunx wrangler d1 migrations list "$binding" --env prod --remote 2>/dev/null)"
+  migrations="$(bunx wrangler d1 migrations list "$binding" --env prod --remote 2>"$stderr_file")" ||
+    fail "wrangler d1 migrations list ${binding} --env prod --remote"
   printf '%s\n' "$migrations"
   if ! grep -q 'No migrations to apply' <<<"$migrations"; then
     drifted=1

--- a/backend/scripts/drift-check.sh
+++ b/backend/scripts/drift-check.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# prod が origin/develop から乖離していないかを検査する（#322）。
+#
+# prod は CI ではなくローカルからの手動 deploy なので、「deploy し忘れ」も
+# 「migration の適用し忘れ」も誰も検知しない。ここでは prod へ一切書き込まず、
+# 次の 2 つの乖離を報告する:
+#
+#   1. prod Worker に出ている commit（deploy 時に打つ DEPLOYED_SHA）と origin/develop の差
+#   2. prod D1 / prod テレメトリ D1 の未適用 migration
+#
+# 実行には wrangler の OAuth ログイン（just backend-deploy-prod と同じ）が必要。
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+git fetch --quiet origin develop
+develop_sha="$(git rev-parse origin/develop)"
+
+cd backend
+
+version_id="$(bunx wrangler deployments status --env prod --json 2>/dev/null |
+  jq -er '.versions[0].version_id')"
+deployed_sha="$(bunx wrangler versions view "$version_id" --env prod --json 2>/dev/null |
+  jq -r '.resources.bindings[] | select(.name == "DEPLOYED_SHA") | .text')"
+
+drifted=0
+
+printf 'origin/develop : %s\n' "$develop_sha"
+if [ -z "$deployed_sha" ]; then
+  # 初回は #322 より前の deploy なのでスタンプが無い。次の deploy 以降は必ず入る。
+  printf 'prod Worker    : (DEPLOYED_SHA 未スタンプ。#322 以降の deploy で付く)\n'
+  drifted=1
+elif [ "$deployed_sha" != "$develop_sha" ]; then
+  printf 'prod Worker    : %s\n' "$deployed_sha"
+  printf 'prod Worker is behind origin/develop by %s commits.\n' \
+    "$(git rev-list --count "${deployed_sha}..${develop_sha}" 2>/dev/null || echo '?')"
+  drifted=1
+else
+  printf 'prod Worker    : %s (up to date)\n' "$deployed_sha"
+fi
+
+for binding in DB TELEMETRY_DB; do
+  printf '\n--- %s の未適用 migration ---\n' "$binding"
+  migrations="$(bunx wrangler d1 migrations list "$binding" --env prod --remote 2>/dev/null)"
+  printf '%s\n' "$migrations"
+  if ! grep -q 'No migrations to apply' <<<"$migrations"; then
+    drifted=1
+  fi
+done
+
+if [ "$drifted" -ne 0 ]; then
+  printf '\nprod drifted from origin/develop. See doc/specs/workers-api-server.md#prod-deploy\n' >&2
+  exit 1
+fi
+
+printf '\nprod is in sync with origin/develop.\n'

--- a/backend/src/compat/draft-count-shim.ts
+++ b/backend/src/compat/draft-count-shim.ts
@@ -1,0 +1,28 @@
+/**
+ * 配信済み v1.2.1+11 との後方互換シム（#322）。
+ *
+ * v1.2.1 の生成クライアントは `MyDictionaryOverview` / `DefinedWordItem` の `draftCount` を
+ * 必須キーとして検査するため、これを欠いたレスポンスを返すと「あなたの辞書」一覧が parse エラーで落ちる。
+ * 下書き機能自体は廃止済みで、サーバーが返せる値は常に 0 になる。
+ *
+ * 契約（OpenAPI）には戻さず、配信レスポンスにだけ定数を足す。契約に必須で戻すと、
+ * シム撤去時にその時点の配信済みアプリを再び壊すため。`OpenAPIHono` はレスポンスを検証しないので、
+ * スキーマ外のキーはそのまま wire に出る。
+ *
+ * `min_app_version_ios` / `min_app_version_android` を v1.2.1 より上へ引き上げた後、
+ * このファイルと `routes/me.ts` の呼び出し、`worker-test/compat-v1_2_1.workers.ts` を削除する。
+ */
+
+/**
+ * レスポンス body に `draftCount: 0` を足す。型は契約どおりのまま扱う。
+ *
+ * @doc doc/specs/workers-api-server.md#配信済みアプリとの後方互換
+ */
+export function withDraftCount<T extends object>(value: T): T {
+  return { ...value, draftCount: 0 } as T;
+}
+
+/** ページレスポンスの各要素に `draftCount: 0` を足す。 */
+export function withDraftCountItems<T extends { items: object[] }>(page: T): T {
+  return { ...page, items: page.items.map(withDraftCount) } as T;
+}

--- a/backend/src/routes/me.ts
+++ b/backend/src/routes/me.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { AuthenticationVariables } from "../auth/middleware";
 import { BrowseService } from "../browse/browse-service";
+import { withDraftCount, withDraftCountItems } from "../compat/draft-count-shim";
 import { paginatedSchema, paginationQuerySchema } from "../schemas/common";
 import { definitionResponseSchema } from "../schemas/definition";
 import {
@@ -87,7 +88,8 @@ type MeRouteEnvironment = {
 export const meRoutes = new OpenAPIHono<MeRouteEnvironment>()
   .openapi(getOverviewRoute, async (context) => {
     const result = await new BrowseService(context.env).getMyOverview(context.get("firebaseUid"));
-    return context.json(result, 200);
+    // v1.2.1 互換シム。撤去条件は compat/draft-count-shim.ts を参照
+    return context.json(withDraftCount(result), 200);
   })
   .openapi(getDefinedWordsRoute, async (context) => {
     const query = context.req.valid("query");
@@ -96,7 +98,8 @@ export const meRoutes = new OpenAPIHono<MeRouteEnvironment>()
       query.limit,
       query.cursor,
     );
-    return context.json(result, 200);
+    // v1.2.1 互換シム。撤去条件は compat/draft-count-shim.ts を参照
+    return context.json(withDraftCountItems(result), 200);
   })
   .openapi(getMyDefinitionsRoute, async (context) => {
     const query = context.req.valid("query");

--- a/backend/test/cors.test.ts
+++ b/backend/test/cors.test.ts
@@ -4,7 +4,8 @@ import { createApp } from "../src/app";
 import { isAllowedWebQaOrigin } from "../src/middleware/cors";
 
 const WEB_QA_ENV = { WEB_QA_PAGES_PROJECT: "teigiii-web-dev" };
-const PROD_ENV = {};
+// prod の wrangler.toml は WEB_QA_PAGES_PROJECT を空文字で明示する（#322）
+const PROD_ENV = { WEB_QA_PAGES_PROJECT: "" };
 
 function testApp() {
   return createApp({
@@ -17,6 +18,13 @@ describe("isAllowedWebQaOrigin", () => {
   test("pagesProject 未設定ではすべて拒否する", () => {
     expect(isAllowedWebQaOrigin("http://localhost:3000", undefined)).toBe(false);
     expect(isAllowedWebQaOrigin("https://teigiii-web-dev.pages.dev", undefined)).toBe(false);
+  });
+
+  // prod は wrangler の vars 継承警告を消すために空文字を明示している（#322）。
+  // 空文字が「未設定」と同じ扱いでなくなると、prod の CORS が無言で緩む。
+  test("pagesProject が空文字（prod の明示的な無効化）でもすべて拒否する", () => {
+    expect(isAllowedWebQaOrigin("http://localhost:3000", "")).toBe(false);
+    expect(isAllowedWebQaOrigin("https://teigiii-web-dev.pages.dev", "")).toBe(false);
   });
 
   test("localhost / 127.0.0.1 を許可する", () => {

--- a/backend/test/justfile.test.ts
+++ b/backend/test/justfile.test.ts
@@ -21,10 +21,16 @@ backend-migrate-prod-telemetry:
   // さらに正しい順序が migration の性質で反転する（additive なら migrate → deploy、
   // destructive なら deploy → migrate）ため、束ねると後者が扱えなくなる。
   test("deploy does not implicitly run migrations", () => {
-    expect(justfile).toContain(`
-backend-deploy-prod: backend-guard-prod
-    cd backend && bunx wrangler deploy --env prod
-`);
+    expect(justfile).toMatch(
+      /^backend-deploy-prod: backend-guard-prod\n {4}cd backend && bunx wrangler deploy --env prod\b/m,
+    );
+    const deploy = justfile.slice(justfile.indexOf("\nbackend-deploy-prod:"));
+    expect(deploy.split("\n")[2]).not.toContain("migrations apply");
+  });
+
+  // prod に出ている commit を特定できないと、deploy し忘れをドリフト検査が検知できない。
+  test("deploy stamps the deployed commit for drift detection", () => {
+    expect(justfile).toContain('--var DEPLOYED_SHA:"$(git rev-parse HEAD)"');
   });
 
   // prod はローカルから deploy するため、作業ツリーの中身がそのまま prod に出る事故を
@@ -41,5 +47,33 @@ backend-deploy-prod: backend-guard-prod
     expect(guard).toContain("git diff --quiet");
     expect(guard).toContain("git rev-parse origin/develop");
     expect(guard).toContain("ci-passed");
+  });
+
+  // Time Travel は destructive migration が失敗したときの唯一の戻し手段。
+  // 復元は prod への破壊的操作なので、明示確認なしに実行できてはならない。
+  test("time travel recipes exist and restore asks for confirmation", () => {
+    expect(justfile).toContain("wrangler d1 time-travel info DB --env prod");
+    const restore = justfile.slice(
+      justfile.indexOf("\nbackend-restore-prod "),
+      justfile.indexOf("\n# prod の app_config を表示する"),
+    );
+    expect(restore).toContain("read -r -p");
+    expect(restore).toContain("wrangler d1 time-travel restore DB --env prod");
+  });
+
+  // app_config の確認は読み取りのみに保つ。参照のつもりで prod を書き換える事故を防ぐ。
+  test("prod app_config inspection stays read-only", () => {
+    const inspect = justfile.slice(
+      justfile.indexOf("\nbackend-app-config-prod:"),
+      justfile.indexOf("\n# prod app-config の初期行"),
+    );
+    expect(inspect).toContain("select * from app_config");
+    expect(inspect).not.toMatch(/insert|update|delete/i);
+  });
+
+  test("prod drift check does not write to prod", () => {
+    expect(justfile).toMatch(/^backend-drift-check:\n {4}backend\/scripts\/drift-check\.sh$/m);
+    const script = readFileSync(resolve(repositoryRoot, "backend/scripts/drift-check.sh"), "utf8");
+    expect(script).not.toMatch(/wrangler (deploy\b|d1 execute|d1 migrations apply)/);
   });
 });

--- a/backend/test/justfile.test.ts
+++ b/backend/test/justfile.test.ts
@@ -49,8 +49,8 @@ backend-migrate-prod-telemetry:
     expect(guard).toContain("ci-passed");
   });
 
-  // Time Travel は destructive migration が失敗したときの唯一の戻し手段。
-  // 復元は prod への破壊的操作なので、明示確認なしに実行できてはならない。
+  // commit 済みの migration が壊れた状態を作った場合の唯一の戻し手段。
+  // 復元は prod への破壊的な上書きなので、明示確認なしに実行できてはならない。
   test("time travel recipes exist and restore asks for confirmation", () => {
     expect(justfile).toContain("wrangler d1 time-travel info DB --env prod");
     const restore = justfile.slice(
@@ -69,6 +69,22 @@ backend-migrate-prod-telemetry:
     );
     expect(inspect).toContain("select * from app_config");
     expect(inspect).not.toMatch(/insert|update|delete/i);
+  });
+
+  // min_app_version_* はアプリが Version.parse に直接渡す（app_config_state.dart）。
+  // 壊れた値を prod に書くと全クライアントが起動時に例外で固まり、行を直すまで復帰しない。
+  // 検証は remote への最初の書き込みより前に置く。
+  test("min app version update validates before writing to prod", () => {
+    const recipe = justfile.slice(
+      justfile.indexOf("\nbackend-set-min-app-version-prod "),
+      justfile.indexOf("\n# prod が origin/develop から乖離"),
+    );
+    const validation = recipe.indexOf("^[0-9]+\\.[0-9]+\\.[0-9]+$");
+    expect(validation).toBeGreaterThan(-1);
+    expect(validation).toBeLessThan(recipe.indexOf("wrangler d1 execute"));
+    // 文字列補間だとクオートを含む値が SQL 自体を書き換えられる
+    expect(recipe).not.toContain("{{ios}}");
+    expect(recipe).not.toContain("{{android}}");
   });
 
   test("prod drift check does not write to prod", () => {

--- a/backend/worker-test/browse.workers.ts
+++ b/backend/worker-test/browse.workers.ts
@@ -190,6 +190,8 @@ describe("my dictionary lists", () => {
     expect(overview.status).toBe(200);
     await expect(overview.json()).resolves.toMatchObject({
       definedWordCount: 2,
+      // v1.2.1 互換シム（compat/draft-count-shim.ts）。契約には無いが wire には常に出る
+      draftCount: 0,
       savedWordCount: 1,
       recentDefinitions: [{ id: "private-w2" }, { id: "private" }, { id: "public" }],
     });
@@ -197,8 +199,20 @@ describe("my dictionary lists", () => {
     const definedWords = await request("alice", "/v1/me/defined-words");
     await expect(definedWords.json()).resolves.toMatchObject({
       items: [
-        { privateCount: 1, publicCount: 1, readingSubGroup: "あ", word: { id: "w1" } },
-        { privateCount: 1, publicCount: 0, readingSubGroup: "よ", word: { id: "w2" } },
+        {
+          draftCount: 0,
+          privateCount: 1,
+          publicCount: 1,
+          readingSubGroup: "あ",
+          word: { id: "w1" },
+        },
+        {
+          draftCount: 0,
+          privateCount: 1,
+          publicCount: 0,
+          readingSubGroup: "よ",
+          word: { id: "w2" },
+        },
       ],
     });
 

--- a/backend/worker-test/compat-v1_2_1.workers.ts
+++ b/backend/worker-test/compat-v1_2_1.workers.ts
@@ -1,0 +1,97 @@
+/**
+ * 配信済み v1.2.1+11 の生成クライアントとの後方互換を固定する（#322）。
+ *
+ * 生成クライアントは `$checkKeys(requiredKeys:)` で必須キーの存在だけを検査し、未知キーは無視する。
+ * したがって「旧クライアントが必須とするキーがレスポンスに全て存在すること」が互換の必要十分条件になる。
+ * ここでの期待値は tag `v1.2.1+11` の `*.g.dart` から literal で書き写したものであり、
+ * 現行スキーマから導出してはならない（導出すると削除を検知できない）。
+ */
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createApp } from "../src/app";
+import { readingSubGroup } from "../src/words/reading-sub-group";
+
+/** v1.2.1+11:mobile_app/packages/teigiii_api/lib/src/model/my_dictionary_overview.g.dart */
+const myDictionaryOverviewRequiredKeys = [
+  "definedWordCount",
+  "draftCount",
+  "savedWordCount",
+  "recentDefinitions",
+];
+
+/** v1.2.1+11:mobile_app/packages/teigiii_api/lib/src/model/defined_word_item.g.dart:101 */
+const definedWordItemRequiredKeys = ["word", "publicCount", "privateCount", "draftCount"];
+
+const authHeaders = {
+  Authorization: "Bearer valid-id-token",
+  "X-Firebase-AppCheck": "valid-app-check",
+};
+
+async function request(path: string) {
+  const app = createApp({
+    logRequest: () => {},
+    verifyAppCheck: async () => ({ appId: "test-app-id" }),
+    verifyFirebaseIdToken: async () => ({ uid: "alice" }),
+  });
+  return app.request(path, { headers: authHeaders }, env);
+}
+
+beforeEach(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  await env.DB.batch([env.DB.prepare("delete from users"), env.DB.prepare("delete from words")]);
+
+  await env.DB.prepare(
+    `insert into users
+       (id, public_id, name, bio, last_os_version, last_app_version, created_at, updated_at)
+     values ('alice', 'alice-public', 'alice', '', 'iOS 19', '1.2.1', 1, 1)`,
+  ).run();
+  await env.DB.prepare(
+    `insert into words
+       (id, word, reading, reading_sub_group, created_by,
+        first_registered_at, first_registered_by, created_at, updated_at)
+     values ('w1', '朝', 'あさ', ?, 'alice', 10, 'alice', 10, 10)`,
+  )
+    .bind(readingSubGroup("あさ"))
+    .run();
+  await env.DB.prepare(
+    `insert into definitions
+       (id, word_id, author_id, body, status, finalized_at, is_edited, created_at, updated_at)
+     values ('d1', 'w1', 'alice', 'body', 'public', 100, 0, 100, 100)`,
+  ).run();
+});
+
+describe("v1.2.1+11 の生成クライアントとの互換", () => {
+  test("GET /v1/me/dictionary/overview が旧クライアントの必須キーを全て返す", async () => {
+    const response = await request("/v1/me/dictionary/overview");
+    expect(response.status).toBe(200);
+
+    const body = await response.json<Record<string, unknown>>();
+    expect(Object.keys(body)).toEqual(expect.arrayContaining(myDictionaryOverviewRequiredKeys));
+    expect(body.draftCount).toBe(0);
+  });
+
+  test("GET /v1/me/defined-words の各要素が旧クライアントの必須キーを全て返す", async () => {
+    const response = await request("/v1/me/defined-words");
+    expect(response.status).toBe(200);
+
+    const body = await response.json<{ items: Record<string, unknown>[] }>();
+    expect(body.items.length).toBeGreaterThan(0);
+    for (const item of body.items) {
+      expect(Object.keys(item)).toEqual(expect.arrayContaining(definedWordItemRequiredKeys));
+      expect(item.draftCount).toBe(0);
+    }
+  });
+
+  // シムは wire レベルに限定し、契約（OpenAPI）へ復活させない。
+  // 契約に必須で戻すと、シム撤去時にその時点の配信済みアプリを再び壊す。
+  test("draftCount は OpenAPI 契約に含まれない", async () => {
+    const { buildOpenApiDocument } = await import("../src/app");
+    const schemas = buildOpenApiDocument().components?.schemas ?? {};
+
+    for (const name of ["MyDictionaryOverview", "DefinedWordItem"]) {
+      const schema = schemas[name] as { properties?: Record<string, unknown> };
+      expect(Object.keys(schema.properties ?? {})).not.toContain("draftCount");
+    }
+  });
+});

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -56,6 +56,10 @@ name = "teigiii-api-prod"
 FIREBASE_PROJECT_ID = "everyone-teigi-prod"
 FIREBASE_PROJECT_NUMBER = "713374936833"
 AVATAR_BASE_URL = "https://teigiii-api-prod.tetsuo21ad.workers.dev/v1"
+# prod では Web QA の CORS 緩和を無効化する（空文字は未設定と同じく全 origin 拒否）。
+# 未定義のままにすると wrangler が「top-level の vars が継承されない」警告を毎回出し、
+# 本当の設定ミスがノイズに埋もれるため、意図を値として明示する。
+WEB_QA_PAGES_PROJECT = ""
 
 [[env.prod.d1_databases]]
 binding = "DB"

--- a/doc/plans/2026-08-10-322-prod-deploy-resume.md
+++ b/doc/plans/2026-08-10-322-prod-deploy-resume.md
@@ -1,0 +1,76 @@
+# backend prod deploy を安全に再開できるようにする（#322）
+
+## 目的
+
+prod Worker が develop から乖離したまま deploy できない状態を解消し、次のストア配信（v1.2.1+11 以降）の
+前提を整える。本 plan のスコープは **コード / 設定 / 手順の整備と PR まで**で、実際の prod migrate / deploy は
+`backend-guard-prod` が `origin/develop` 一致を要求するため merge 後に別途実施する。
+
+## 互換性の実測
+
+v1.2.1+11 タグの `backend/openapi.json` と現行 develop の差分を突き合わせた結果:
+
+| スキーマ | 差分 | 配信済み v1.2.1 への影響 |
+| --- | --- | --- |
+| `DefinedWordItem` | `draftCount` 削除 / `readingSubGroup` 追加 | **破壊的**（必須キー欠落） |
+| `MyDictionaryOverview` | `draftCount` 削除 | **破壊的** |
+| `AppConfigResponse` / `SavedWordItem` / `UserDictionaryItem` | プロパティ追加のみ | 影響なし |
+| `UpdateDefinitionRequest` | `wordId` 削除 | 影響なし |
+| パス | `/v1/words/lookup`・`/v1/telemetry/frames` 追加のみ | 影響なし |
+
+追加プロパティが安全なのは、生成クライアントが `$checkKeys(requiredKeys:)` しか検査せず未知キーを無視するため。
+リクエスト側の `wordId` 削除が安全なのは、zod が非 strict で未知キーを strip するため。
+
+→ **互換シムが必要なのは `draftCount` の 2 箇所だけ。**
+
+## 実行手順
+
+1. `draftCount` 互換シムを `backend/src/compat/draft-count-shim.ts` に置き、HTTP 境界（`routes/me.ts`）で適用する。
+   OpenAPI 契約には載せない（`openapi.json` は無変更）
+2. prod 運用 recipe を justfile に追加する
+   - `backend-app-config-prod` / `backend-seed-prod` / `backend-set-min-app-version-prod`
+   - `backend-bookmark-prod` / `backend-restore-prod`（D1 Time Travel）
+   - `backend-drift-check`（prod と `origin/develop` の乖離検査）
+   - `backend-deploy-prod` に `--var DEPLOYED_SHA:$(git rev-parse HEAD)` を追加
+3. `backend/wrangler.toml` の `[env.prod.vars]` に `WEB_QA_PAGES_PROJECT = ""` を置き、vars 継承警告を消す
+4. `doc/specs/workers-api-server.md` の prod 手順を更新する
+5. 各テスト（compat / justfile / cors）を追加する
+
+## 設計判断
+
+### 互換シムを OpenAPI 契約に戻さない
+
+スキーマに戻すと `mobile_app/packages/teigiii_api` の再生成が必要になる。さらに必須で戻すと、シム撤去時に
+「その時点の配信済みアプリ」を再び壊す。optional で戻しても新クライアントに不要なフィールドが残る。
+`OpenAPIHono` はレスポンスを検証しないため、シムは wire レベルで完結でき、撤去は 1 ファイル削除で済む。
+
+### ドリフト検知は「deploy 時に SHA をスタンプし、読み取り recipe で照合する」
+
+`wrangler deployments list` の時刻比較は乖離を推測できるだけで、prod に出ている commit を特定できない。
+`backend-guard-prod` が `HEAD == origin/develop` を保証しているため、deploy 時に `--var DEPLOYED_SHA` を
+打てば、その値がそのまま「prod に出ている develop の commit」になる。
+
+定期通知（Cron / Slack）は #291 のリリース回帰検知 Cron に相乗りさせる方針とし、本 Issue では実装しない。
+単独の Cron を先に建てると、#291 側で `controller.cron` の dispatch 設計をやり直すことになるため。
+
+### migration の順序
+
+`0003` / `0004` は 2 件とも旧 Worker のまま先に適用してよい（Issue #322 に判断根拠を記載）。
+壊れるのは migration ではなく Worker deploy によるレスポンス形状の変更であり、シムがそれを吸収する。
+順序は `bookmark → migrate → 互換シム入り Worker を deploy`。
+
+## 完了条件
+
+- [ ] `draftCount` 互換シムが入り、v1.2.1 の `requiredKeys` を満たすことが worker-test で固定されている
+- [ ] `openapi.json` に差分が出ていない
+- [ ] Time Travel によるバックアップ / 復旧手順が `doc/specs/workers-api-server.md` の prod 手順に含まれている
+- [ ] prod `app_config` を確認・更新する recipe が存在する
+- [ ] `just backend-drift-check` が prod と `origin/develop` の乖離を検出できる
+- [ ] prod ドリフト検知の自動化方針が記録されている
+- [ ] `just backend-analyze` / `just backend-test` / `just backend-validate-prod` / `just docbridge-check` が通る
+
+## スコープ外（merge 後に別途実施）
+
+- prod の migrate / deploy / smoke test
+- dev Worker のドリフト解消（本 PR が `backend/**` を触るため、develop への merge で CI の `deploy-dev` が走り自動解消する）
+- 互換シムの撤去（`min_app_version_*` 引き上げ後に別 Issue）

--- a/doc/plans/2026-08-10-322-prod-deploy-resume.md
+++ b/doc/plans/2026-08-10-322-prod-deploy-resume.md
@@ -72,5 +72,11 @@ v1.2.1+11 タグの `backend/openapi.json` と現行 develop の差分を突き�
 ## スコープ外（merge 後に別途実施）
 
 - prod の migrate / deploy / smoke test
-- dev Worker のドリフト解消（本 PR が `backend/**` を触るため、develop への merge で CI の `deploy-dev` が走り自動解消する）
+- dev Worker のドリフト解消。**merge では解消しない。** `ci.yml` の `deploy-dev` は secret
+  `CLOUDFLARE_API_TOKEN_DEV` を要求するが未登録で（登録済みは perf 分析用の D1 Read 専用
+  `CLOUDFLARE_API_TOKEN` のみ）、develop の最新 run も `Missing required secrets` で失敗している。
+  `ci-passed` の `needs` に含まれないため無言で赤いままだった。dev deploy 用の token を発行して
+  登録するか、`just backend-deploy-dev` を手動実行するまで解消しない
 - 互換シムの撤去（`min_app_version_*` 引き上げ後に別 Issue）
+
+#322 の完了条件は prod / dev への実操作を含むため、この PR の merge では閉じない。

--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -33,7 +33,8 @@ prod に出る事故は `backend-guard-prod`（作業ツリー clean / `origin/d
 可逆だが migration は forward-only で不可逆であり、さらに正しい順序が migration の性質で
 反転する（additive なら migrate → deploy、destructive なら deploy → migrate）。
 `backend-migrate-prod` / `backend-migrate-prod-telemetry` は個別に実行し、順序は
-その migration の性質に応じて判断する。
+その migration の性質に応じて判断する。migration の性質とは別に、Worker deploy が
+**配信済みアプリを壊さないか**も判断軸になる（「prod デプロイ」節を参照）。
 
 ## リクエスト保護
 
@@ -56,7 +57,9 @@ prod に出る事故は `backend-guard-prod`（作業ツリー clean / `origin/d
 
 ブラウザからの **dev** Web QA アクセスのため、App Check より前に CORS を適用する。
 緩和は binding `WEB_QA_PAGES_PROJECT` が設定されている環境（local / `env.dev`）でのみ有効で、
-prod（`env.prod`）にはこの binding を置かず allowlist を空にする。
+prod（`env.prod`）では空文字を明示して allowlist を空にする。空文字は未設定と同じく全 origin 拒否だが、
+未定義のままだと wrangler が「top-level の vars が継承されない」警告を prod 系コマンドで毎回出し、
+本当の設定ミスがノイズに埋もれるため、無効化の意図を値として置く。
 
 有効時の許可 origin は次のみ。
 
@@ -293,25 +296,72 @@ curl 'http://localhost:8787/__scheduled?cron=0+3+*+*+*'
 
 ### prod デプロイ
 
-1. `just backend-validate-prod` で `teigiii-api-prod`、`teigiii-prod`、
+1. `just backend-drift-check` で prod と `origin/develop` の乖離（未 deploy の commit /
+   未適用 migration）を洗い出す。
+2. `just backend-validate-prod` で `teigiii-api-prod`、`teigiii-prod`、
    `teigiii-prod-avatars`、prod Firebase vars の bundle / bindings 解決を dry-run する。
-2. 未適用の migration があるかを
-   `wrangler d1 migrations list DB --env prod --remote` と
-   `wrangler d1 migrations list TELEMETRY_DB --env prod --remote` で確認する。
-3. 未適用の migration がある場合、その性質に応じて順序を決めて実行する。
+3. **配信済みアプリとの後方互換**を確認する（後述）。壊す変更があれば互換シムを先に入れる。
+4. 未適用の migration がある場合、その性質に応じて順序を決めて実行する。
    **`just backend-deploy-prod` は migration を実行しない。**
+   - 実行前に `just backend-bookmark-prod` で Time Travel bookmark を控える（後述）
    - additive（列・テーブルの追加）: `just backend-migrate-prod` /
-     `just backend-migrate-prod-telemetry` を先に実行してから 4 へ進む
+     `just backend-migrate-prod-telemetry` を先に実行してから 5 へ進む
    - destructive（列の削除・リネーム。drizzle-kit が table recreate を吐く）:
-     先に 4 で新コードを deploy し、その後に migration を実行する
-4. `just backend-deploy-prod` を実行する。この recipe は `backend-guard-prod`
+     先に 5 で新コードを deploy し、その後に migration を実行する
+5. `just backend-deploy-prod` を実行する。この recipe は `backend-guard-prod`
    （作業ツリー clean / `origin/develop` と一致 / その commit の `ci-passed` が green）
-   を通過した場合にだけ prod Worker を deploy する。
-5. 手順 2 のコマンドで未適用 migration がゼロであることを再確認し、
-   prod の主要フローを smoke test する。
+   を通過した場合にだけ prod Worker を deploy し、その commit を `DEPLOYED_SHA` として打つ。
+6. `just backend-drift-check` が green になることを確認し、prod の主要フローを smoke test する。
 
 R2 public access は有効化しない。Cron は Wrangler 設定を正本とし、UTC の実行時刻を
 変更する場合はデプロイ前に確認する。
+
+<!-- @code backend/src/compat/draft-count-shim.ts#withDraftCount -->
+#### 配信済みアプリとの後方互換
+
+migration の additive / destructive とは別軸の判断で、**Worker deploy によるレスポンス形状の変更**が
+ストアで配信済みのアプリを壊さないかを見る。生成クライアント（dart-dio + json_serializable）は
+`$checkKeys(requiredKeys:)` で必須キーの存在だけを検査し、未知キーは無視する。したがって:
+
+- レスポンスのプロパティ追加・新規エンドポイント追加は安全
+- リクエストのプロパティ削除は安全（zod は非 strict で未知キーを strip する）
+- **レスポンスの必須プロパティ削除は破壊的**。配信済みアプリの当該画面が parse エラーで落ちる
+
+判定は、配信済みバージョンの tag（例 `v1.2.1+11`）の `backend/openapi.json` と現行の差分を取り、
+required から消えたプロパティの有無で行う。破壊的な削除がある場合は、契約（OpenAPI）へ戻さず
+配信レスポンスにだけ定数を足す**互換シム**を入れてから deploy する（`backend/src/compat/`）。
+シムは `min_app_version_ios` / `min_app_version_android` を該当バージョンより上へ引き上げた後に撤去する。
+
+#### バックアップと復旧（D1 Time Travel）
+
+migration は forward-only で、途中失敗時の戻し手段は D1 Time Travel だけ。destructive な
+migration は table recreate になり、D1 は暗黙トランザクション内で `PRAGMA foreign_keys=OFF` が
+効かないため、cascade 参照している行（`likes` → `definitions`）まで巻き込む。
+
+1. migration の直前に `just backend-bookmark-prod` を実行し、出力された bookmark を控える
+   （Issue / PR に貼る。控えを取らないまま migration を流さない）
+2. 失敗したら `just backend-restore-prod <bookmark>` で復元する。prod への破壊的操作なので
+   recipe は明示的な確認入力を求める。復元後の書き込みは失われるため、復元判断は速やかに行う
+3. 復元したら `just backend-drift-check` で migration の適用状態を確認してから再実行する
+
+#### prod app_config の運用
+
+- 確認: `just backend-app-config-prod`（読み取りのみ）
+- 初期行の作成: `just backend-seed-prod`（冪等。既存行があれば no-op）
+- 強制アップデート下限の更新: `just backend-set-min-app-version-prod <ios> <android>`。
+  更新前後の行を表示するので、値の変化を Issue / PR に記録する
+
+#### ドリフト検知
+
+prod は手動 deploy のため「deploy し忘れ」「migration の適用し忘れ」を誰も検知しない。
+`just backend-drift-check` は prod へ書き込まずに次を照合し、乖離があれば非 0 で終了する。
+
+- prod Worker の `DEPLOYED_SHA`（deploy 時に `backend-deploy-prod` が打つ）と `origin/develop`
+- prod `DB` / prod `TELEMETRY_DB` の未適用 migration
+
+定期実行して能動的に通知する導線は、**#291 のリリース回帰検知 Cron に相乗りさせる**方針とする。
+単独の Cron を先に建てると `scheduled` handler の `controller.cron` dispatch 設計を #291 側で
+やり直すことになるため、それまでは prod deploy 手順と手動実行で担保する。
 
 ### 使用量監視と通知
 

--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -334,15 +334,22 @@ required から消えたプロパティの有無で行う。破壊的な削除�
 
 #### バックアップと復旧（D1 Time Travel）
 
-migration は forward-only で、途中失敗時の戻し手段は D1 Time Travel だけ。destructive な
-migration は table recreate になり、D1 は暗黙トランザクション内で `PRAGMA foreign_keys=OFF` が
-効かないため、cascade 参照している行（`likes` → `definitions`）まで巻き込む。
+migration は forward-only で down migration を持たない。戻し手段は D1 Time Travel だけだが、
+**Time Travel restore は失敗時の通常対応ではない。** 対応は失敗の種類で分かれる。
 
 1. migration の直前に `just backend-bookmark-prod` を実行し、出力された bookmark を控える
    （Issue / PR に貼る。控えを取らないまま migration を流さない）
-2. 失敗したら `just backend-restore-prod <bookmark>` で復元する。prod への破壊的操作なので
-   recipe は明示的な確認入力を求める。復元後の書き込みは失われるため、復元判断は速やかに行う
-3. 復元したら `just backend-drift-check` で migration の適用状態を確認してから再実行する
+2. **`wrangler d1 migrations apply` がエラーを返した場合**: その migration はロールバックされて
+   未適用のまま残り、それ以前に成功した migration は適用済みのまま残る。`just backend-drift-check`
+   で `d1_migrations` の適用状態を確認し、migration SQL を修正して再実行する。ここで restore しない
+   （同じ状態へ戻すために bookmark 以降の書き込みを失うだけになる）
+3. **migration が成功した後に、意味的に誤った状態やデータ欠損が判明した場合**: `just backend-restore-prod <bookmark>`
+   で復元する。destructive な migration は table recreate になり、D1 は暗黙トランザクション内で
+   `PRAGMA foreign_keys=OFF` が効かないため、cascade 参照している行（`likes` → `definitions`）を
+   退避・復元する構成に依存する。ここが誤っていると **成功したまま行が失われる**ので、この経路が
+   restore の主な用途になる。restore は破壊的な上書きで bookmark 以降の書き込みを失うため、
+   recipe は明示的な確認入力を求める。判断は速やかに行う
+4. 復元したら `just backend-drift-check` で適用状態を確認してから再実行する
 
 #### prod app_config の運用
 

--- a/justfile
+++ b/justfile
@@ -194,24 +194,28 @@ backend-migrate-prod:
 backend-migrate-prod-telemetry:
     cd backend && bunx wrangler d1 migrations apply TELEMETRY_DB --env prod --remote
 
-# migration は forward-only で、destructive な migration（table recreate）は cascade で
-# 関連行まで落とす。失敗時の唯一の戻し手段が Time Travel なので、適用前に bookmark を控える。
+# migration が commit された後に意味的な壊れ（table recreate + cascade で行が消える等）が
+# 判明した場合、戻し手段は Time Travel だけになる。適用前に必ず bookmark を控える。
+# なお apply がエラーを返した場合はその migration 自体が未適用のまま残るため、
+# その経路の通常対応は restore ではなく修正して再実行（doc/specs/workers-api-server.md）。
 # prod D1 の現在の Time Travel bookmark を表示する（migration の直前に実行して控える）
 backend-bookmark-prod:
     cd backend && bunx wrangler d1 time-travel info DB --env prod
 
-# prod D1 を bookmark 時点へ復元する（migration 失敗時の復旧用。実行前に確認を求める）
+# prod D1 を bookmark 時点へ復元する（commit 済みの migration が壊れた状態を作った場合の復旧用）。
+# 引数は positional-arguments で受ける。文字列補間だとクオートを含む値がコマンドを書き換えるため。
+[positional-arguments]
 backend-restore-prod bookmark:
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "prod D1 (teigiii-prod) を bookmark {{bookmark}} 時点へ復元します。"
+    echo "prod D1 (teigiii-prod) を bookmark $1 時点へ復元します。"
     echo "この操作以降に書き込まれた prod データは失われます。"
     read -r -p "続行するには 'restore prod' と入力: " confirmation
     if [ "$confirmation" != 'restore prod' ]; then
       echo 'Aborted.' >&2
       exit 1
     fi
-    cd backend && bunx wrangler d1 time-travel restore DB --env prod --bookmark '{{bookmark}}'
+    cd backend && bunx wrangler d1 time-travel restore DB --env prod --bookmark "$1"
 
 # prod の app_config を表示する（読み取りのみ）
 backend-app-config-prod:
@@ -221,14 +225,25 @@ backend-app-config-prod:
 backend-seed-prod:
     cd backend && bunx wrangler d1 execute DB --env prod --remote --command "insert into app_config (id, min_app_version_ios, min_app_version_android, in_maintenance, maintenance_scheduled_end_time, perf_telemetry_enabled, updated_at) values (1, '0.0.0', '0.0.0', 0, null, 1, unixepoch('now') * 1000) on conflict(id) do nothing"
 
+# 値の検証は remote への最初の書き込みより前に行う。アプリは min_app_version_* を
+# Version.parse に直接渡す（app_config_state.dart）ため、壊れた値を書くと全クライアントが
+# 起動時に例外で retry 画面から復帰できなくなり、prod の行を直すまで回復しない。
+# 引数は positional-arguments で受ける。文字列補間だとクオートを含む値が SQL を書き換えるため。
 # prod の強制アップデート下限を更新する。更新前後の行を表示し、値の変化を記録に残せるようにする
+[positional-arguments]
 backend-set-min-app-version-prod ios android:
     #!/usr/bin/env bash
     set -euo pipefail
+    for value in "$1" "$2"; do
+      if [[ ! "$value" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Invalid version '${value}'. Use x.y.z (digits only)." >&2
+        exit 1
+      fi
+    done
     cd backend
     echo '--- before ---'
     bunx wrangler d1 execute DB --env prod --remote --command "select min_app_version_ios, min_app_version_android, updated_at from app_config"
-    bunx wrangler d1 execute DB --env prod --remote --command "update app_config set min_app_version_ios = '{{ios}}', min_app_version_android = '{{android}}', updated_at = unixepoch('now') * 1000 where id = 1"
+    bunx wrangler d1 execute DB --env prod --remote --command "update app_config set min_app_version_ios = '$1', min_app_version_android = '$2', updated_at = unixepoch('now') * 1000 where id = 1"
     echo '--- after ---'
     bunx wrangler d1 execute DB --env prod --remote --command "select min_app_version_ios, min_app_version_android, updated_at from app_config"
 

--- a/justfile
+++ b/justfile
@@ -194,6 +194,48 @@ backend-migrate-prod:
 backend-migrate-prod-telemetry:
     cd backend && bunx wrangler d1 migrations apply TELEMETRY_DB --env prod --remote
 
+# migration は forward-only で、destructive な migration（table recreate）は cascade で
+# 関連行まで落とす。失敗時の唯一の戻し手段が Time Travel なので、適用前に bookmark を控える。
+# prod D1 の現在の Time Travel bookmark を表示する（migration の直前に実行して控える）
+backend-bookmark-prod:
+    cd backend && bunx wrangler d1 time-travel info DB --env prod
+
+# prod D1 を bookmark 時点へ復元する（migration 失敗時の復旧用。実行前に確認を求める）
+backend-restore-prod bookmark:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "prod D1 (teigiii-prod) を bookmark {{bookmark}} 時点へ復元します。"
+    echo "この操作以降に書き込まれた prod データは失われます。"
+    read -r -p "続行するには 'restore prod' と入力: " confirmation
+    if [ "$confirmation" != 'restore prod' ]; then
+      echo 'Aborted.' >&2
+      exit 1
+    fi
+    cd backend && bunx wrangler d1 time-travel restore DB --env prod --bookmark '{{bookmark}}'
+
+# prod の app_config を表示する（読み取りのみ）
+backend-app-config-prod:
+    cd backend && bunx wrangler d1 execute DB --env prod --remote --command "select * from app_config"
+
+# prod app-config の初期行だけを冪等に作成する（既に行があれば no-op）
+backend-seed-prod:
+    cd backend && bunx wrangler d1 execute DB --env prod --remote --command "insert into app_config (id, min_app_version_ios, min_app_version_android, in_maintenance, maintenance_scheduled_end_time, perf_telemetry_enabled, updated_at) values (1, '0.0.0', '0.0.0', 0, null, 1, unixepoch('now') * 1000) on conflict(id) do nothing"
+
+# prod の強制アップデート下限を更新する。更新前後の行を表示し、値の変化を記録に残せるようにする
+backend-set-min-app-version-prod ios android:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd backend
+    echo '--- before ---'
+    bunx wrangler d1 execute DB --env prod --remote --command "select min_app_version_ios, min_app_version_android, updated_at from app_config"
+    bunx wrangler d1 execute DB --env prod --remote --command "update app_config set min_app_version_ios = '{{ios}}', min_app_version_android = '{{android}}', updated_at = unixepoch('now') * 1000 where id = 1"
+    echo '--- after ---'
+    bunx wrangler d1 execute DB --env prod --remote --command "select min_app_version_ios, min_app_version_android, updated_at from app_config"
+
+# prod が origin/develop から乖離していないかを検査する（prod へは書き込まない）
+backend-drift-check:
+    backend/scripts/drift-check.sh
+
 # prod は CI からではなくローカルから deploy する運用のため、
 # 「作業ツリーの中身がそのまま prod に出る」事故をここで防ぐ。
 # prod deploy の事前条件を検査する（作業ツリー clean / origin/develop と一致 / CI green）
@@ -225,9 +267,11 @@ backend-guard-prod:
 # migration は意図的に依存に含めない。deploy は wrangler rollback で可逆だが
 # migration は forward-only で不可逆であり、さらに正しい順序が migration の性質で反転する
 # （additive なら migrate → deploy、destructive なら deploy → migrate）。
+# DEPLOYED_SHA は backend-drift-check が「prod に出ている commit」を特定するためのスタンプ。
+# guard が HEAD == origin/develop を保証済みなので、この値はそのまま prod の実体を指す。
 # prod Worker を手動 deploy する（migration が必要なら backend-migrate-prod* を個別に実行する）
 backend-deploy-prod: backend-guard-prod
-    cd backend && bunx wrangler deploy --env prod
+    cd backend && bunx wrangler deploy --env prod --var DEPLOYED_SHA:"$(git rev-parse HEAD)"
 
 # --- perf（本番テレメトリ D1 の分析。D1 Read のみの CLOUDFLARE_API_TOKEN が必須）---
 


### PR DESCRIPTION
## 概要

prod deploy を安全に再開できる状態にする。実際の prod migrate / deploy は
`backend-guard-prod` が `origin/develop` 一致を要求するため、この PR の merge 後に別途実施する。

## 変更内容

### 1. `draftCount` 互換シム（問題 1）

配信済み v1.2.1+11 の生成クライアントは `MyDictionaryOverview` / `DefinedWordItem` の
`draftCount` を必須キーとして検査するため、削除済みのまま deploy すると「あなたの辞書」一覧が落ちる。

契約（OpenAPI）には戻さず、`backend/src/compat/draft-count-shim.ts` で wire レベルにのみ定数を足す。
契約に必須で戻すとシム撤去時にその時点の配信済みアプリを再び壊すため。**`openapi.json` は無変更**で、
`mobile_app/packages/teigiii_api` の再生成も不要。

v1.2.1+11 タグの `openapi.json` と現行の差分を全スキーマで突き合わせた結果、
破壊的なのはこの 2 箇所のみ:

| スキーマ | 差分 | 影響 |
| --- | --- | --- |
| `DefinedWordItem` | `draftCount` 削除 / `readingSubGroup` 追加 | **破壊的** |
| `MyDictionaryOverview` | `draftCount` 削除 | **破壊的** |
| `AppConfigResponse` / `SavedWordItem` / `UserDictionaryItem` | プロパティ追加のみ | 影響なし |
| `UpdateDefinitionRequest` | `wordId` 削除 | 影響なし（zod が strip する） |
| パス | 2 件追加のみ | 影響なし |

### 2. ドリフト検知（問題 2）

- `backend-deploy-prod` が deploy 時に `DEPLOYED_SHA` を打つ（guard が `HEAD == origin/develop` を保証済み）
- `just backend-drift-check` が prod へ書き込まずに、未 deploy の commit と未適用 migration を照合する
- 定期通知は #291 のリリース回帰検知 Cron に相乗りさせる方針を spec に記録した
  （単独 Cron を先に建てると `controller.cron` の dispatch 設計を #291 でやり直すため）

### 3. バックアップ・復旧（問題 3）

`just backend-bookmark-prod` / `just backend-restore-prod <bookmark>`（D1 Time Travel）を追加し、
prod デプロイ手順の migration ステップに組み込んだ。復元は prod への破壊的操作なので明示確認を求める。

### 4. prod `app_config` の運用（問題 4）

`backend-app-config-prod`（読み取り専用）/ `backend-seed-prod`（冪等）/
`backend-set-min-app-version-prod <ios> <android>`（更新前後の行を表示）を追加。

### 5. wrangler の vars 継承警告（問題 6）

`env.prod.vars` に `WEB_QA_PAGES_PROJECT = ""` を明示。空文字は未設定と同じく全 origin 拒否で振る舞いは不変。

## 検証

- `bun run lint` / `typecheck` / `format:check`: pass
- `bun run test:workers`: 137 pass（compat テスト 3 件を追加）
- `bunx wrangler deploy --env prod --dry-run`: pass、vars 警告が消えたことを確認
- `docbridge check`: 0 errors, 0 warnings
- `just backend-drift-check` を prod に対して実行し、Issue 記載どおり `0003` / `0004` 未適用 + 未 deploy を検出することを確認

`bun test`（unit）はローカル bun 1.3.13 の SQLite が `0003` の table recreate を拒否して 13 件落ちるが、
**この PR 以前から develop で同様**で、CI（pin された bun）では green。本 PR の変更とは無関係。

## 問題 5（dev ドリフト）について

Issue の想定と異なり、**dev CD はそもそも一度も成功していない**。
`ci.yml` の `deploy-dev` は secret `CLOUDFLARE_API_TOKEN_DEV` を要求するが、
リポジトリに登録されているのは `CLOUDFLARE_API_TOKEN`（perf 分析用の D1 Read 専用）だけで、
develop の最新 run も `Missing required secrets: CLOUDFLARE_API_TOKEN_DEV` で失敗している。
`ci-passed` の needs に含まれないため無言で赤いままだった。

この PR を merge しても dev ドリフトは解消しないため、別途どちらかが必要（本 PR のスコープ外）:

- dev deploy 用の Cloudflare API token を発行し `CLOUDFLARE_API_TOKEN_DEV` として登録する（恒久対応）
- `just backend-deploy-dev` を手動実行する（暫定）

## merge 後の手順

1. `just backend-drift-check`
2. `just backend-bookmark-prod`（bookmark を Issue に貼る）
3. `just backend-migrate-prod`（`0003` / `0004`。旧 Worker のまま先に適用してよいことは Issue で判断済み）
4. `just backend-deploy-prod`
5. `just backend-app-config-prod` で `min_app_version_*` を確認
6. `just backend-drift-check` が green になることを確認し、smoke test

レビュー指摘（引数検証・stderr・restore 条件・dev の前提）は 634cfec / 18c4e16 で対応済み。

**この PR は #322 を閉じない。** #322 の完了条件は prod への migrate / deploy と dev Worker の一致を含み、いずれも merge 後の実操作（dev は `CLOUDFLARE_API_TOKEN_DEV` の登録待ち）が必要なため。関連: #322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored backward-compatible `draftCount: 0` fields in dictionary overview and defined-word responses.
  * Production CORS behavior now explicitly rejects unauthorized web origins when Web QA access is disabled.

* **Reliability**
  * Added production deployment and database drift checks to detect mismatches and unapplied migrations.
  * Added safer production database inspection, backup, restoration, and configuration management workflows.
  * Production deployments now record the deployed commit for easier verification.

* **Documentation**
  * Expanded deployment guidance, compatibility checks, migration procedures, and recovery steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->