### PR TITLE
chore: リリース 1.3.0+12 へバージョンを上げる

### DIFF
--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: teigi_app
 description: A new Flutter project.
 
-version: 1.2.1+11
+version: 1.3.0+12
 publish_to: none
 
 environment:


### PR DESCRIPTION
## 概要

`v1.2.1+11`（2026-07-25）以降の **106 コミット**を配信するため、`mobile_app/pubspec.yaml` を
`1.2.1+11` → `1.3.0+12` に上げる。

言葉の同一性を `(表記, よみ)` に変更する仕様変更を含むため、patch ではなく minor を上げる。

## 前提（確認済み）

- prod Worker が `origin/develop` と一致（#322）
- 新アプリが要求する `readingSubGroup` / `perfTelemetryEnabled` / `/v1/words/lookup` は prod で提供済み
- 配信済み v1.2.1 は `draftCount` 互換シムで保護（実機確認済み）
- prod `min_app_version_*` は `1.1.0` のままで、強制アップデートは発火しない

## 配信内容

### 仕様変更

- **言葉の同一性を `(表記, よみ)` に変更**。同じ表記でもよみが異なれば別の言葉として登録できる
- **下書き機能を廃止**（Draft API / `definitions.status = draft` を削除）
- **読み分類の正本をサーバーへ一本化**。旧かな行索引の到達不能な画面と依存を撤去

### 機能

- 言葉登録画面で既存語を事前に知らせ、登録結果（新規作成 / 既存への登録 / 登録済み）を正しく伝える
- 画面別のフレーム統計を収集して送信（kill switch つき）

### 改善・修正

- 定義一覧と discover timeline の N+1 を解消
- 無限スクロールの遅延構築を復活
- バナー広告のライフサイクル修正
- 保存一覧の並び順を修正
- Flutter 非推奨 API の置換、死コードと未使用依存の整理、Firestore 移行資材の撤去

### 内部（ユーザーには見えない）

デザインシステム（Ds トークン / コンポーネント / Widgetbook / CI 違反検出）、Web QA プレビュー、
prod デプロイの運用整備（#322）、パフォーマンス分析 CLI。

## 申請前の確認事項

**App Privacy の申告を見直すこと。** 今回からフレーム計測テレメトリで以下を送信する。

| 送信内容 | 例 |
| --- | --- |
| アプリバージョン / ビルド番号 / flavor | `1.3.0` / `12` / `prod` |
| プラットフォーム / OS バージョン | `ios` / `iOS 26.0` |
| 端末モデル | `iPhone17,1` |
| リフレッシュレート | `120` |
| 画面名と集計値（フレーム数、slow / frozen 件数、ビルド・ラスタ時間） | `DiscoverTimelinePage` |
| セッション ID（起動ごとの使い捨て） | UUID |

個人を特定しうる値と生フレームは含まない。既存の申告で足りるかを確認する。

## 配信手順

1. この PR を merge
2. `v1.3.0+12` タグを push（`deliver.yml` が `v*` タグで起動する）

関連: #322