### PR TITLE
build: #322 nix dev shell に Node.js 22 を追加する

### DIFF
--- a/doc/specs/workers-api-server.md
+++ b/doc/specs/workers-api-server.md
@@ -296,6 +296,10 @@ curl 'http://localhost:8787/__scheduled?cron=0+3+*+*+*'
 
 ### prod デプロイ
 
+recipe は `nix develop` の中で実行する。wrangler は `node_modules/.bin/wrangler` の
+shebang 経由で node に起動されるため Node.js 22 以上を要求し、shell 外の node バージョンに
+依存すると手順の途中で止まる。node は `flake.nix` で固定している。
+
 1. `just backend-drift-check` で prod と `origin/develop` の乖離（未 deploy の commit /
    未適用 migration）を洗い出す。
 2. `just backend-validate-prod` で `teigiii-api-prod`、`teigiii-prod`、

--- a/flake.nix
+++ b/flake.nix
@@ -145,9 +145,12 @@
             pkgs.just
           ];
           # ci.yml deploy-dev job: justfile 経由で wrangler を叩くだけ。Flutter は不要。
+          # nodejs は wrangler の実行に要る（下記 toolPackages のコメント参照）。
+          # runner の preinstall node に依存すると、runner image 更新で無言で壊れる。
           ciBackendPackages = [
             pkgs.just
             pkgs.bun
+            pkgs.nodejs_22
           ];
           # deliver.yml: iOS の署名済みビルドに必要なものだけ。
           # macos runner は課金 10 倍なので、openapi-generator-cli（JDK 込み）や
@@ -170,6 +173,10 @@
             pkgs.lcov
             pkgs.git
             pkgs.bun
+            # wrangler は node_modules/.bin/wrangler の shebang（#!/usr/bin/env node）経由で
+            # 起動するため bun ではなく node で動き、Node.js 22 以上を要求する。
+            # ここで固定しないと prod デプロイ手順が各人の node バージョン任せになる。
+            pkgs.nodejs_22
             pkgs.curl
             pkgs.jq
             pkgs.ripgrep


### PR DESCRIPTION
## 背景

#324 merge 後の prod 切替中、`just backend-migrate-prod` が起動前に落ちた。

```
Wrangler requires at least Node.js v22.0.0. You are using v20.19.1.
```

`bunx wrangler` は `backend/node_modules/.bin/wrangler` を実行するが、この shim の shebang が
`#!/usr/bin/env node` なので **bun ではなく PATH 上の node で起動される**。
`flake.nix` は `nodejs` を含んでいなかったため、wrangler が動くかどうかが各人の環境任せになっていた。

## 変更

- `toolPackages`（dev shell）に `pkgs.nodejs_22`（22.23.1 / LTS）を追加
- `ciBackendPackages`（`deploy-dev` ジョブ）にも追加。runner の preinstall node に暗黙依存していたため、
  runner image の更新で無言で壊れうる
- `doc/specs/workers-api-server.md` の prod デプロイ手順に「recipe は `nix develop` 内で実行する」と理由を明記

`nodejs_24` ではなく `nodejs_22` を選んだのは、wrangler の要求（>= 22）を満たす LTS で最も変化が小さいため。

## 検証

```
$ nix develop --command bash -c 'node --version; cd backend && bunx wrangler --version'
v22.23.1
4.110.0
```

## 影響

prod 切替（#322）はこの PR の merge 待ち。`backend-guard-prod` が作業ツリー clean と
`origin/develop` 一致を要求するため、flake の変更を develop に入れてから migrate / deploy を実行する。
**prod のデータには何も適用していない**（`0003` / `0004` とも未適用のまま）。

関連: #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated production deployment instructions to run recipes within the development environment.
  * Documented the requirement to use Node.js 22 or later.

* **Chores**
  * Standardized development and CI environments on Node.js 22 for more consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->